### PR TITLE
fix: #4776 add missing base layout to email verification page

### DIFF
--- a/website/templates/account/email_confirm.html
+++ b/website/templates/account/email_confirm.html
@@ -2,27 +2,21 @@
 {% load static %}
 {% load custom_tags %}
 {% load i18n %}
-
 {% block title %}
     Confirm Email Address | {% env 'PROJECT_NAME' %}
 {% endblock title %}
-
 {% block description %}
     Complete your email verification to activate your account.
 {% endblock description %}
-
 {% block keywords %}
     Email Confirmation, Account Activation, Email Verification
 {% endblock keywords %}
-
 {% block og_title %}
     Complete Email Verification
 {% endblock og_title %}
-
 {% block og_description %}
     Complete your email verification to activate your account.
 {% endblock og_description %}
-
 {% block natural_content %}
     {% include "includes/sidenav.html" %}
     <div class="flex items-center justify-center w-full min-h-screen p-4 bg-gray-100">
@@ -30,29 +24,26 @@
             <div class="text-center">
                 <!-- Email Icon -->
                 <div class="mx-auto mb-6 w-16 h-16 bg-blue-100 rounded-full flex items-center justify-center">
-                    <svg class="w-8 h-8 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"></path>
+                    <svg class="w-8 h-8 text-blue-600"
+                         fill="none"
+                         stroke="currentColor"
+                         viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z">
+                        </path>
                     </svg>
                 </div>
-
                 <!-- Heading -->
-                <h1 class="text-2xl font-bold text-gray-900 mb-4">
-                    {% trans "Confirm Email Address" %}
-                </h1>
-
+                <h1 class="text-2xl font-bold text-gray-900 mb-4">{% trans "Confirm Email Address" %}</h1>
                 {% if confirmation %}
                     {% if confirmation.email_address.verified %}
                         <!-- Already Verified -->
                         <div class="text-green-600 mb-6">
-                            <p class="text-lg font-semibold mb-2">
-                                {% trans "Email Already Verified" %}
-                            </p>
+                            <p class="text-lg font-semibold mb-2">{% trans "Email Already Verified" %}</p>
                             <p class="text-gray-600">
                                 {% blocktrans with confirmation.email_address.email as email %}Your email address {{ email }} has already been confirmed.{% endblocktrans %}
                             </p>
                         </div>
-                        
-                        <a href="{% url 'account_login' %}" 
+                        <a href="{% url 'account_login' %}"
                            class="w-full inline-block px-4 py-2 text-lg font-semibold text-white bg-red-500 rounded-md shadow hover:bg-red-600 focus:outline-none focus:ring-red-200 focus:ring-4 transition-colors duration-300 text-center">
                             {% trans "Sign In" %}
                         </a>
@@ -63,16 +54,15 @@
                                 {% blocktrans with confirmation.email_address.email as email %}Please confirm that <strong class="text-gray-900">{{ email }}</strong> is an email address for user {{ confirmation.email_address.user }}.{% endblocktrans %}
                             </p>
                         </div>
-
-                        <form method="post" action="{% url 'account_confirm_email' confirmation.key %}">
+                        <form method="post"
+                              action="{% url 'account_confirm_email' confirmation.key %}">
                             {% csrf_token %}
-                            <button type="submit" 
+                            <button type="submit"
                                     class="w-full px-4 py-2 text-lg font-semibold text-white bg-red-500 rounded-md shadow hover:bg-red-600 focus:outline-none focus:ring-red-200 focus:ring-4 transition-colors duration-300 mb-4">
                                 {% trans "Confirm" %}
                             </button>
                         </form>
-
-                        <a href="{% url 'home' %}" 
+                        <a href="{% url 'home' %}"
                            class="w-full inline-block px-4 py-2 text-lg font-semibold text-gray-700 bg-gray-200 rounded-md shadow hover:bg-gray-300 focus:outline-none focus:ring-gray-200 focus:ring-4 transition-colors duration-300 text-center">
                             {% trans "Cancel" %}
                         </a>
@@ -81,26 +71,25 @@
                     <!-- Invalid or Expired Link -->
                     <div class="text-red-600 mb-6">
                         <div class="mx-auto mb-4 w-16 h-16 bg-red-100 rounded-full flex items-center justify-center">
-                            <svg class="w-8 h-8 text-red-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L3.732 16c-.77.833.192 2.5 1.732 2.5z"></path>
+                            <svg class="w-8 h-8 text-red-600"
+                                 fill="none"
+                                 stroke="currentColor"
+                                 viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L3.732 16c-.77.833.192 2.5 1.732 2.5z">
+                                </path>
                             </svg>
                         </div>
