### PR TITLE
Fix code scanning alert no. 125: Information exposure through an exception

### DIFF
--- a/website/views.py
+++ b/website/views.py
@@ -2231,9 +2231,8 @@ def chatbot_conversation(request):
         try:
             response = crc.invoke({"question": question})
         except Exception as e:
-            error_message = f"Error: {str(e)}"
-            ChatBotLog.objects.create(question=question, answer=error_message)
-            return Response({"error": error_message}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            ChatBotLog.objects.create(question=question, answer=f"Error: {str(e)}")
+            return Response({"error": "An internal error has occurred."}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
         cache.set(rate_limit_key, request_count + 1, timeout=86400)  # Timeout set to one day
         request.session["buffer"] = memory.buffer
 
@@ -2242,9 +2241,8 @@ def chatbot_conversation(request):
         return Response({"answer": response["answer"]}, status=status.HTTP_200_OK)
 
     except Exception as e:
-        error_message = f"Error: {str(e)}"
-        ChatBotLog.objects.create(question=request.data.get("question", ""), answer=error_message)
-        return Response({"error": error_message}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+        ChatBotLog.objects.create(question=request.data.get("question", ""), answer=f"Error: {str(e)}")
+        return Response({"error": "An internal error has occurred."}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
 
 def weekly_report(request):


### PR DESCRIPTION
Fixes [https://github.com/OWASP-BLT/BLT/security/code-scanning/125](https://github.com/OWASP-BLT/BLT/security/code-scanning/125)

To fix the problem, we need to ensure that detailed error messages and stack traces are not exposed to the end user. Instead, we should log the detailed error information on the server and return a generic error message to the user. This can be achieved by modifying the exception handling code to log the error and return a generic message.

- Modify the exception handling block to log the detailed error message and return a generic error message.
- Ensure that the logging mechanism captures enough information for debugging purposes without exposing it to the end user.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
