### PR TITLE
Add GitHub OAuth Configuration Management Commands

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,6 +24,10 @@ if check_migrations; then
     echo "Migration script is running"
     python manage.py migrate
 
+    # Setup GitHub OAuth
+    echo "Setting up GitHub OAuth"
+    python manage.py setup_github_oauth
+
     # Load initial data
     python manage.py loaddata website/fixtures/initial_data.json
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 set -x
+set -e  # Exit on error
 echo "Entrypoint script is running"
 
 # Wait for the database to be ready
@@ -26,7 +27,11 @@ if check_migrations; then
 
     # Setup GitHub OAuth
     echo "Setting up GitHub OAuth"
-    python manage.py setup_github_oauth
+    if ! python manage.py setup_github_oauth; then
+        echo "ERROR: GitHub OAuth setup failed"
+        exit 1
+    fi
+    echo "GitHub OAuth setup completed successfully"
 
     # Load initial data
     python manage.py loaddata website/fixtures/initial_data.json

--- a/website/management/commands/check_oauth_settings.py
+++ b/website/management/commands/check_oauth_settings.py
@@ -1,0 +1,19 @@
+from django.core.management.base import BaseCommand
+from django.conf import settings
+
+class Command(BaseCommand):
+    help = 'Check OAuth settings configuration'
+
+    def handle(self, *args, **options):
+        self.stdout.write("Checking OAuth settings...")
+        
+        # Check GitHub settings
+        github_key = getattr(settings, 'SOCIAL_AUTH_GITHUB_KEY', None)
+        github_secret = getattr(settings, 'SOCIAL_AUTH_GITHUB_SECRET', None)
+        
+        self.stdout.write(f"GitHub Client ID: {'✓ Set' if github_key else '✗ Missing'}")
+        self.stdout.write(f"GitHub Secret: {'✓ Set' if github_secret else '✗ Missing'}")
+        
+        # Check Site ID
+        site_id = getattr(settings, 'SITE_ID', None)
+        self.stdout.write(f"Site ID: {site_id if site_id else '✗ Missing'}")

--- a/website/management/commands/check_oauth_settings.py
+++ b/website/management/commands/check_oauth_settings.py
@@ -3,18 +3,18 @@ from django.core.management.base import BaseCommand
 
 
 class Command(BaseCommand):
-    help = 'Check OAuth settings configuration'
+    help = "Check OAuth settings configuration"
 
     def handle(self, *args, **options):
         self.stdout.write("Checking OAuth settings...")
-        
+
         # Check GitHub settings
-        github_key = getattr(settings, 'SOCIAL_AUTH_GITHUB_KEY', None)
-        github_secret = getattr(settings, 'SOCIAL_AUTH_GITHUB_SECRET', None)
-        
+        github_key = getattr(settings, "SOCIAL_AUTH_GITHUB_KEY", None)
+        github_secret = getattr(settings, "SOCIAL_AUTH_GITHUB_SECRET", None)
+
         self.stdout.write(f"GitHub Client ID: {'✓ Set' if github_key else '✗ Missing'}")
         self.stdout.write(f"GitHub Secret: {'✓ Set' if github_secret else '✗ Missing'}")
-        
+
         # Check Site ID
-        site_id = getattr(settings, 'SITE_ID', None)
+        site_id = getattr(settings, "SITE_ID", None)
         self.stdout.write(f"Site ID: {site_id if site_id else '✗ Missing'}")

--- a/website/management/commands/check_oauth_settings.py
+++ b/website/management/commands/check_oauth_settings.py
@@ -1,5 +1,6 @@
-from django.core.management.base import BaseCommand
 from django.conf import settings
+from django.core.management.base import BaseCommand
+
 
 class Command(BaseCommand):
     help = 'Check OAuth settings configuration'

