### PR TITLE
Bacon integrarted with different pages and user profile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ requirements.txt
 *.exe
 .vs
 .qodo
+ssl

--- a/website/feed_signals.py
+++ b/website/feed_signals.py
@@ -57,7 +57,7 @@ def create_activity(instance, action_type):
         title=title,
         content_type=content_type,
         object_id=instance.id,  # Use object_id for GenericForeignKey
-        description=getattr(instance, "description", getattr(instance, "content", ""))[:100],
+        # description=getattr(instance, "description", getattr(instance, "content", ""))[:100],
         image=getattr(instance, "screenshot", getattr(instance, "image", None)),
     )
 

--- a/website/feed_signals.py
+++ b/website/feed_signals.py
@@ -164,17 +164,3 @@ def handle_organization_creation(sender, instance, created, **kwargs):
         create_activity(instance, "created")
         # Give first organization badge
         assign_first_action_badge(instance.admin, "First Organization Created")
-
-
-@receiver(post_save, sender=Issue)
-def handle_issue_bacon_rewards(sender, instance, created, update_fields, **kwargs):
-    """Handle BACON rewards for GitHub issues"""
-    if created:
-        # Give initial BACON reward for creating an issue
-        assign_first_action_badge(instance.user, "First Bug Reported")
-        giveBacon(instance.user, 5)
-        create_activity(instance, "created")
-
-    # Give extra BACON for security-related issues when marked as such
-    if update_fields and "is_security" in update_fields and instance.is_security:
-        giveBacon(instance.user, 3)  # Extra tokens for security issues

--- a/website/feed_signals.py
+++ b/website/feed_signals.py
@@ -2,8 +2,6 @@ from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
 from django.db.models.signals import post_save, pre_delete
 from django.dispatch import receiver
-from django.contrib import messages
-from django.core.cache import cache
 
 from .models import (
     Activity,
@@ -14,10 +12,10 @@ from .models import (
     Hunt,
     IpReport,
     Issue,
+    Organization,
     Post,
     TimeLog,
     UserBadge,
-    Organization,
     UserProfile,
 )
 
@@ -116,7 +114,6 @@ def handle_post_save(sender, instance, created, **kwargs):
         assign_first_action_badge(instance.user, "First Forum Post")
         create_activity(instance, "created")
         giveBacon(instance.user, 2)  # Reward for posting in forum
-    
 
     elif sender == Bid and created:  # Track first bid placed
         assign_first_action_badge(instance.user, "First Bid Placed")
@@ -156,6 +153,7 @@ def update_user_streak(sender, instance, created, **kwargs):
                 user=instance.user, current_streak=1, longest_streak=1, last_check_in=check_in_date
             )
 
+
 @receiver(post_save, sender=Organization)
 def handle_organization_creation(sender, instance, created, **kwargs):
     """Give bacon to user when they create an organization"""
@@ -166,6 +164,7 @@ def handle_organization_creation(sender, instance, created, **kwargs):
         create_activity(instance, "created")
         # Give first organization badge
         assign_first_action_badge(instance.admin, "First Organization Created")
+
 
 @receiver(post_save, sender=Issue)
 def handle_issue_bacon_rewards(sender, instance, created, update_fields, **kwargs):

--- a/website/feed_signals.py
+++ b/website/feed_signals.py
@@ -51,7 +51,7 @@ def create_activity(instance, action_type):
     # Get instance name or title
     name = getattr(instance, "name", getattr(instance, "title", ""))[:50]
     title = f"{model_name.capitalize()} {action_type.capitalize()} {name}"
-
+    description = getattr(instance, "description", None)
     # Create the activity
     Activity.objects.create(
         user=user,
@@ -59,7 +59,7 @@ def create_activity(instance, action_type):
         title=title,
         content_type=content_type,
         object_id=instance.id,  # Use object_id for GenericForeignKey
-        description=getattr(instance, "description", getattr(instance, "content", ""))[:100],
+        description=description[:100] if description else "",
         image=getattr(instance, "screenshot", getattr(instance, "image", None)),
     )
 

