### PR TITLE
Fix: Filter out users with empty usernames in leaderboard view

### DIFF
--- a/website/views/user.py
+++ b/website/views/user.py
@@ -418,11 +418,12 @@ class LeaderboardBase:
             .order_by("-total_score")
             .filter(
                 total_score__gt=0,
+                username__isnull=False,
             )
+            .exclude(username='')
         )
         if api:
             return data.values("id", "username", "total_score")
-
         return data
 
     def current_month_leaderboard(self, api=False):

--- a/website/views/user.py
+++ b/website/views/user.py
@@ -420,7 +420,7 @@ class LeaderboardBase:
                 total_score__gt=0,
                 username__isnull=False,
             )
-            .exclude(username='')
+            .exclude(username="")
         )
         if api:
             return data.values("id", "username", "total_score")


### PR DESCRIPTION
Description:

Fixes: #4682 

Found that the leaderboard was including users with empty or null usernames, which was causing a NoReverseMatch error while generating profile URLs.

Added filters in get_leaderboard to exclude such users.
```
.filter(username__isnull=False)
.exclude(username="")
```


This prevents the error and ensures only valid users are shown in the leaderboard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced leaderboard data quality by filtering out entries with missing or invalid user identifiers, ensuring only legitimate user records appear in rankings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->