### PR TITLE
added missing menu options

### DIFF
--- a/website/templates/includes/header.html
+++ b/website/templates/includes/header.html
@@ -271,7 +271,7 @@
                                     </li>
                                     <li>
                                         <a href="{% url 'style_guide' %}"
-                                           class="flex items-center text-gray-700 hover:text-[#e74c3c]"><i class="fab fa-palette w-5 mr-2"></i>Style Guide</a>
+                                           class="flex items-center text-gray-700 hover:text-[#e74c3c]"><i class="fas fa-palette w-5 mr-2"></i>Style Guide</a>
                                     </li>
                                     <li>
                                         <a href="https://github.com/OWASP-BLT/BLT/blob/main/website/templates/{{ current_template }}"

--- a/website/templates/includes/header.html
+++ b/website/templates/includes/header.html
@@ -169,6 +169,10 @@
                                            class="flex items-center text-gray-700 hover:text-[#e74c3c]"><i class="fas fa-flag-checkered w-5 mr-2"></i>Challenges</a>
                                     </li>
                                     <li>
+                                        <a href="{% url 'staking_home' %}"
+                                           class="flex items-center text-gray-700 hover:text-[#e74c3c]"><i class="fas fa-coins w-5 mr-2"></i>Staking</a>
+                                    </li>
+                                    <li>
                                         <a href="{% url 'leaderboard_global' %}"
                                            class="flex items-center text-gray-700 hover:text-[#e74c3c]"><i class="fas fa-medal w-5 mr-2"></i>Leaderboard</a>
                                     </li>
@@ -266,6 +270,10 @@
                                            class="flex items-center text-gray-700 hover:text-[#e74c3c]"><i class="fab fa-figma w-5 mr-2"></i>Design</a>
                                     </li>
                                     <li>
+                                        <a href="{% url 'style_guide' %}"
+                                           class="flex items-center text-gray-700 hover:text-[#e74c3c]"><i class="fab fa-palette w-5 mr-2"></i>Style Guide</a>
+                                    </li>
+                                    <li>
                                         <a href="https://github.com/OWASP-BLT/BLT/blob/main/website/templates/{{ current_template }}"
                                            target="_blank"
                                            class="flex items-center text-gray-700 hover:text-[#e74c3c]"><i class="fas fa-edit w-5 mr-2"></i>Edit this page</a>
@@ -293,6 +301,10 @@
                                     <li>
                                         <a href="{% url 'education' %}"
                                            class="flex items-center text-gray-700 hover:text-[#e74c3c]"><i class="fas fa-tv w-5 mr-2"></i>Education</a>
+                                    </li>
+                                    <li>
+                                        <a href="{% url 'simulation_dashboard' %}"
+                                           class="flex items-center text-gray-700 hover:text-[#e74c3c]"><i class="fas fa-flask w-5 mr-2"></i>Security Labs</a>
                                     </li>
                                     <li>
                                         <a href="{% url 'ossh_home' %}"

--- a/website/templates/includes/sidenav.html
+++ b/website/templates/includes/sidenav.html
@@ -295,6 +295,13 @@
                             </div>
                             <span class="truncate">{% trans "Badges" %}</span>
                         </a>
+                        <a href="{% url 'reminder_settings' %}"
+                           class="group flex items-center px-2 py-2 text-lg font-medium rounded-md {% if request.resolver_match.url_name == 'reminder_settings' %}bg-[#feeae9] text-[#e74c3c]{% else %}text-gray-700 hover:bg-gray-100 hover:text-[#e74c3c]{% endif %} transition-all duration-200">
+                            <div class="mr-3 flex-shrink-0 w-5 h-5 flex items-center justify-center {% if request.resolver_match.url_name == 'reminder_settings' %}text-[#e74c3c]{% else %}text-gray-500 group-hover:text-[#e74c3c]{% endif %} transition-all duration-200">
+                                <i class="fas fa-bell"></i>
+                            </div>
+                            <span class="truncate">{% trans "Reminder Settings" %}</span>
+                        </a>
                     </div>
                 </div>
                 <!-- Teams Section -->


### PR DESCRIPTION
closes #4785  added security labs, staking, style guide and remainder settings in menu
<img width="350" height="859" alt="Screenshot 2025-11-13 034215" src="https://github.com/user-attachments/assets/875dae30-de6b-4faf-aa32-0f522766bec0" />
<img width="1709" height="705" alt="Screenshot 2025-11-13 034153" src="https://github.com/user-attachments/assets/e72a6b4e-3c07-40ef-a8e3-b6f6817e4d7e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Staking, Style Guide, and Security Labs entries to the main mega-menu under Users, Resources, and Contribute respectively for easier access to those sections.
  * Added a Reminder Settings item to the sidebar navigation for quick access to notification preferences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->