--- a/website/feed_signals.py
+++ b/website/feed_signals.py
@@ -15,6 +15,7 @@ from .models import (
     Post,
     TimeLog,
     UserBadge,
+    Organization,
     UserProfile,
 )
 
@@ -146,3 +147,14 @@ def update_user_streak(sender, instance, created, **kwargs):
             UserProfile.objects.create(
                 user=instance.user, current_streak=1, longest_streak=1, last_check_in=check_in_date
             )
+
+@receiver(post_save, sender=Organization)
+def handle_organization_creation(sender, instance, created, **kwargs):
+    """Give bacon to user when they create an organization"""
+    if created and instance.admin:
+        # Give 10 bacon tokens for creating an organization
+        giveBacon(instance.admin, 10)
+        # Create an activity for the organization creation
+        create_activity(instance, "created")
+        # Give first organization badge
+        assign_first_action_badge(instance.admin, "First Organization Created")

--- a/website/templates/github_issues.html
+++ b/website/templates/github_issues.html
@@ -39,37 +39,38 @@
                 <p class="text-2xl font-bold text-blue-600">{{ issue_count }}</p>
             </div>
         </div>
-                        <!-- BACON Rewards Section -->
-                <div class="mt-12 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
-                    <div class="sm:col-span-5">
-                        <div class="bg-gray-50 p-6 rounded-lg border-2 border-[#e74c3c] shadow-sm">
-                            <div class="flex items-center gap-3 mb-4">
-                                <i class="fas fa-bacon text-2xl text-[#e74c3c]"></i>
-                                <h3 class="text-xl font-semibold text-gray-900">BACON Rewards</h3>
-                            </div>
-                            <p class="text-gray-600 mb-4">
-                                Get rewarded with BACON tokens for your contributions! Create quality issues and earn tokens when they get resolved.
-                            </p>
-                            <div class="flex flex-wrap gap-4">
-                                <div class="flex items-center gap-2">
-                                    <i class="fas fa-check-circle text-[#e74c3c]"></i>
-                                    <span class="text-sm text-gray-700">5 BACON tokens for accepted issues</span>
-                                </div>
-                                <div class="flex items-center gap-2">
-                                    <i class="fas fa-star text-[#e74c3c]"></i>
-                                    <span class="text-sm text-gray-700">Bonus tokens for security-related issues</span>
-                                </div>
-                            </div>
-                            <div class="mt-4">
-                                <a href="/bacon" class="text-[#e74c3c] hover:text-[#c0392b] inline-flex items-center gap-2 text-sm">
-                                    <i class="fas fa-info-circle"></i>
-                                    Learn more about BACON rewards
-                                </a>
-                            </div>
+        <!-- BACON Rewards Section -->
+        <div class="mt-12 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
+            <div class="sm:col-span-5">
+                <div class="bg-gray-50 p-6 rounded-lg border-2 border-[#e74c3c] shadow-sm">
+                    <div class="flex items-center gap-3 mb-4">
+                        <i class="fas fa-bacon text-2xl text-[#e74c3c]"></i>
+                        <h3 class="text-xl font-semibold text-gray-900">BACON Rewards</h3>
+                    </div>
+                    <p class="text-gray-600 mb-4">
+                        Get rewarded with BACON tokens for your contributions! Create quality issues and earn tokens when they get resolved.
+                    </p>
+                    <div class="flex flex-wrap gap-4">
+                        <div class="flex items-center gap-2">
+                            <i class="fas fa-check-circle text-[#e74c3c]"></i>
+                            <span class="text-sm text-gray-700">5 BACON tokens for accepted issues</span>
+                        </div>
+                        <div class="flex items-center gap-2">
+                            <i class="fas fa-star text-[#e74c3c]"></i>
+                            <span class="text-sm text-gray-700">Bonus tokens for security-related issues</span>
                         </div>
                     </div>
