### PR TITLE
fix : read environment variables from .env in settings.py

### DIFF
--- a/blt/settings.py
+++ b/blt/settings.py
@@ -15,12 +15,15 @@ import dj_database_url
 import environ
 from django.utils.translation import gettext_lazy as _
 
-env = environ.Env()
 # reading .env file
 environ.Env.read_env()
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
+env = environ.Env()
+env_file = os.path.join(BASE_DIR, ".env")
+environ.Env.read_env(env_file)
+
 PROJECT_ROOT = os.path.dirname(os.path.abspath(__file__))
 GITHUB_TOKEN = os.environ.get("GITHUB_TOKEN", "blank")
 


### PR DESCRIPTION
This PR fixes the issue of manually exporting environment variables like DATABASE_URL by updating the settings.py file
This is done by providing the explicit path to the .env file in the in the read_env function call
