### PR TITLE
Fix: pre-commit failure due to missing height and width attributes in <img> tag

### DIFF
--- a/website/templates/bounties_list.html
+++ b/website/templates/bounties_list.html
@@ -149,8 +149,8 @@
                                             <div class="flex items-center">
                                                 <img src="{{ earner.avatar_url }}"
                                                      alt="{{ earner.name }}"
-                                                     width="100%"
-                                                     height="100%"
+                                                     width="40"
+                                                     height="40"
                                                      class="w-10 h-10 rounded-full mr-3">
                                                 <a href="{{ earner.github_url }}"
                                                    target="_blank"

--- a/website/templates/bounties_list.html
+++ b/website/templates/bounties_list.html
@@ -149,6 +149,8 @@
                                             <div class="flex items-center">
                                                 <img src="{{ earner.avatar_url }}"
                                                      alt="{{ earner.name }}"
+                                                     width="100%"
+                                                     height="100%"
                                                      class="w-10 h-10 rounded-full mr-3">
                                                 <a href="{{ earner.github_url }}"
                                                    target="_blank"

--- a/website/templates/home.html
+++ b/website/templates/home.html
@@ -248,7 +248,7 @@
                                     </div>
                                     <p class="text-gray-600 text-sm mb-3">
                                         Organized by <a href="{% url 'organization_detail' slug=hackathon.organization.slug %}"
-                                                        class="text-[#e74c3c] hover:underline">{{ hackathon.organization.name }}</a>
+    class="text-[#e74c3c] hover:underline">{{ hackathon.organization.name }}</a>
                                     </p>
                                     <p class="text-gray-700 mb-4 line-clamp-3">{{ hackathon.description|truncatechars:150 }}</p>
                                     <div class="flex items-center text-sm text-gray-500 mb-4">

--- a/website/views/core.py
+++ b/website/views/core.py
@@ -32,7 +32,7 @@ from django.core.files.base import ContentFile
 from django.core.files.storage import default_storage
 from django.core.management import call_command, get_commands, load_command_class
 from django.db import connection, models
-from django.db.models import Case, Count, DecimalField, F, OuterRef, Q, Subquery, Sum, Value, When
+from django.db.models import Case, Count, DecimalField, F, Q, Sum, Value, When
 from django.db.models.functions import Coalesce, TruncDate
 from django.http import Http404, HttpResponse, JsonResponse
 from django.shortcuts import redirect, render


### PR DESCRIPTION
Fixes: #4749 
**Description:**
This PR fixes the issue where the `djLint` hook was failing during `pre-commit run --all-files` because of an HTML linting rule violation.

The error reported:

```
website/templates/bounties_list.html
H006 150:48 Img tag should have height and width attributes. <img src="{{ earner.
```

**Changes made:**

* Added missing `height` and `width` attributes to the `<img>` tag in `bounties_list.html` to satisfy the `djLint` rule.

**Result:**

* All `pre-commit` hooks, including `djLint`, now pass successfully.
* No functional or visual changes to the template layout.

**Screenshot (Before):**
Previously it get failed at ruff 
<img width="690" height="187" alt="2025-11-08_01-26-52" src="https://github.com/user-attachments/assets/3f9d93d2-c632-45d3-aa3d-1b801f1d6600" />

**Screenshot (After):**
Passed all the pre-commit test with and fixed the issue
<img width="553" height="183" alt="image" src="https://github.com/user-attachments/assets/39c16fc8-46bc-4c92-87d7-5dc8f650ef63" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Added explicit image dimensions for avatars in the Top Earners leaderboard to ensure consistent rendering.
  * Minor HTML formatting adjustments for cleaner markup and consistent indentation.

* **Chores**
  * Removed unused imports/dependencies to tidy code and improve maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->