-                        
-                        <h2 class="text-xl font-bold mb-2">
-                            {% trans "Invalid Verification Link" %}
-                        </h2>
+                        <h2 class="text-xl font-bold mb-2">{% trans "Invalid Verification Link" %}</h2>
                         <p class="text-gray-600 mb-4">
                             {% trans "This email confirmation link expired or is invalid. Please request a new verification email." %}
                         </p>
                     </div>
-
                     <div class="space-y-3">
-                        <a href="{% url 'account_email' %}" 
+                        <a href="{% url 'account_email' %}"
                            class="w-full inline-block px-4 py-2 text-lg font-semibold text-white bg-red-500 rounded-md shadow hover:bg-red-600 focus:outline-none focus:ring-red-200 focus:ring-4 transition-colors duration-300 text-center">
                             {% trans "Request New Verification Email" %}
                         </a>
-                        
-                        <a href="{% url 'home' %}" 
+                        <a href="{% url 'home' %}"
                            class="w-full inline-block px-4 py-2 text-lg font-semibold text-gray-700 bg-gray-200 rounded-md shadow hover:bg-gray-300 focus:outline-none focus:ring-gray-200 focus:ring-4 transition-colors duration-300 text-center">
                             {% trans "Return to Home" %}
                         </a>

--- a/website/templates/account/email_confirm.html
+++ b/website/templates/account/email_confirm.html
@@ -1,0 +1,112 @@
+{% extends "base.html" %}
+{% load static %}
+{% load custom_tags %}
+{% load i18n %}
+
+{% block title %}
+    Confirm Email Address | {% env 'PROJECT_NAME' %}
+{% endblock title %}
+
+{% block description %}
+    Complete your email verification to activate your account.
+{% endblock description %}
+
+{% block keywords %}
+    Email Confirmation, Account Activation, Email Verification
+{% endblock keywords %}
+
+{% block og_title %}
+    Complete Email Verification
+{% endblock og_title %}
+
+{% block og_description %}
+    Complete your email verification to activate your account.
+{% endblock og_description %}
+
+{% block natural_content %}
+    {% include "includes/sidenav.html" %}
+    <div class="flex items-center justify-center w-full min-h-screen p-4 bg-gray-100">
+        <div class="w-full max-w-md bg-white rounded-lg shadow-lg p-8">
+            <div class="text-center">
+                <!-- Email Icon -->
+                <div class="mx-auto mb-6 w-16 h-16 bg-blue-100 rounded-full flex items-center justify-center">
+                    <svg class="w-8 h-8 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"></path>
+                    </svg>
+                </div>
+
+                <!-- Heading -->
+                <h1 class="text-2xl font-bold text-gray-900 mb-4">
+                    {% trans "Confirm Email Address" %}
+                </h1>
+
+                {% if confirmation %}
+                    {% if confirmation.email_address.verified %}
+                        <!-- Already Verified -->
+                        <div class="text-green-600 mb-6">
+                            <p class="text-lg font-semibold mb-2">
+                                {% trans "Email Already Verified" %}
+                            </p>
+                            <p class="text-gray-600">
+                                {% blocktrans with confirmation.email_address.email as email %}Your email address {{ email }} has already been confirmed.{% endblocktrans %}
+                            </p>
+                        </div>
+                        
+                        <a href="{% url 'account_login' %}" 
+                           class="w-full inline-block px-4 py-2 text-lg font-semibold text-white bg-red-500 rounded-md shadow hover:bg-red-600 focus:outline-none focus:ring-red-200 focus:ring-4 transition-colors duration-300 text-center">
+                            {% trans "Sign In" %}
+                        </a>
+                    {% else %}
+                        <!-- Confirm Email -->
+                        <div class="text-gray-600 mb-6">
+                            <p class="mb-4">
+                                {% blocktrans with confirmation.email_address.email as email %}Please confirm that <strong class="text-gray-900">{{ email }}</strong> is an email address for user {{ confirmation.email_address.user }}.{% endblocktrans %}
+                            </p>
+                        </div>
+
+                        <form method="post" action="{% url 'account_confirm_email' confirmation.key %}">
+                            {% csrf_token %}
+                            <button type="submit" 
+                                    class="w-full px-4 py-2 text-lg font-semibold text-white bg-red-500 rounded-md shadow hover:bg-red-600 focus:outline-none focus:ring-red-200 focus:ring-4 transition-colors duration-300 mb-4">
+                                {% trans "Confirm" %}
+                            </button>
+                        </form>
+
+                        <a href="{% url 'home' %}" 
+                           class="w-full inline-block px-4 py-2 text-lg font-semibold text-gray-700 bg-gray-200 rounded-md shadow hover:bg-gray-300 focus:outline-none focus:ring-gray-200 focus:ring-4 transition-colors duration-300 text-center">
+                            {% trans "Cancel" %}
+                        </a>
+                    {% endif %}
+                {% else %}
+                    <!-- Invalid or Expired Link -->
+                    <div class="text-red-600 mb-6">
+                        <div class="mx-auto mb-4 w-16 h-16 bg-red-100 rounded-full flex items-center justify-center">
+                            <svg class="w-8 h-8 text-red-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L3.732 16c-.77.833.192 2.5 1.732 2.5z"></path>
+                            </svg>
+                        </div>
+                        
+                        <h2 class="text-xl font-bold mb-2">
+                            {% trans "Invalid Verification Link" %}
+                        </h2>
+                        <p class="text-gray-600 mb-4">
+                            {% trans "This email confirmation link expired or is invalid. Please request a new verification email." %}
+                        </p>
+                    </div>
+
+                    <div class="space-y-3">
+                        <a href="{% url 'account_email' %}" 
+                           class="w-full inline-block px-4 py-2 text-lg font-semibold text-white bg-red-500 rounded-md shadow hover:bg-red-600 focus:outline-none focus:ring-red-200 focus:ring-4 transition-colors duration-300 text-center">
+                            {% trans "Request New Verification Email" %}
+                        </a>
+                        
+                        <a href="{% url 'home' %}" 
+                           class="w-full inline-block px-4 py-2 text-lg font-semibold text-gray-700 bg-gray-200 rounded-md shadow hover:bg-gray-300 focus:outline-none focus:ring-gray-200 focus:ring-4 transition-colors duration-300 text-center">
+                            {% trans "Return to Home" %}
+                        </a>
+                    </div>
+                {% endif %}
+            </div>
+        </div>
+    </div>
+{% endblock natural_content %}