+                    <div class="mt-4">
+                        <a href="/bacon"
+                           class="text-[#e74c3c] hover:text-[#c0392b] inline-flex items-center gap-2 text-sm">
+                            <i class="fas fa-info-circle"></i>
+                            Learn more about BACON rewards
+                        </a>
+                    </div>
                 </div>
-                <input type="hidden" name="csrfmiddlewaretoken" value="{{ csrf_token }}">
+            </div>
+        </div>
+        <input type="hidden" name="csrfmiddlewaretoken" value="{{ csrf_token }}">
         <!-- Add GitHub Issue Form -->
         <div class="bg-white rounded-lg shadow p-6 mb-8">
             <h2 class="text-xl font-bold mb-4">Add GitHub Issue with Bounty</h2>

--- a/website/templates/github_issues.html
+++ b/website/templates/github_issues.html
@@ -39,6 +39,37 @@
                 <p class="text-2xl font-bold text-blue-600">{{ issue_count }}</p>
             </div>
         </div>
+                        <!-- BACON Rewards Section -->
+                <div class="mt-12 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
+                    <div class="sm:col-span-5">
+                        <div class="bg-gray-50 p-6 rounded-lg border-2 border-[#e74c3c] shadow-sm">
+                            <div class="flex items-center gap-3 mb-4">
+                                <i class="fas fa-bacon text-2xl text-[#e74c3c]"></i>
+                                <h3 class="text-xl font-semibold text-gray-900">BACON Rewards</h3>
+                            </div>
+                            <p class="text-gray-600 mb-4">
+                                Get rewarded with BACON tokens for your contributions! Create quality issues and earn tokens when they get resolved.
+                            </p>
+                            <div class="flex flex-wrap gap-4">
+                                <div class="flex items-center gap-2">
+                                    <i class="fas fa-check-circle text-[#e74c3c]"></i>
+                                    <span class="text-sm text-gray-700">5 BACON tokens for accepted issues</span>
+                                </div>
+                                <div class="flex items-center gap-2">
+                                    <i class="fas fa-star text-[#e74c3c]"></i>
+                                    <span class="text-sm text-gray-700">Bonus tokens for security-related issues</span>
+                                </div>
+                            </div>
+                            <div class="mt-4">
+                                <a href="/bacon" class="text-[#e74c3c] hover:text-[#c0392b] inline-flex items-center gap-2 text-sm">
+                                    <i class="fas fa-info-circle"></i>
+                                    Learn more about BACON rewards
+                                </a>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <input type="hidden" name="csrfmiddlewaretoken" value="{{ csrf_token }}">
         <!-- Add GitHub Issue Form -->
         <div class="bg-white rounded-lg shadow p-6 mb-8">
             <h2 class="text-xl font-bold mb-4">Add GitHub Issue with Bounty</h2>
@@ -66,8 +97,20 @@
                 </div>
                 <div>
                     <button type="submit"
-                            class="bg-[#e74c3c] text-white px-4 py-2 rounded-md hover:bg-opacity-90 transition-colors">
+                            class="bg-[#e74c3c] text-white px-4 py-2 rounded-md hover:bg-opacity-90 transition-colors group relative"
+                            data-tooltip="Earn 5 BACON tokens for submitting a valid issue!">
                         Add GitHub Issue
+                        <!-- Tooltip -->
+                        <div class="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 px-3 py-2 bg-gray-900 text-white text-sm rounded-lg opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-200 whitespace-nowrap">
+                            <div class="flex items-center gap-2">
+                                <i class="fas fa-bacon"></i>
+                                <span>Earn 5 BACON tokens for submitting a valid issue!</span>
+                            </div>
+                            <!-- Arrow -->
+                            <div class="absolute left-1/2 bottom-0 transform -translate-x-1/2 translate-y-full">
+                                <div class="border-8 border-transparent border-t-gray-900"></div>
+                            </div>
+                        </div>
                     </button>
                 </div>
             </form>

