### PR TITLE
Potential fix for code scanning alert no. 218: Information exposure through an exception

### DIFF
--- a/website/views/organization.py
+++ b/website/views/organization.py
@@ -1351,7 +1351,8 @@ def add_or_update_organization(request):
             return HttpResponse("Organization updated successfully")
 
         except (Organization.DoesNotExist, User.DoesNotExist, KeyError) as e:
-            return HttpResponse(f"Error: {str(e)}")
+            logger.error(f"Error updating organization: {str(e)}")
+            return HttpResponse("An internal error has occurred. Please try again later.")
     else:
         return HttpResponse("Invalid request method")
 
@@ -1385,7 +1386,8 @@ def add_role(request):
                 return HttpResponse("Role added successfully")
 
         except (OrganizationAdmin.DoesNotExist, User.DoesNotExist, KeyError) as e:
-            return HttpResponse(f"Error: {str(e)}")
+            logger.error(f"Error adding role: {str(e)}")
+            return HttpResponse("An internal error has occurred. Please try again later.")
     else:
         return HttpResponse("Invalid request method")
 

--- a/website/views/organization.py
+++ b/website/views/organization.py
@@ -1352,7 +1352,7 @@ def add_or_update_organization(request):
 
         except (Organization.DoesNotExist, User.DoesNotExist, KeyError) as e:
             logger.error(f"Error updating organization: {str(e)}")
-            return HttpResponse("An internal error has occurred. Please try again later.")
+            return HttpResponse("Error updating organization. Either organization or user doesn't exist or there was a key error. Please try again later.")
     else:
         return HttpResponse("Invalid request method")
 
@@ -1387,7 +1387,7 @@ def add_role(request):
 
         except (OrganizationAdmin.DoesNotExist, User.DoesNotExist, KeyError) as e:
             logger.error(f"Error adding role: {str(e)}")
-            return HttpResponse("An internal error has occurred. Please try again later.")
+            return HttpResponse("Error updating organization. Either organization or user doesn't exist or there was a key error. Please try again later.")
     else:
         return HttpResponse("Invalid request method")
 


### PR DESCRIPTION
Potential fix for [https://github.com/OWASP-BLT/BLT/security/code-scanning/218](https://github.com/OWASP-BLT/BLT/security/code-scanning/218)

To fix the problem, we need to ensure that detailed error messages are not exposed to the user. Instead, we should log the detailed error messages on the server and return a generic error message to the user. This can be achieved by using the `logging` module to log the exceptions and returning a generic error message in the HTTP response.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
