### PR TITLE
Fix: Remove deprecated DEFAULT_FILE_STORAGE setting (Django 4.2+)

### DIFF
--- a/blt/settings.py
+++ b/blt/settings.py
@@ -318,7 +318,6 @@ else:
             "BACKEND": "django.contrib.staticfiles.storage.ManifestStaticFilesStorage",
         },
     }
-    DEFAULT_FILE_STORAGE = "storages.backends.gcloud.GoogleCloudStorage"
     # Removed DEBUG override - DEBUG should be controlled by environment variable
 
     # use this to debug emails locally


### PR DESCRIPTION
Fixes: #4755

**Description**
This removes the old DEFAULT_FILE_STORAGE line from settings.py.
It is deprecated in Django 4.2+ and conflicts with the STORAGES dict already defined.

This fixes the local test failure and keeps production behavior unchanged since Heroku uses the correct storage config inside its block.

**Screenshot before resolving**
<img width="1265" height="665" alt="2025-11-08_21-56-11" src="https://github.com/user-attachments/assets/3dcc6c36-c8fb-4e52-bdb5-6cbe1dc3aeba" />


**Screenshot after resolving**
<img width="833" height="318" alt="2025-11-08_22-17-52" src="https://github.com/user-attachments/assets/002a744e-4d06-411a-80a6-557003540886" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated file storage configuration system to use dictionary-based configuration, streamlining storage backend management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->