--- a/website/templates/organization/register_organization.html
+++ b/website/templates/organization/register_organization.html
@@ -27,6 +27,10 @@
                     <p class="mt-3 text-gray-600 max-w-2xl mx-auto">
                         {% trans "Join our platform and manage your organization's bug tracking efficiently." %}
                     </p>
+                    <div class="mt-4 inline-flex items-center px-4 py-2 bg-red-50 text-[#e74c3c] rounded-full text-sm">
+                        <i class="fas fa-gift mr-2"></i>
+                        Earn <a href="/bacon" class="font-bold hover:text-red-700 underline mx-1">10 BACON</a> tokens on registration!
+                    </div>
                 </div>
                 <!-- Registration Form -->
                 <form method="post"
@@ -200,9 +204,16 @@
                             {% trans "Cancel" %}
                         </button>
                         <button type="submit"
-                                class="inline-flex items-center px-6 py-3 border border-transparent  font-medium rounded-md shadow-sm text-white bg-[#e74c3c] hover:bg-[#c0392b] focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[#e74c3c]">
+                                class="inline-flex items-center px-6 py-3 border border-transparent font-medium rounded-md shadow-sm text-white bg-[#e74c3c] hover:bg-[#c0392b] focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[#e74c3c] relative group">
                             <i class="fas fa-save mr-2"></i>
                             {% trans "Save Organization" %}
+                            <div class="absolute hidden group-hover:block -top-12 left-1/2 transform -translate-x-1/2 px-3 py-2 bg-gray-900 text-white text-xs rounded">
+                                <div class="flex items-center whitespace-nowrap">
+                                    <i class="fas fa-bacon mr-2"></i>
+                                    <a href="/bacon" class="hover:text-red-300">+10 BACON</a>
+                                </div>
+                                <div class="absolute -bottom-1 left-1/2 transform -translate-x-1/2 w-2 h-2 bg-gray-900 rotate-45"></div>
+                            </div>
                         </button>
                     </div>
                 </form>
@@ -344,4 +355,4 @@
         add_email_container();
     });
     </script>
-{% endblock %}
+{% endblock scripts %}

--- a/website/templates/profile.html
+++ b/website/templates/profile.html
@@ -392,6 +392,35 @@
                     {% endif %}
                 </div>
             </div>
+<div class="flex flex-col gap-4 p-4 bg-gray-50 rounded-lg shadow">
+    <h1 class="text-2xl font-semibold text-black/90">{% trans "Bacon Stats" %}</h1>
+
+    <!-- Show Bacon Earned -->
+    <div class="flex items-center gap-2 text-lg">
+        <span class="font-medium text-black/80">{% trans "Bacon Earned:" %}</span>
+        <span class="text-red-500 font-bold">{{ bacon_earned }}</span>
+    </div>
+
+            <!-- Show Bacon Submission Stats -->
+            <div class="grid grid-cols-2 gap-3 text-center">
+                <div class="p-3 rounded-lg bg-yellow-100 text-yellow-800">
+                    <div class="text-sm font-semibold">{% trans "Pending Submissions" %}</div>
+                    <div class="text-xl font-bold">{{ bacon_submissions.pending }}</div>
+                </div>
+                <div class="p-3 rounded-lg bg-green-100 text-green-800">
+                    <div class="text-sm font-semibold">{% trans "Completed Submissions" %}</div>
+                    <div class="text-xl font-bold">{{ bacon_submissions.completed }}</div>
+                </div>
+            </div>
+
+            <!-- Action Button -->
+            <button class="mt-4 bg-red-400 hover:bg-red-500 transition text-white font-medium py-2 px-4 rounded-lg"
+                    onclick="window.location.href='{% url 'bacon' %}'">
+                {% trans "View Bacon Submissions" %}
+            </button>
+        </div>
+
+
             <div class="flex flex-col gap-3">
                 <h1 class="text-xl font-semibold text-black/90">{% trans "Monthly Report" %}</h1>
                 <div id="chart" class="w-full"></div>