--- a/website/templates/account/verification_sent.html
+++ b/website/templates/account/verification_sent.html
@@ -2,27 +2,21 @@
 {% load static %}
 {% load custom_tags %}
 {% load i18n %}
-
 {% block title %}
     Verify Your Email Address | {% env 'PROJECT_NAME' %}
 {% endblock title %}
-
 {% block description %}
     Please check your email for a verification link to complete your account registration.
 {% endblock description %}
-
 {% block keywords %}
     Email Verification, Account Verification, Complete Registration
 {% endblock keywords %}
-
 {% block og_title %}
     Email Verification Required
 {% endblock og_title %}
-
 {% block og_description %}
     Please check your email for a verification link to complete your account registration.
 {% endblock og_description %}
-
 {% block natural_content %}
     {% include "includes/sidenav.html" %}
     <div class="flex items-center justify-center w-full min-h-screen p-4 bg-gray-100">
@@ -30,16 +24,16 @@
             <div class="text-center">
                 <!-- Success Icon -->
                 <div class="mx-auto mb-6 w-16 h-16 bg-green-100 rounded-full flex items-center justify-center">
-                    <svg class="w-8 h-8 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"></path>
+                    <svg class="w-8 h-8 text-green-600"
+                         fill="none"
+                         stroke="currentColor"
+                         viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z">
+                        </path>
                     </svg>
                 </div>
-
                 <!-- Heading -->
-                <h1 class="text-2xl font-bold text-gray-900 mb-4">
-                    {% trans "Verify Your Email Address" %}
-                </h1>
-
+                <h1 class="text-2xl font-bold text-gray-900 mb-4">{% trans "Verify Your Email Address" %}</h1>
                 <!-- Message -->
                 <div class="text-gray-600 mb-6 space-y-3">
                     <p>
@@ -52,26 +46,21 @@
                         {% blocktrans %}Please contact us if you do not receive the verification email within a few minutes.{% endblocktrans %}
                     </p>
                 </div>
-
                 <!-- Action Buttons -->
                 <div class="space-y-3">
-                    <a href="{% url 'home' %}" 
+                    <a href="{% url 'home' %}"
                        class="w-full inline-block px-4 py-2 text-lg font-semibold text-white bg-red-500 rounded-md shadow hover:bg-red-600 focus:outline-none focus:ring-red-200 focus:ring-4 transition-colors duration-300 text-center">
                         {% trans "Return to Home" %}
                     </a>
-                    
-                    <a href="{% url 'account_login' %}" 
+                    <a href="{% url 'account_login' %}"
                        class="w-full inline-block px-4 py-2 text-lg font-semibold text-gray-700 bg-gray-200 rounded-md shadow hover:bg-gray-300 focus:outline-none focus:ring-gray-200 focus:ring-4 transition-colors duration-300 text-center">
                         {% trans "Sign In" %}
                     </a>
                 </div>
-
                 <!-- Resend Email Link -->
                 <div class="mt-6 pt-6 border-t border-gray-200">
-                    <p class="text-sm text-gray-600 mb-2">
-                        {% trans "Didn't receive the email?" %}
-                    </p>
-                    <a href="{% url 'account_email' %}" 
+                    <p class="text-sm text-gray-600 mb-2">{% trans "Didn't receive the email?" %}</p>
+                    <a href="{% url 'account_email' %}"
                        class="text-red-500 hover:text-red-600 font-medium text-sm underline">
                         {% trans "Resend verification email" %}
                     </a>

