### PR TITLE
Potential fix for code scanning alert no. 181: Full server-side request forgery

### DIFF
--- a/website/api/views.py
+++ b/website/api/views.py
@@ -986,6 +986,13 @@ class OwaspComplianceChecker(APIView):
 
     def check_vendor_neutrality(self, url):
         """Check vendor neutrality compliance"""
+        authorized_domains = ["example.com", "owasp.org"]
+        parsed_url = urlparse(url)
+        if parsed_url.netloc not in authorized_domains:
+            return {
+                "possible_paywall": None,
+                "details": {"url_checked": url, "error": "Unauthorized domain"},
+            }
         try:
             response = requests.get(url, timeout=10)
             soup = BeautifulSoup(response.text, "html.parser")
@@ -1006,6 +1013,11 @@ class OwaspComplianceChecker(APIView):
         url = request.data.get("url")
         if not url:
             return Response({"error": "URL is required"}, status=status.HTTP_400_BAD_REQUEST)
+
+        authorized_domains = ["example.com", "owasp.org"]
+        parsed_url = urlparse(url)
+        if parsed_url.netloc not in authorized_domains:
+            return Response({"error": "Unauthorized domain"}, status=status.HTTP_400_BAD_REQUEST)
 
         # Run all compliance checks
         github_check = self.check_github_compliance(url)


### PR DESCRIPTION
Potential fix for [https://github.com/OWASP-BLT/BLT/security/code-scanning/181](https://github.com/OWASP-BLT/BLT/security/code-scanning/181)

To fix the problem, we need to validate the user-provided URL to ensure it is safe to use. One way to do this is to maintain a list of authorized domains and ensure the user-provided URL belongs to one of these domains. Additionally, we can parse the URL and verify its components to ensure it does not point to any internal or sensitive resources.

1. Create a list of authorized domains.
2. Parse the user-provided URL and extract its domain.
3. Check if the extracted domain is in the list of authorized domains.
4. If the domain is not authorized, return an error response.
5. If the domain is authorized, proceed with the HTTP request.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added domain authorization checks to restrict processing to approved domains only. Users will receive an error message if attempting to check a URL outside the authorized list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->