--- a/website/templates/profile.html
+++ b/website/templates/profile.html
@@ -392,35 +392,30 @@
                     {% endif %}
                 </div>
             </div>
-<div class="flex flex-col gap-4 p-4 bg-gray-50 rounded-lg shadow">
-    <h1 class="text-2xl font-semibold text-black/90">{% trans "Bacon Stats" %}</h1>
-
-    <!-- Show Bacon Earned -->
-    <div class="flex items-center gap-2 text-lg">
-        <span class="font-medium text-black/80">{% trans "Bacon Earned:" %}</span>
-        <span class="text-red-500 font-bold">{{ bacon_earned }}</span>
-    </div>
-
-            <!-- Show Bacon Submission Stats -->
-            <div class="grid grid-cols-2 gap-3 text-center">
-                <div class="p-3 rounded-lg bg-yellow-100 text-yellow-800">
-                    <div class="text-sm font-semibold">{% trans "Pending Submissions" %}</div>
-                    <div class="text-xl font-bold">{{ bacon_submissions.pending }}</div>
+            <div class="flex flex-col gap-4 p-4 bg-gray-50 rounded-lg shadow">
+                <h1 class="text-2xl font-semibold text-black/90">{% trans "Bacon Stats" %}</h1>
+                <!-- Show Bacon Earned -->
+                <div class="flex items-center gap-2 text-lg">
+                    <span class="font-medium text-black/80">{% trans "Bacon Earned:" %}</span>
+                    <span class="text-red-500 font-bold">{{ bacon_earned }}</span>
                 </div>
-                <div class="p-3 rounded-lg bg-green-100 text-green-800">
-                    <div class="text-sm font-semibold">{% trans "Completed Submissions" %}</div>
-                    <div class="text-xl font-bold">{{ bacon_submissions.completed }}</div>
+                <!-- Show Bacon Submission Stats -->
+                <div class="grid grid-cols-2 gap-3 text-center">
+                    <div class="p-3 rounded-lg bg-yellow-100 text-yellow-800">
+                        <div class="text-sm font-semibold">{% trans "Pending Submissions" %}</div>
+                        <div class="text-xl font-bold">{{ bacon_submissions.pending }}</div>
+                    </div>
+                    <div class="p-3 rounded-lg bg-green-100 text-green-800">
+                        <div class="text-sm font-semibold">{% trans "Completed Submissions" %}</div>
+                        <div class="text-xl font-bold">{{ bacon_submissions.completed }}</div>
+                    </div>
                 </div>
+                <!-- Action Button -->
+                <button class="mt-4 bg-red-400 hover:bg-red-500 transition text-white font-medium py-2 px-4 rounded-lg"
+                        onclick="window.location.href='{% url 'bacon' %}'">
+                    {% trans "View Bacon Submissions" %}
+                </button>
             </div>
-
-            <!-- Action Button -->
-            <button class="mt-4 bg-red-400 hover:bg-red-500 transition text-white font-medium py-2 px-4 rounded-lg"
-                    onclick="window.location.href='{% url 'bacon' %}'">
-                {% trans "View Bacon Submissions" %}
-            </button>
-        </div>
-
-
             <div class="flex flex-col gap-3">
                 <h1 class="text-xl font-semibold text-black/90">{% trans "Monthly Report" %}</h1>
                 <div id="chart" class="w-full"></div>

--- a/website/templates/report.html
+++ b/website/templates/report.html
@@ -61,6 +61,17 @@
     <div class="min-h-screen bg-gray-50 py-8">
         <div class="w-[90%] mx-auto">
             <div class="bg-white rounded-lg shadow-sm border border-gray-200 px-4 md:px-8 py-8 mb-8">