--- a/website/management/commands/setup_github_oauth.py
+++ b/website/management/commands/setup_github_oauth.py
@@ -1,0 +1,41 @@
+from django.core.management.base import BaseCommand
+from django.contrib.sites.models import Site
+from allauth.socialaccount.models import SocialApp
+from django.conf import settings
+
+class Command(BaseCommand):
+    help = 'Sets up GitHub OAuth configuration in the database'
+
+    def handle(self, *args, **options):
+        # First ensure we have a site configured
+        site, created = Site.objects.get_or_create(
+            id=settings.SITE_ID,
+            defaults={
+                "domain": "localhost:8000",
+                "name": "localhost"
+            }
+        )
+        if not created:
+            site.domain = "localhost:8000"
+            site.name = "localhost"
+            site.save()
+            
+        self.stdout.write(self.style.SUCCESS(f'Site configured: {site.domain}'))
+        
+        # Set up GitHub OAuth
+        try:
+            github_app = SocialApp.objects.get(provider="github")
+            github_app.client_id = settings.SOCIAL_AUTH_GITHUB_KEY
+            github_app.secret = settings.SOCIAL_AUTH_GITHUB_SECRET
+            github_app.save()
+            github_app.sites.add(site)
+            self.stdout.write(self.style.SUCCESS('Updated GitHub OAuth configuration'))
+        except SocialApp.DoesNotExist:
+            github_app = SocialApp.objects.create(
+                provider="github",
+                name="GitHub",
+                client_id=settings.SOCIAL_AUTH_GITHUB_KEY,
+                secret=settings.SOCIAL_AUTH_GITHUB_SECRET
+            )
+            github_app.sites.add(site)
+            self.stdout.write(self.style.SUCCESS('Created GitHub OAuth configuration'))

--- a/website/management/commands/setup_github_oauth.py
+++ b/website/management/commands/setup_github_oauth.py
@@ -1,41 +1,66 @@
-from django.core.management.base import BaseCommand
-from django.contrib.sites.models import Site
 from allauth.socialaccount.models import SocialApp
 from django.conf import settings
+from django.contrib.sites.models import Site
+from django.core.management.base import BaseCommand
+
 
 class Command(BaseCommand):
     help = 'Sets up GitHub OAuth configuration in the database'
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--domain',
+            default=getattr(settings, 'SITE_DOMAIN', 'localhost:8000'),
+            help='Domain for the site'
+        )
+        parser.add_argument(
+            '--name',
+            default=getattr(settings, 'SITE_NAME', 'localhost'),
+            help='Name for the site'
+        )
 
     def handle(self, *args, **options):
         # First ensure we have a site configured
         site, created = Site.objects.get_or_create(
             id=settings.SITE_ID,
             defaults={
-                "domain": "localhost:8000",
-                "name": "localhost"
+                "domain": options['domain'],
+                "name": options['name']
             }
         )
         if not created:
-            site.domain = "localhost:8000"
-            site.name = "localhost"
+            site.domain = options['domain']
+            site.name = options['name']
             site.save()
             
         self.stdout.write(self.style.SUCCESS(f'Site configured: {site.domain}'))
         
         # Set up GitHub OAuth
+        github_key = getattr(settings, 'SOCIAL_AUTH_GITHUB_KEY', None)
+        github_secret = getattr(settings, 'SOCIAL_AUTH_GITHUB_SECRET', None)
+        
+        if not github_key or not github_secret:
+            self.stdout.write(
+                self.style.ERROR(
+                    'Missing required settings: SOCIAL_AUTH_GITHUB_KEY and/or SOCIAL_AUTH_GITHUB_SECRET'
+                )
+            )
+            return
+        
         try:
             github_app = SocialApp.objects.get(provider="github")
-            github_app.client_id = settings.SOCIAL_AUTH_GITHUB_KEY
-            github_app.secret = settings.SOCIAL_AUTH_GITHUB_SECRET
+            github_app.client_id = github_key
+            github_app.secret = github_secret
             github_app.save()
-            github_app.sites.add(site)
+            if site not in github_app.sites.all():
+                github_app.sites.add(site)
             self.stdout.write(self.style.SUCCESS('Updated GitHub OAuth configuration'))
         except SocialApp.DoesNotExist:
             github_app = SocialApp.objects.create(
                 provider="github",
                 name="GitHub",
-                client_id=settings.SOCIAL_AUTH_GITHUB_KEY,
-                secret=settings.SOCIAL_AUTH_GITHUB_SECRET
+                client_id=github_key,
+                secret=github_secret
             )
             github_app.sites.add(site)
             self.stdout.write(self.style.SUCCESS('Created GitHub OAuth configuration'))

--- a/website/management/commands/setup_github_oauth.py
+++ b/website/management/commands/setup_github_oauth.py
@@ -5,48 +5,42 @@ from django.core.management.base import BaseCommand
 
 
 class Command(BaseCommand):
