### PR TITLE
slack integration: Fix api call for getting channel details.

### DIFF
--- a/company/views.py
+++ b/company/views.py
@@ -855,7 +855,7 @@ class AddSlackIntegrationView(View):
         cursor = None
         try:
             while True:
-                response = app.conversations_list(cursor=cursor)
+                response = app.client.conversations_list(cursor=cursor)
                 for channel in response["channels"]:
                     if channel["name"] == channel_name.strip("#"):
                         return channel["id"]


### PR DESCRIPTION
https://github.com/OWASP-BLT/BLT/blob/f6e758b0e81ac04a8947c1fffd8b3c2bfd8b3985/company/views.py#L858
It should be
response = app.client.conversations_list(cursor=cursor)
Instead of
response = app.conversations_list(cursor=cursor)