+                <!-- BACON Reward Section -->
+                <div class="mb-6 p-4 bg-[#e74c3c]/10 rounded-lg">
+                    <div class="flex items-center gap-3">
+                        <i class="fas fa-bacon text-[#e74c3c] text-xl"></i>
+                        <h2 class="text-lg font-semibold text-gray-800">BACON Token Rewards</h2>
+                    </div>
+                    <p class="mt-2 text-gray-600">
+                        Earn 5 BACON tokens for reporting a valid bug! Extra 3 tokens for security-related issues.
+                    </p>
+                </div>
+                <!-- Main Header -->
                 <div class="flex items-center gap-6">
                     <div class="size-16 bg-gradient-to-r from-[#e74c3c] to-[#c0392b] rounded-full flex items-center justify-center">
                         <i class="fas fa-bug text-2xl text-white"></i>
@@ -309,8 +320,19 @@
                         </button>
                         <button type="submit"
                                 name="reportbug_button"
-                                class="px-6 py-2 bg-[#e74c3c] text-white rounded-lg hover:bg-[#c0392b] transition-colors duration-200 font-medium">
+                                class="px-6 py-2 bg-[#e74c3c] text-white rounded-lg hover:bg-[#c0392b] transition-colors duration-200 font-medium group relative">
                             {% trans "Report" %}
+                            <!-- Tooltip -->
+                            <div class="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 px-3 py-2 bg-gray-900 text-white text-sm rounded-lg opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-200 whitespace-nowrap">
+                                <div class="flex items-center gap-2">
+                                    <i class="fas fa-bacon"></i>
+                                    <span>Earn 5 BACON tokens for reporting a bug!</span>
+                                </div>
+                                <!-- Arrow -->
+                                <div class="absolute left-1/2 bottom-0 transform -translate-x-1/2 translate-y-full">
+                                    <div class="border-8 border-transparent border-t-gray-900"></div>
+                                </div>
+                            </div>
                         </button>
                     </div>
                 </div>

--- a/website/templates/report_ip.html
+++ b/website/templates/report_ip.html
@@ -33,9 +33,7 @@
                         <i class="fas fa-bacon text-[#e74c3c] text-xl"></i>
                         <h2 class="text-lg font-semibold text-gray-800">BACON Token Rewards</h2>
                     </div>
-                    <p class="mt-2 text-gray-600">
-                        Earn 5 BACON tokens for reporting a suspicious IP address!
-                    </p>
+                    <p class="mt-2 text-gray-600">Earn 5 BACON tokens for reporting a suspicious IP address!</p>
                 </div>
                 <div class="absolute top-0 right-0 w-48 h-48 bg-gradient-to-br from-red-50 to-red-100 rounded-bl-full -z-10 opacity-70">
                 </div>

--- a/website/templates/report_ip.html
+++ b/website/templates/report_ip.html
@@ -27,6 +27,16 @@
         <div class="w-full max-w-4xl">
             <!-- Card Header with Visual Element -->
             <div class="bg-white rounded-t-2xl shadow-lg p-4 border-b border-gray-100 relative overflow-hidden">
+                <!-- BACON Reward Section -->
+                <div class="mb-6 p-4 bg-[#e74c3c]/10 rounded-lg">
+                    <div class="flex items-center gap-3">
+                        <i class="fas fa-bacon text-[#e74c3c] text-xl"></i>
+                        <h2 class="text-lg font-semibold text-gray-800">BACON Token Rewards</h2>
+                    </div>
+                    <p class="mt-2 text-gray-600">
+                        Earn 5 BACON tokens for reporting a suspicious IP address!
+                    </p>
+                </div>
                 <div class="absolute top-0 right-0 w-48 h-48 bg-gradient-to-br from-red-50 to-red-100 rounded-bl-full -z-10 opacity-70">
                 </div>
                 <div class="relative z-10">
@@ -233,7 +243,18 @@
                                     Cancel
                                 </button>
                                 <button type="submit"
