### PR TITLE
Adds the End Time for a user's sizzle report.

### DIFF
--- a/website/templates/sizzle/user_sizzle_report.html
+++ b/website/templates/sizzle/user_sizzle_report.html
@@ -26,6 +26,7 @@
                     <th>Issue Title</th>
                     <th>Duration</th>
                     <th>Start Time</th>
+                    <th>End Time</th>
                 </tr>
             </thead>
             <tbody>
@@ -35,6 +36,7 @@
                         <td>{{ log.issue_title }}</td>
                         <td>{{ log.duration }}</td>
                         <td>{{ log.start_time }}</td>
+                        <td>{{ log.end_time }}</td>
                     </tr>
                 {% endfor %}
             </tbody>

--- a/website/views/organization.py
+++ b/website/views/organization.py
@@ -908,12 +908,14 @@ def user_sizzle_report(request, username):
         issue_title = get_github_issue_title(first_log.github_issue_url)
 
         start_time = first_log.start_time.strftime("%I:%M %p")
+        end_time = first_log.end_time.strftime("%I:%M %p")
         formatted_date = first_log.created.strftime("%d %B %Y")
 
         day_data = {
             "issue_title": issue_title,
             "duration": formatted_duration,
             "start_time": start_time,
+            "end_time": end_time,
             "date": formatted_date,
         }
 


### PR DESCRIPTION
Fixes #3091.

Screenshot
![image](https://github.com/user-attachments/assets/fc866faa-3a43-47c1-9b1e-557d47e49b9a)