--- a/website/templates/account/verification_sent.html
+++ b/website/templates/account/verification_sent.html
@@ -1,0 +1,82 @@
+{% extends "base.html" %}
+{% load static %}
+{% load custom_tags %}
+{% load i18n %}
+
+{% block title %}
+    Verify Your Email Address | {% env 'PROJECT_NAME' %}
+{% endblock title %}
+
+{% block description %}
+    Please check your email for a verification link to complete your account registration.
+{% endblock description %}
+
+{% block keywords %}
+    Email Verification, Account Verification, Complete Registration
+{% endblock keywords %}
+
+{% block og_title %}
+    Email Verification Required
+{% endblock og_title %}
+
+{% block og_description %}
+    Please check your email for a verification link to complete your account registration.
+{% endblock og_description %}
+
+{% block natural_content %}
+    {% include "includes/sidenav.html" %}
+    <div class="flex items-center justify-center w-full min-h-screen p-4 bg-gray-100">
+        <div class="w-full max-w-md bg-white rounded-lg shadow-lg p-8">
+            <div class="text-center">
+                <!-- Success Icon -->
+                <div class="mx-auto mb-6 w-16 h-16 bg-green-100 rounded-full flex items-center justify-center">
+                    <svg class="w-8 h-8 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"></path>
+                    </svg>
+                </div>
+
+                <!-- Heading -->
+                <h1 class="text-2xl font-bold text-gray-900 mb-4">
+                    {% trans "Verify Your Email Address" %}
+                </h1>
+
+                <!-- Message -->
+                <div class="text-gray-600 mb-6 space-y-3">
+                    <p>
+                        {% blocktrans %}We have sent an email to you for verification. Follow the link provided to finalize the signup process.{% endblocktrans %}
+                    </p>
+                    <p>
+                        {% blocktrans %}If you do not see the verification email in your main inbox, check your spam folder.{% endblocktrans %}
+                    </p>
+                    <p class="text-sm text-gray-500">
+                        {% blocktrans %}Please contact us if you do not receive the verification email within a few minutes.{% endblocktrans %}
+                    </p>
+                </div>
+
+                <!-- Action Buttons -->
+                <div class="space-y-3">
+                    <a href="{% url 'home' %}" 
+                       class="w-full inline-block px-4 py-2 text-lg font-semibold text-white bg-red-500 rounded-md shadow hover:bg-red-600 focus:outline-none focus:ring-red-200 focus:ring-4 transition-colors duration-300 text-center">
+                        {% trans "Return to Home" %}
+                    </a>
+                    
+                    <a href="{% url 'account_login' %}" 
+                       class="w-full inline-block px-4 py-2 text-lg font-semibold text-gray-700 bg-gray-200 rounded-md shadow hover:bg-gray-300 focus:outline-none focus:ring-gray-200 focus:ring-4 transition-colors duration-300 text-center">
+                        {% trans "Sign In" %}
+                    </a>
+                </div>
+
+                <!-- Resend Email Link -->
+                <div class="mt-6 pt-6 border-t border-gray-200">
+                    <p class="text-sm text-gray-600 mb-2">
+                        {% trans "Didn't receive the email?" %}
+                    </p>
+                    <a href="{% url 'account_email' %}" 
+                       class="text-red-500 hover:text-red-600 font-medium text-sm underline">
+                        {% trans "Resend verification email" %}
+                    </a>
+                </div>
+            </div>
+        </div>
+    </div>
+{% endblock natural_content %}


### PR DESCRIPTION
This PR fixes the missing styles on the **Email Verification** page mentioned in issue #4776  that appears after user signup.  
The page was rendering without the site’s layout or CSS because it did not extend the main base template.

Verified that all static files load correctly and the layout now matches other authentication pages

### 🎯 Impact
- Restores full styling (navbar, fonts, layout) to the verify email page  
- Provides a consistent user experience after signup  

###before
<img width="1465" height="953" alt="Screenshot 2025-11-11 at 4 39 56 PM" src="https://github.com/user-attachments/assets/a8fc31b9-7079-4cdb-a819-ca96ca353f5b" />
### after
<img width="1463" height="848" alt="Screenshot 2025-11-11 at 7 41 21 PM" src="https://github.com/user-attachments/assets/03ff4a47-b317-4771-95ad-1c905e31cbb3" />

Closes #4776 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added email verification confirmation page displaying verification status with options to sign in or return home
  * Added email confirmation interface supporting multiple verification scenarios including successful verification, pending verification, and invalid confirmation cases
  * Added functionality to resend verification emails

<!-- end of auto-generated comment: release notes by coderabbit.ai -->