-                                        class="inline-flex justify-center items-center px-5 py-2 border border-transparent text-sm font-medium rounded-lg shadow-sm text-white bg-red-600 hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 transition-all">
+                                        class="inline-flex justify-center items-center px-5 py-2 border border-transparent text-sm font-medium rounded-lg shadow-sm text-white bg-[#e74c3c] hover:bg-[#c0392b] focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 transition-all group relative">
+                                    <!-- Tooltip -->
+                                    <div class="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 px-3 py-2 bg-gray-900 text-white text-sm rounded-lg opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-200 whitespace-nowrap">
+                                        <div class="flex items-center gap-2">
+                                            <i class="fas fa-bacon"></i>
+                                            <span>Earn 1 BACON token for reporting an IP!</span>
+                                        </div>
+                                        <!-- Arrow -->
+                                        <div class="absolute left-1/2 bottom-0 transform -translate-x-1/2 translate-y-full">
+                                            <div class="border-8 border-transparent border-t-gray-900"></div>
+                                        </div>
+                                    </div>
                                     <svg xmlns="http://www.w3.org/2000/svg"
                                          class="h-4 w-4 mr-2"
                                          fill="none"

--- a/website/views/user.py
+++ b/website/views/user.py
@@ -50,6 +50,8 @@ from website.models import (
     UserBadge,
     UserProfile,
     Wallet,
+    BaconEarning,
+    BaconSubmission,
 )
 
 logger = logging.getLogger(__name__)
@@ -297,6 +299,17 @@ class UserProfileDetailView(DetailView):
 
         user = self.object
         context = super(UserProfileDetailView, self).get_context_data(**kwargs)
+        # Add bacon earning data
+        bacon_earning = BaconEarning.objects.filter(user=user).first()
+        print(f"Bacon earning for {user.username}: {bacon_earning}")
+        context["bacon_earned"] = bacon_earning.tokens_earned if bacon_earning else 0
+
+        # Get bacon submission stats
+        context["bacon_submissions"] = {
+            "pending": BaconSubmission.objects.filter(user=user, transaction_status="pending").count(),
+            "completed": BaconSubmission.objects.filter(user=user, transaction_status="completed").count(),
+        }
+
         milestones = [7, 15, 30, 100, 180, 365]
         base_milestone = 0
         next_milestone = 0

--- a/website/views/user.py
+++ b/website/views/user.py
@@ -32,6 +32,8 @@ from blt import settings
 from website.forms import MonitorForm, UserDeleteForm, UserProfileForm
 from website.models import (
     IP,
+    BaconEarning,
+    BaconSubmission,
     Badge,
     Challenge,
     Contributor,
@@ -50,8 +52,6 @@ from website.models import (
     UserBadge,
     UserProfile,
     Wallet,
-    BaconEarning,
-    BaconSubmission,
 )
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
fixes #4229
demo: 
<img width="1101" alt="Screenshot 2025-06-18 at 12 48 51 PM" src="https://github.com/user-attachments/assets/a41ceae5-a682-4f8a-94b5-10e7d8c87da2" />
<img width="531" alt="Screenshot 2025-06-10 at 2 58 03 PM" src="https://github.com/user-attachments/assets/d29bdbda-e2e8-4e43-9145-af2e015d03be" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Admin users receive 10 bacon tokens, an activity record, and a "First Organization Created" badge upon creating a new organization.
  - User profiles now display a "Bacon Stats" section showing total bacon earned and submission statuses, with a link to view bacon submissions.
  - Contributors earn bacon tokens and badges for creating posts, issues, hunts, forum posts, bids, and security-related issues.
  - BACON token rewards information and tooltips added to GitHub issue submission, bug report, suspicious IP report, and organization registration pages to highlight earning opportunities.

- **Style**
  - The organization registration page features a promotional message and tooltip highlighting the 10 bacon token reward, with improved visual cues and corrected template structure.
  - Submit buttons on bug report, IP report, and GitHub issue forms include tooltips with bacon token reward details and enhanced styling for better user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->