### PR TITLE
Fix: include all reviewers in GitHubReview and fixes issue #3440

### DIFF
--- a/website/management/commands/update_github_issues.py
+++ b/website/management/commands/update_github_issues.py
@@ -137,23 +137,35 @@ class Command(LoggedBaseCommand):
                             reviews_response.raise_for_status()  # Check for HTTP errors
                             reviews_data = reviews_response.json()
 
-                            # Store reviews made by the user
+                            # Store reviews made by ANY user (not just the PR author)
                             if isinstance(reviews_data, list):
                                 for review in reviews_data:
-                                    if review.get("user") and review["user"].get("login") == github_username:
-                                        GitHubReview.objects.update_or_create(
-                                            review_id=review["id"],
-                                            defaults={
-                                                "pull_request": github_issue,
-                                                "reviewer": user,
-                                                "body": review.get("body", ""),
-                                                "state": review["state"],
-                                                "submitted_at": timezone.make_aware(
-                                                    datetime.strptime(review["submitted_at"], "%Y-%m-%dT%H:%M:%SZ")
-                                                ),
-                                                "url": review["html_url"],
-                                            },
-                                        )
+                                    reviewer_login = review.get("user", {}).get("login")
+                                    if reviewer_login:
+                                        # Try to find the reviewer's UserProfile
+                                        try:
+                                            reviewer_profile = UserProfile.objects.filter(
+                                                github_url__icontains=reviewer_login
+                                            ).first()
+
+                                            if reviewer_profile:
+                                                GitHubReview.objects.update_or_create(
+                                                    review_id=review["id"],
+                                                    defaults={
+                                                        "pull_request": github_issue,
+                                                        "reviewer": reviewer_profile,  # The actual reviewer, not the PR author
+                                                        "body": review.get("body", ""),
+                                                        "state": review["state"],
+                                                        "submitted_at": timezone.make_aware(
+                                                            datetime.strptime(review["submitted_at"], "%Y-%m-%dT%H:%M:%SZ")
+                                                        ),
+                                                        "url": review["html_url"],
+                                                    },
+                                                )
+                                        except Exception as e:
+                                            self.stdout.write(
+                                                self.style.WARNING(f"Could not find UserProfile for reviewer {reviewer_login}: {str(e)}")
+                                            )
                         except requests.exceptions.RequestException as e:
                             self.stdout.write(
                                 self.style.ERROR(f"Error fetching reviews for PR {pr['number']}: {str(e)}")

--- a/website/management/commands/update_github_issues.py
+++ b/website/management/commands/update_github_issues.py
@@ -144,8 +144,10 @@ class Command(LoggedBaseCommand):
                                     if reviewer_login:
                                         # Try to find the reviewer's UserProfile
                                         try:
+                                            # Construct the expected URL for an exact match
+                                            expected_github_url = f"https://github.com/{reviewer_login}"
                                             reviewer_profile = UserProfile.objects.filter(
-                                                github_url__icontains=reviewer_login
+                                                github_url__iexact=expected_github_url
                                             ).first()
 
                                             if reviewer_profile:
@@ -157,14 +159,18 @@ class Command(LoggedBaseCommand):
                                                         "body": review.get("body", ""),
                                                         "state": review["state"],
                                                         "submitted_at": timezone.make_aware(
-                                                            datetime.strptime(review["submitted_at"], "%Y-%m-%dT%H:%M:%SZ")
+                                                            datetime.strptime(
+                                                                review["submitted_at"], "%Y-%m-%dT%H:%M:%SZ"
+                                                            )
                                                         ),
                                                         "url": review["html_url"],
                                                     },
                                                 )
                                         except Exception as e:
                                             self.stdout.write(
-                                                self.style.WARNING(f"Could not find UserProfile for reviewer {reviewer_login}: {str(e)}")
+                                                self.style.WARNING(
+                                                    f"Could not find UserProfile for reviewer {reviewer_login}: {str(e)}"
+                                                )
                                             )
                         except requests.exceptions.RequestException as e:
                             self.stdout.write(


### PR DESCRIPTION
This pr fix issue #3440  review Leaderboard so it shows the users who have reviewed PRs on the projects / repos

This PR fixes a logic issue  in update_github_issues.py where only reviews made by the PR author were stored.
As a result, the Code Review Leaderboard had missing data.

Fixes #3440 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Capture and store reviews from any reviewer (no longer limited to the PR author), associating reviews with matching user profiles when found.
  * Add resilient handling for missing or failing reviewer profile lookups: log warnings and continue processing reviews without blocking overall pull request handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->