### PR TITLE
Fix code scanning alert no. 116: Information exposure through an exception

### DIFF
--- a/website/views.py
+++ b/website/views.py
@@ -2231,9 +2231,11 @@ def chatbot_conversation(request):
         try:
             response = crc.invoke({"question": question})
         except Exception as e:
-            error_message = f"Error: {str(e)}"
-            ChatBotLog.objects.create(question=question, answer=error_message)
-            return Response({"error": error_message}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            import logging
+            logger = logging.getLogger(__name__)
+            logger.error("Error during chatbot conversation", exc_info=True)
+            ChatBotLog.objects.create(question=question, answer="An internal error occurred.")
+            return Response({"error": "An internal error occurred."}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
         cache.set(rate_limit_key, request_count + 1, timeout=86400)  # Timeout set to one day
         request.session["buffer"] = memory.buffer
 
@@ -2242,9 +2244,11 @@ def chatbot_conversation(request):
         return Response({"answer": response["answer"]}, status=status.HTTP_200_OK)
 
     except Exception as e:
-        error_message = f"Error: {str(e)}"
-        ChatBotLog.objects.create(question=request.data.get("question", ""), answer=error_message)
-        return Response({"error": error_message}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+        import logging
+        logger = logging.getLogger(__name__)
+        logger.error("Error during chatbot conversation", exc_info=True)
+        ChatBotLog.objects.create(question=request.data.get("question", ""), answer="An internal error occurred.")
+        return Response({"error": "An internal error occurred."}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
 
 def weekly_report(request):


### PR DESCRIPTION
Fixes [https://github.com/OWASP-BLT/BLT/security/code-scanning/116](https://github.com/OWASP-BLT/BLT/security/code-scanning/116)

To fix the problem, we need to ensure that detailed error messages and stack traces are not exposed to the end user. Instead, we should log the detailed error information on the server and return a generic error message to the user. This can be achieved by modifying the exception handling code to log the error and return a generic message.

- Modify the exception handling in the `chatbot_conversation` function to log the detailed error message and return a generic error message to the user.
- Ensure that the logging mechanism captures the necessary details for debugging without exposing them to the end user.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