-    help = 'Sets up GitHub OAuth configuration in the database'
+    help = "Sets up GitHub OAuth configuration in the database"
 
     def add_arguments(self, parser):
         parser.add_argument(
-            '--domain',
-            default=getattr(settings, 'SITE_DOMAIN', 'localhost:8000'),
-            help='Domain for the site'
+            "--domain", default=getattr(settings, "SITE_DOMAIN", "localhost:8000"), help="Domain for the site"
         )
-        parser.add_argument(
-            '--name',
-            default=getattr(settings, 'SITE_NAME', 'localhost'),
-            help='Name for the site'
-        )
+        parser.add_argument("--name", default=getattr(settings, "SITE_NAME", "localhost"), help="Name for the site")
 
     def handle(self, *args, **options):
+        # Check if SITE_ID is configured
+        site_id = getattr(settings, "SITE_ID", None)
+        if not site_id:
+            self.stdout.write(self.style.ERROR("Missing required setting: SITE_ID"))
+            return
+
         # First ensure we have a site configured
         site, created = Site.objects.get_or_create(
-            id=settings.SITE_ID,
-            defaults={
-                "domain": options['domain'],
-                "name": options['name']
-            }
+            id=site_id, defaults={"domain": options["domain"], "name": options["name"]}
         )
         if not created:
-            site.domain = options['domain']
-            site.name = options['name']
+            site.domain = options["domain"]
+            site.name = options["name"]
             site.save()
-            
-        self.stdout.write(self.style.SUCCESS(f'Site configured: {site.domain}'))
-        
+
+        self.stdout.write(self.style.SUCCESS(f"Site configured: {site.domain}"))
+
         # Set up GitHub OAuth
-        github_key = getattr(settings, 'SOCIAL_AUTH_GITHUB_KEY', None)
-        github_secret = getattr(settings, 'SOCIAL_AUTH_GITHUB_SECRET', None)
-        
+        github_key = getattr(settings, "SOCIAL_AUTH_GITHUB_KEY", None)
+        github_secret = getattr(settings, "SOCIAL_AUTH_GITHUB_SECRET", None)
+
         if not github_key or not github_secret:
             self.stdout.write(
-                self.style.ERROR(
-                    'Missing required settings: SOCIAL_AUTH_GITHUB_KEY and/or SOCIAL_AUTH_GITHUB_SECRET'
-                )
+                self.style.ERROR("Missing required settings: SOCIAL_AUTH_GITHUB_KEY and/or SOCIAL_AUTH_GITHUB_SECRET")
             )
             return
-        
+
         try:
             github_app = SocialApp.objects.get(provider="github")
             github_app.client_id = github_key
@@ -54,13 +48,10 @@ class Command(BaseCommand):
             github_app.save()
             if site not in github_app.sites.all():
                 github_app.sites.add(site)
-            self.stdout.write(self.style.SUCCESS('Updated GitHub OAuth configuration'))
+            self.stdout.write(self.style.SUCCESS("Updated GitHub OAuth configuration"))
         except SocialApp.DoesNotExist:
             github_app = SocialApp.objects.create(
-                provider="github",
-                name="GitHub",
-                client_id=github_key,
-                secret=github_secret
+                provider="github", name="GitHub", client_id=github_key, secret=github_secret
             )
             github_app.sites.add(site)
-            self.stdout.write(self.style.SUCCESS('Created GitHub OAuth configuration'))
+            self.stdout.write(self.style.SUCCESS("Created GitHub OAuth configuration"))


### PR DESCRIPTION
This PR addresses issue #3649 by automating the GitHub OAuth setup process for BLT. It adds management commands to configure and verify OAuth settings using BLT's existing GitHub credentials.

What This PR Does:

1. Adds two management commands:
- setup_github_oauth: Configures GitHub OAuth using BLT's credentials
- check_oauth_settings: Verifies OAuth configuration

Implementation Details

2. setup_github_oauth:
- Creates/updates site configuration with correct domain
- Sets up GitHub social application using BLT's existing OAuth credentials
- Links the social application with the site

2. check_oauth_settings:
- Verifies GitHub OAuth credentials are properly loaded
- Validates site configuration
- Helps diagnose auth issues

https://github.com/user-attachments/assets/288292f8-cee1-40d2-8803-74eb6e3afe47

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a command to verify OAuth configuration parameters.
  - Introduced a command to automate the setup and updating of GitHub OAuth integration.
  - Included a new step in the startup process to configure GitHub OAuth settings automatically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->