### PR TITLE
Add GitHub action to test Docker build and serve

### DIFF
--- a/docker-build-test.yml
+++ b/docker-build-test.yml
@@ -1,0 +1,47 @@
+name: Docker Build and Serve Test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build-and-serve:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Build Docker image
+        run: docker build -t owasp-blt .
+
+      - name: Run Docker container
+        run: docker run -d -p 8000:8000 owasp-blt
+
+      - name: Wait for container to be ready
+        run: |
+          for i in {1..30}; do
+            if curl -s http://localhost:8000 > /dev/null; then
+              exit 0
+            fi
+            sleep 1
+          done
+          exit 1
+
+      - name: Verify site is served
+        run: curl -s http://localhost:8000


### PR DESCRIPTION
Fixes #2791

Add a new GitHub action workflow to test Docker build and serve functionality.

* Create `docker-build-test.yml` in `.github/workflows` directory
* Trigger the workflow on `push` and `pull_request` events
* Use `ubuntu-latest` runner for the workflow
* Include steps to check out the repository, set up Docker, build the Docker image, and run the container
* Verify that the Docker container is running and serving the site by making an HTTP request to `http://localhost:8000` and checking for a successful response

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/OWASP-BLT/BLT/issues/2791?shareId=207b9bc0-95e4-4dbc-998d-685aa2f00268).