### PR TITLE
fix: youtube embedded videos not showing in /education (#4730)

### DIFF
--- a/website/templates/education/education.html
+++ b/website/templates/education/education.html
@@ -159,6 +159,7 @@
                             title="YouTube video player"
                             frameborder="0"
                             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                            referrerpolicy="strict-origin-when-cross-origin"
                             allowfullscreen></iframe>
                 </div>
             </div>
@@ -169,6 +170,7 @@
                             title="YouTube video player"
                             frameborder="0"
                             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                            referrerpolicy="strict-origin-when-cross-origin"
                             allowfullscreen></iframe>
                 </div>
             </div>
@@ -179,6 +181,7 @@
                             title="YouTube video player"
                             frameborder="0"
                             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                            referrerpolicy="strict-origin-when-cross-origin"
                             allowfullscreen></iframe>
                 </div>
             </div>
@@ -189,6 +192,7 @@
                             title="How to configure Slack Bot"
                             frameborder="0"
                             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                            referrerpolicy="strict-origin-when-cross-origin"
                             allowfullscreen></iframe>
                 </div>
             </div>
@@ -199,6 +203,7 @@
                             title="Host Slack Bot on PythonAnywhere"
                             frameborder="0"
                             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                            referrerpolicy="strict-origin-when-cross-origin"
                             allowfullscreen></iframe>
                 </div>
             </div>


### PR DESCRIPTION
Fixes: #4730 
Embedded YouTube videos were showing 'Error 153'
Added the attribute referrerpolicy="strict-origin-when-cross-origin" to all <iframe> elements to resolve the issue (as also suggested by other contributors).
<img width="1874" height="917" alt="image" src="https://github.com/user-attachments/assets/beb8c526-8cf6-4615-a8ac-878f86b7fe7c" />
<img width="1893" height="963" alt="image" src="https://github.com/user-attachments/assets/a987034b-5474-4170-9e3b-4a9d665b9e93" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated embedded YouTube videos in the Featured videos section to use a stricter referrer policy, improving privacy and security when playing videos. This change does not alter playback behavior or layout—only how referrer information is handled when navigating to embedded content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->