### PR TITLE
fix: Slack link fixed on the contribute page

### DIFF
--- a/website/templates/contribute.html
+++ b/website/templates/contribute.html
@@ -352,7 +352,7 @@
                         Github activity can be seen in Slack <strong>#blt-github</strong>.
                     </li>
                     <li>
-                        Communicate with us on slack <strong>#project-blt</strong> <a href="#" target="_blank" class="text-blue-500 hover:underline">Join OWASP Slack Channel</a>
+                        Communicate with us on slack <strong>#project-blt</strong> <a href="https://join.slack.com/share/enQtOTQxMjcyOTU0NzkxMS0xNGQwNzQ0ZjcyZDQ4NDM2MDc4YWE5NzlmOWRiNDdhMzcxZmU2YjgwMDE3NDJiOGM1ZGVlYjAxOTE3NTlkNDli" target="_blank" class="text-blue-500 hover:underline">Join OWASP Slack Channel</a>
                     </li>
                 </ul>
                 <h3 class="text-2xl font-semibold mt-8 mb-4">Development</h3>

--- a/website/templates/contribute.html
+++ b/website/templates/contribute.html
@@ -352,7 +352,9 @@
                         Github activity can be seen in Slack <strong>#blt-github</strong>.
                     </li>
                     <li>
-                        Communicate with us on slack <strong>#project-blt</strong> <a href="https://join.slack.com/share/enQtOTQxMjcyOTU0NzkxMS0xNGQwNzQ0ZjcyZDQ4NDM2MDc4YWE5NzlmOWRiNDdhMzcxZmU2YjgwMDE3NDJiOGM1ZGVlYjAxOTE3NTlkNDli" target="_blank" class="text-blue-500 hover:underline">Join OWASP Slack Channel</a>
+                        Communicate with us on slack <strong>#project-blt</strong> <a href="https://join.slack.com/share/enQtOTQxMjcyOTU0NzkxMS0xNGQwNzQ0ZjcyZDQ4NDM2MDc4YWE5NzlmOWRiNDdhMzcxZmU2YjgwMDE3NDJiOGM1ZGVlYjAxOTE3NTlkNDli"
+    target="_blank"
+    class="text-blue-500 hover:underline">Join OWASP Slack Channel</a>
                     </li>
                 </ul>
                 <h3 class="text-2xl font-semibold mt-8 mb-4">Development</h3>


### PR DESCRIPTION
fixes #4518

https://github.com/user-attachments/assets/38a5b8c7-4176-4b86-8f64-a004bd6969d3



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - None.

- Bug Fixes
  - Fixed the “Join OWASP Slack Channel” link on the Contribute page to use the actual #project-blt Slack invite URL instead of a placeholder; link text, styling, and behavior (opens in a new tab) are unchanged.

- Documentation
  - Updated external link destination to the valid Slack invite URL for easier access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->