### PR TITLE
Fixed mismatch between page views in bottom left widget and homepage stats

### DIFF
--- a/website/templates/includes/page_stats.html
+++ b/website/templates/includes/page_stats.html
@@ -1,7 +1,7 @@
 {% load custom_tags %}
 {% get_current_template as current_template %}
 {% get_current_url_path as current_url_path %}
-{% get_page_views current_url_path 30 as page_views %}
+{% get_page_views None 30 as page_views %}
 {% get_page_votes current_template as upvotes %}
 {% get_page_votes current_template "downvote" as downvotes %}
 <div id="pageStatsContainer"

--- a/website/templatetags/custom_tags.py
+++ b/website/templatetags/custom_tags.py
@@ -107,7 +107,6 @@ def get_page_views(url_path, days=30):
     if url_path:
         queryset = queryset.filter(path__icontains=url_path)
 
-
     # Query the IP table for views of this page
     daily_views = (
         queryset.values("created__date")

--- a/website/templatetags/custom_tags.py
+++ b/website/templatetags/custom_tags.py
@@ -97,11 +97,11 @@ def get_page_views(url_path, days=30):
     as a JSON dictionary with dates as keys and view counts as values.
     """
     # Get the date range
-    end_date = timezone.now()
-    start_date = end_date - timedelta(days=days)
+    end_day = timezone.localdate()
+    start_day = end_day - timedelta(days=days - 1)
 
-    # Base queryset for given date range
-    queryset = IP.objects.filter(created__gte=start_date, created__lte=end_date)
+    # Base queryset for the last `days` calendar days (inclusive of today)
+    queryset = IP.objects.filter(created__date__range=(start_day, end_day))
 
     # Only filter by path if url_path is provided
     if url_path:
@@ -115,7 +115,7 @@ def get_page_views(url_path, days=30):
 
     # First, initialize the dictionary with zeros for all dates in the range
     for i in range(days):
-        current_date = (start_date + timedelta(days=i)).date()
+        current_date = (start_day + timedelta(days=i))
         formatted_date = current_date.strftime("%Y-%m-%d")
         view_counts_dict[formatted_date] = 0
 

--- a/website/templatetags/custom_tags.py
+++ b/website/templatetags/custom_tags.py
@@ -100,10 +100,17 @@ def get_page_views(url_path, days=30):
     end_date = timezone.now()
     start_date = end_date - timedelta(days=days)
 
+    # Base queryset for given date range
+    queryset = IP.objects.filter(created__gte=start_date, created__lte=end_date)
+
+    # Only filter by path if url_path is provided
+    if url_path:
+        queryset = queryset.filter(path__icontains=url_path)
+
+
     # Query the IP table for views of this page
     daily_views = (
-        IP.objects.filter(path__contains=url_path, created__gte=start_date, created__lte=end_date)
-        .values("created__date")
+        queryset.values("created__date")
         .annotate(total_views=models.Sum("count"))
         .order_by("created__date")
     )

--- a/website/templatetags/custom_tags.py
+++ b/website/templatetags/custom_tags.py
@@ -108,12 +108,7 @@ def get_page_views(url_path, days=30):
         queryset = queryset.filter(path__icontains=url_path)
 
     # Query the IP table for views of this page
-    daily_views = (
-    queryset
-    .values("created__date")
-    .annotate(total_views=models.Sum("count"))
-    .order_by("created__date")
-)
+    daily_views = queryset.values("created__date").annotate(total_views=models.Sum("count")).order_by("created__date")
 
     # Create a dictionary with dates as keys and view counts as values
     view_counts_dict = {}

--- a/website/templatetags/custom_tags.py
+++ b/website/templatetags/custom_tags.py
@@ -115,7 +115,7 @@ def get_page_views(url_path, days=30):
 
     # First, initialize the dictionary with zeros for all dates in the range
     for i in range(days):
-        current_date = (start_day + timedelta(days=i))
+        current_date = start_day + timedelta(days=i)
         formatted_date = current_date.strftime("%Y-%m-%d")
         view_counts_dict[formatted_date] = 0
 

--- a/website/templatetags/custom_tags.py
+++ b/website/templatetags/custom_tags.py
@@ -109,10 +109,11 @@ def get_page_views(url_path, days=30):
 
     # Query the IP table for views of this page
     daily_views = (
-        queryset.values("created__date")
-        .annotate(total_views=models.Sum("count"))
-        .order_by("created__date")
-    )
+    queryset
+    .values("created__date")
+    .annotate(total_views=models.Sum("count"))
+    .order_by("created__date")
+)
 
     # Create a dictionary with dates as keys and view counts as values
     view_counts_dict = {}


### PR DESCRIPTION
fixes: #4567

1. Updated custom_tags.py and page_stats.html to show same and actual page views

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Page views now default to a broader dataset when no specific page is selected, improving the page views chart and total views.
  * Daily aggregation now uses inclusive calendar-day bounds, ensuring per-day and overall view totals are correctly calculated and reducing missing or misattributed counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->