### PR TITLE
Fix TypeError by changing MIDDLEWARE from tuple to list.

### DIFF
--- a/blt/settings.py
+++ b/blt/settings.py
@@ -110,7 +110,7 @@ SOCIAL_AUTH_GITHUB_KEY = os.environ.get("GITHUB_CLIENT_ID", "blank")
 SOCIAL_AUTH_GITHUB_SECRET = os.environ.get("GITHUB_CLIENT_SECRET", "blank")
 
 
-MIDDLEWARE = (
+MIDDLEWARE = [
     "django.contrib.sessions.middleware.SessionMiddleware",
     "blt.middleware.domain.DomainMiddleware",
     "django.middleware.locale.LocaleMiddleware",
@@ -126,7 +126,7 @@ MIDDLEWARE = (
     "tz_detect.middleware.TimezoneMiddleware",
     "blt.middleware.ip_restrict.IPRestrictMiddleware",
     "blt.middleware.user_visit_tracking.VisitTrackingMiddleware",
-)
+]
 
 if DEBUG:
     MIDDLEWARE += ["livereload.middleware.LiveReloadScript"]


### PR DESCRIPTION
fixes #4510
Fixes a TypeError in settings.py by changing MIDDLEWARE from a tuple to a list.  
Django supports both, but using a list avoids tuple + list concatenation errors 
and follows modern Django conventions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Standardized middleware configuration to a more flexible structure, enabling easier future extensions and improving compatibility with development tooling. No user-facing behavior changes.
- Chores
  - Minor configuration formatting cleanup for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->