### PR TITLE
Fix: Map does not zoom or highlight any banned country

### DIFF
--- a/website/templates/banned_apps.html
+++ b/website/templates/banned_apps.html
@@ -211,7 +211,7 @@
             const displayCount = count;
             const markerHTML = `
                 <div style="position: relative; width: 42px; height: 42px;">
-                    <div style="width: 42px; height: 42px; border-radius: 50% 50% 50% 0; background: #dc2626; transform: rotate(-45deg); display: flex; align-items: center; justify-content: center; color: white; font-size: 16px; font-weight: 700; box-shadow: 0 0 10px rgba(0,0,0,0.25); animation: popIn 0.35s ease-out;">
+                    <div style="width: 42px; height: 42px; border-radius: 50% 50% 50% 0; background: #dc2626; transform: rotate(-45deg); display: flex; align-items: center; justify-content: center; color: white; font-size: 16px; font-weight: 700; box-shadow: 0 0 10px rgba(0,0,0,0.25); ">
                         <div style="transform: rotate(45deg);">
                             ${displayCount}
                         </div>

--- a/website/templates/banned_apps.html
+++ b/website/templates/banned_apps.html
@@ -58,7 +58,7 @@
         // Initialize variables
         let map;
         let countriesLayer;
-        let markerLayer;
+        let markersLayer;
         let allCountriesData = {};
         let geoJSONLoaded = false;
         
@@ -95,7 +95,7 @@
             }).addTo(map);
 
             // Create layer for markers
-            markerLayer = L.layerGroup().addTo(map);
+            markersLayer = L.layerGroup().addTo(map);
 
             // Load countries GeoJSON
             fetch('https://raw.githubusercontent.com/datasets/geo-countries/master/data/countries.geojson')
@@ -199,8 +199,8 @@
         
         // Place marker
         function placeCountryMarker(country, apps) {
-            if (!markerLayer) return;
-            markerLayer.clearLayers();
+            if (!markersLayer) return;
+            markersLayer.clearLayers();
             
             const lower = country.toLowerCase();
             const countryData = allCountriesData[lower];
@@ -237,7 +237,7 @@
                 showCountryInfo(country, apps);
             });
 
-            markerLayer.addLayer(marker);
+            markersLayer.addLayer(marker);
         }
 
         function showResults(apps) {

--- a/website/templates/banned_apps.html
+++ b/website/templates/banned_apps.html
@@ -61,7 +61,7 @@
         let markerLayer;
         let allCountriesData = {};
         let geoJSONLoaded = false;
-    
+        
         // Initialize tabs
         document.getElementById('listViewBtn').addEventListener('click', function () {
             document.getElementById('listView').classList.remove('hidden');
@@ -71,7 +71,7 @@
             document.getElementById('mapViewBtn').classList.remove('text-red-600', 'border-b-2', 'border-red-600');
             document.getElementById('mapViewBtn').classList.add('text-gray-500');
         });
-    
+        
         document.getElementById('mapViewBtn').addEventListener('click', function () {
             document.getElementById('mapView').classList.remove('hidden');
             document.getElementById('listView').classList.add('hidden');
@@ -79,24 +79,23 @@
             this.classList.remove('text-gray-500');
             document.getElementById('listViewBtn').classList.remove('text-red-600', 'border-b-2', 'border-red-600');
             document.getElementById('listViewBtn').classList.add('text-gray-500');
-    
+            
             // Initialize map if it hasn't been initialized yet
             if (!map) {
                 initMap();
-                markerLayer = L.layerGroup().addTo(map);
             }
         });
-    
+        
         // Initialize map
         function initMap() {
             map = L.map('map').setView([20, 0], 2);
-    
+            
             L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
                 attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
             }).addTo(map);
-    
+            
             markerLayer = L.layerGroup().addTo(map);
-    
+            
             fetch('https://raw.githubusercontent.com/datasets/geo-countries/master/data/countries.geojson')
                 .then(response => response.json())
                 .then(data => {
@@ -111,12 +110,14 @@
                         onEachFeature: function (feature, layer) {
                             const countryName = (feature.properties.name || feature.properties.ADMIN || "").toLowerCase();
                             if (!countryName) return;
-    
-                            allCountriesData[countryName] = {
+                            
+                            // store lowercase key for consistent lookup
+                            allCountriesData[countryName.toLowerCase()] = {
                                 layer: layer,
-                                center: layer.getBounds().getCenter()
+                                center: layer.getBounds().getCenter(),
+                                feature: feature
                             };
-    
+                            
                             layer.on({
                                 mouseover: function () {
                                     layer.setStyle({ weight: 2, color: "#9ca3af" });
@@ -129,9 +130,11 @@
                     }).addTo(map);
                     geoJSONLoaded = true;
                 })
-                .catch(err => console.error("Error loading GeoJSON:", err));
+                .catch(err => { console.error("Error loading GeoJSON:", err);
+                    geoJSONLoaded = true;
+                });
         }
-    
+        
         // Debounce function
         function debounce(func, wait) {
             let timeout;
@@ -140,13 +143,13 @@
                 timeout = setTimeout(() => func(...args), wait);
             };
         }
-    
+        
         // Search function
         document.getElementById('countrySearch').addEventListener('input', debounce(function (e) {
             const country = e.target.value.trim();
             searchApps(country);
         }, 300));
-    
+        
         function searchApps(country) {
             if (!geoJSONLoaded) {
                 setTimeout(() => searchApps(country), 500);
@@ -157,7 +160,7 @@
                 resetMap();
                 return;
             }
-    
+            
             fetch(`/api/banned_apps/search/?country=${encodeURIComponent(country)}`)
                 .then(response => response.json())
                 .then(data => {
@@ -172,40 +175,38 @@
                 })
                 .catch(err => console.error('Error:', err));
         }
-    
+        
         // Highlight country 
         function highlightCountry(country, hasApps) {
             if (!map || !countriesLayer) return;
             resetMap();
-    
+            
             const lower = country.toLowerCase();
             const countryData = allCountriesData[lower];
             if (!countryData) return;
-    
+            
             countryData.layer.setStyle({
                 fillColor: hasApps ? '#ef4444' : '#a1a1aa',
                 weight: 2,
                 color: hasApps ? '#b91c1c' : '#71717a',
                 fillOpacity: 0.8
             });
-    
+            
             map.flyToBounds(countryData.layer.getBounds(), { duration: 1.2 });
         }
-    
+        
         // Place marker
         function placeCountryMarker(country, apps) {
             if (!markerLayer) return;
             markerLayer.clearLayers();
-    
+            
             const lower = country.toLowerCase();
             const countryData = allCountriesData[lower];
             if (!countryData) return;
-    
+            
             const center = countryData.center;
             const count = apps.length;
-    
             const displayCount = count;
-    
             const markerHTML = `
                 <div style="position: relative; width: 42px; height: 42px;">
                     <div style="width: 42px; height: 42px; border-radius: 50% 50% 50% 0; background: #dc2626; transform: rotate(-45deg); display: flex; align-items: center; justify-content: center; color: white; font-size: 16px; font-weight: 700; box-shadow: 0 0 10px rgba(0,0,0,0.25); animation: popIn 0.35s ease-out;">
@@ -214,7 +215,7 @@
                         </div>
                     </div>
                 </div>`;
-    
+            
             const marker = L.marker(center, {
                 icon: L.divIcon({
                     className: "map-pin-marker",
@@ -223,80 +224,141 @@
                     iconAnchor: [21, 42]
                 })
             });
-    
+
             marker.bindTooltip(
                 `${count} banned ${count === 1 ? "app" : "apps"}`,
                 { permanent: false, direction: "top", offset: [0, -5] }
             );
-    
+
             // Banned apps in map
             marker.on("click", () => {
                 showCountryInfo(country, apps);
             });
-    
+
             markerLayer.addLayer(marker);
         }
-    
+
         function showResults(apps) {
             const grid = document.getElementById('appsGrid');
-            grid.innerHTML = '';
+            // clear previous
+            while (grid.firstChild) grid.removeChild(grid.firstChild);
 
             apps.forEach(app => {
                 const card = document.createElement('div');
                 card.className = 'bg-white rounded-lg shadow-md p-6 hover:shadow-lg transition-shadow';
-                card.innerHTML = `
-                    <h3 class="text-xl font-semibold mb-2 text-red-600">${app.app_name}</h3>
-                    <p class="text-sm text-gray-600 mb-2">${app.app_type}</p>
-                    <p class="text-gray-800 mb-4">${app.ban_reason}</p>
-                    <div class="text-sm text-gray-600">
-                        <p>Ban Date: ${new Date(app.ban_date).toLocaleDateString()}</p>
-                        ${app.source_url ? `<a href="${app.source_url}" target="_blank" class="text-red-600 hover:underline">Source →</a>` : ''}
-                    </div>`;
+
+                const title = document.createElement('h3');
+                title.className = 'text-xl font-semibold mb-2 text-red-600';
+                title.textContent = app.app_name || '';
+
+                const type = document.createElement('p');
+                type.className = 'text-sm text-gray-600 mb-2';
+                type.textContent = app.app_type || '';
+
+                const reason = document.createElement('p');
+                reason.className = 'text-gray-800 mb-4';
+                reason.textContent = app.ban_reason || '';
+
+                const footer = document.createElement('div');
+                footer.className = 'text-sm text-gray-600';
+
+                const date = document.createElement('p');
+                
+                try {
+                    date.textContent = `Ban Date: ${new Date(app.ban_date).toLocaleDateString()}`;
+                } catch (e) {
+                    date.textContent = `Ban Date: ${app.ban_date || 'N/A'}`;
+                }
+                footer.appendChild(date);
+                
+                if (app.source_url) {
+                    const link = document.createElement('a');
+                    link.href = app.source_url;
+                    link.target = '_blank';
+                    link.rel = 'noopener noreferrer';
+                    link.className = 'text-red-600 hover:underline';
+                    link.textContent = 'Source →';
+                    footer.appendChild(link);
+                }
+
+                card.appendChild(title);
+                card.appendChild(type);
+                card.appendChild(reason);
+                card.appendChild(footer);
+
                 grid.appendChild(card);
             });
 
             document.getElementById('resultsSection').classList.remove('hidden');
             document.getElementById('noResults').classList.add('hidden');
         }
-    
+
         function showCountryInfo(country, apps) {
             const countryInfoDiv = document.getElementById('countryInfo');
-            
-            // Update country name
-            document.getElementById('countryName').textContent = country.charAt(0).toUpperCase() + country.slice(1);
-           
+
+            const countryData = allCountriesData[country.toLowerCase()];
+            const properName = countryData?.feature?.properties?.name || country;
+            document.getElementById('countryName').textContent = properName;
+
             // Update banned apps count
             document.getElementById('bannedAppsCount').textContent = `${apps.length} Banned Apps`;
+
+            // Update banned apps list 
+            const appsList = document.getElementById('bannedAppsList');
             
-            // Update banned apps list
-            document.getElementById('bannedAppsList').innerHTML = apps.map(app => `
-                <div class="py-2 border-b border-gray-200">
-                    <h4 class="font-semibold text-red-600">${app.app_name}</h4>
-                    <p class="text-sm text-gray-600">${app.app_type}</p>
-                    <p class="text-sm mt-1">${app.ban_reason}</p>
-                    <p class="text-xs mt-1">Ban Date: ${new Date(app.ban_date).toLocaleDateString()}</p>
-                </div>
-            `).join('');
+            while (appsList.firstChild) appsList.removeChild(appsList.firstChild);
+
+            apps.forEach(app => {
+                const appDiv = document.createElement('div');
+                appDiv.className = 'py-2 border-b border-gray-200';
+
+                const name = document.createElement('h4');
+                name.className = 'font-semibold text-red-600';
+                name.textContent = app.app_name || '';
+
+                const type = document.createElement('p');
+                type.className = 'text-sm text-gray-600';
+                type.textContent = app.app_type || '';
+
+                const reason = document.createElement('p');
+                reason.className = 'text-sm mt-1';
+                reason.textContent = app.ban_reason || '';
+
+                const date = document.createElement('p');
+                date.className = 'text-xs mt-1';
+                try {
+                    date.textContent = `Ban Date: ${new Date(app.ban_date).toLocaleDateString()}`;
+                } catch (e) {
+                    date.textContent = `Ban Date: ${app.ban_date || 'N/A'}`;
+                }
+
+                appDiv.appendChild(name);
+                appDiv.appendChild(type);
+                appDiv.appendChild(reason);
+                appDiv.appendChild(date);
+
+                appsList.appendChild(appDiv);
+            });
 
             // Show the country info section
             countryInfoDiv.classList.remove('hidden');
         }
-    
+
         function showNoResults() {
             document.getElementById('resultsSection').classList.add('hidden');
             document.getElementById('noResults').classList.remove('hidden');
             document.getElementById('countryInfo').classList.add('hidden');
         }
-    
+
         function hideResults() {
             document.getElementById('resultsSection').classList.add('hidden');
             document.getElementById('noResults').classList.add('hidden');
             document.getElementById('countryInfo').classList.add('hidden');
         }
-    
+
         function resetMap() {
             if (!map || !countriesLayer) return;
-            
+
             // Reset country styles
             countriesLayer.eachLayer(layer => {
                 countriesLayer.resetStyle(layer);
@@ -305,7 +367,7 @@
             // Hide country info
             document.getElementById('countryInfo').classList.add('hidden');
         }
-    
+
         // Initialization
         document.addEventListener('DOMContentLoaded', function() {
             // Set default view to List View

--- a/website/templates/banned_apps.html
+++ b/website/templates/banned_apps.html
@@ -242,59 +242,34 @@
 
         function showResults(apps) {
             const grid = document.getElementById('appsGrid');
-            // clear previous
-            while (grid.firstChild) grid.removeChild(grid.firstChild);
-
+            grid.innerHTML = '';
+            
             apps.forEach(app => {
-                const card = document.createElement('div');
-                card.className = 'bg-white rounded-lg shadow-md p-6 hover:shadow-lg transition-shadow';
-
-                const title = document.createElement('h3');
-                title.className = 'text-xl font-semibold mb-2 text-red-600';
-                title.textContent = app.app_name || '';
-
-                const type = document.createElement('p');
-                type.className = 'text-sm text-gray-600 mb-2';
-                type.textContent = app.app_type || '';
-
-                const reason = document.createElement('p');
-                reason.className = 'text-gray-800 mb-4';
-                reason.textContent = app.ban_reason || '';
-
-                const footer = document.createElement('div');
-                footer.className = 'text-sm text-gray-600';
-
-                const date = document.createElement('p');
-                
-                try {
-                    date.textContent = `Ban Date: ${new Date(app.ban_date).toLocaleDateString()}`;
-                } catch (e) {
-                    date.textContent = `Ban Date: ${app.ban_date || 'N/A'}`;
-                }
-                footer.appendChild(date);
-                
-                if (app.source_url) {
-                    const link = document.createElement('a');
-                    link.href = app.source_url;
-                    link.target = '_blank';
-                    link.rel = 'noopener noreferrer';
-                    link.className = 'text-red-600 hover:underline';
-                    link.textContent = 'Source →';
-                    footer.appendChild(link);
-                }
-
-                card.appendChild(title);
-                card.appendChild(type);
-                card.appendChild(reason);
-                card.appendChild(footer);
-
+                const card = createAppCard(app);
                 grid.appendChild(card);
             });
-
+            
             document.getElementById('resultsSection').classList.remove('hidden');
             document.getElementById('noResults').classList.add('hidden');
         }
-
+        
+        function createAppCard(app) {
+            const div = document.createElement('div');
+            div.className = 'bg-white rounded-lg shadow-md p-6 hover:shadow-lg transition-shadow';
+            
+            div.innerHTML = `
+                <h3 class="text-xl font-semibold mb-2 text-red-600">${app.app_name}</h3>
+                <p class="text-sm text-gray-600 mb-2">${app.app_type}</p>
+                <p class="text-gray-800 mb-4">${app.ban_reason}</p>
+                <div class="text-sm text-gray-600">
+                    <p>Ban Date: ${new Date(app.ban_date).toLocaleDateString()}</p>
+                    ${app.source_url ? `<a href="${app.source_url}" target="_blank" class="text-red-600 hover:underline">Source →</a>` : ''}
+                </div>
+            `;
+            
+            return div;
+        }
+                
         function showCountryInfo(country, apps) {
             const countryInfoDiv = document.getElementById('countryInfo');
 

--- a/website/templates/banned_apps.html
+++ b/website/templates/banned_apps.html
@@ -58,12 +58,12 @@
         // Initialize variables
         let map;
         let countriesLayer;
-        let markersLayer;
+        let markerLayer;
         let allCountriesData = {};
-        let currentCountry = '';
-        
+        let geoJSONLoaded = false;
+    
         // Initialize tabs
-        document.getElementById('listViewBtn').addEventListener('click', function() {
+        document.getElementById('listViewBtn').addEventListener('click', function () {
             document.getElementById('listView').classList.remove('hidden');
             document.getElementById('mapView').classList.add('hidden');
             this.classList.add('text-red-600', 'border-b-2', 'border-red-600');
@@ -71,289 +71,205 @@
             document.getElementById('mapViewBtn').classList.remove('text-red-600', 'border-b-2', 'border-red-600');
             document.getElementById('mapViewBtn').classList.add('text-gray-500');
         });
-        
-        document.getElementById('mapViewBtn').addEventListener('click', function() {
+    
+        document.getElementById('mapViewBtn').addEventListener('click', function () {
             document.getElementById('mapView').classList.remove('hidden');
             document.getElementById('listView').classList.add('hidden');
             this.classList.add('text-red-600', 'border-b-2', 'border-red-600');
             this.classList.remove('text-gray-500');
             document.getElementById('listViewBtn').classList.remove('text-red-600', 'border-b-2', 'border-red-600');
             document.getElementById('listViewBtn').classList.add('text-gray-500');
-            
+    
             // Initialize map if it hasn't been initialized yet
             if (!map) {
                 initMap();
+                markerLayer = L.layerGroup().addTo(map);
             }
         });
-        
+    
         // Initialize map
         function initMap() {
             map = L.map('map').setView([20, 0], 2);
-            
+    
             L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
                 attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
             }).addTo(map);
-            
-            // Create layer for markers
-            markersLayer = L.layerGroup().addTo(map);
-            
-            // Load countries GeoJSON
+    
+            markerLayer = L.layerGroup().addTo(map);
+    
             fetch('https://raw.githubusercontent.com/datasets/geo-countries/master/data/countries.geojson')
                 .then(response => response.json())
                 .then(data => {
-                    countriesLayer = L.geoJSON(data, {
-                        style: function(feature) {
-                            return {
-                                fillColor: '#f3f4f6',
-                                weight: 1,
-                                opacity: 1,
-                                color: '#d1d5db',
-                                fillOpacity: 0.7
-                            };
+                    const features = data.features || [];
+                    countriesLayer = L.geoJSON(features, {
+                        style: {
+                            fillColor: "#f3f4f6",
+                            weight: 1,
+                            color: "#d1d5db",
+                            fillOpacity: 0.7
                         },
-                        onEachFeature: function(feature, layer) {
-                            const countryName = feature.properties.ADMIN;
-                            layer.on({
-                                mouseover: function(e) {
-                                    layer.setStyle({
-                                        weight: 2,
-                                        color: '#9ca3af'
-                                    });
-                                },
-                                mouseout: function(e) {
-                                    if (countryName.toLowerCase() !== currentCountry) {
-                                        countriesLayer.resetStyle(layer);
-                                    }
-                                },
-                                click: function(e) {
-                                    document.getElementById('countrySearch').value = countryName;
-                                    searchApps(countryName);
-                                }
-                            });
-                            
-                            // Store country data for later use
-                            allCountriesData[countryName.toLowerCase()] = {
+                        onEachFeature: function (feature, layer) {
+                            const countryName = (feature.properties.name || feature.properties.ADMIN || "").toLowerCase();
+                            if (!countryName) return;
+    
+                            allCountriesData[countryName] = {
                                 layer: layer,
-                                feature: feature,
                                 center: layer.getBounds().getCenter()
                             };
+    
+                            layer.on({
+                                mouseover: function () {
+                                    layer.setStyle({ weight: 2, color: "#9ca3af" });
+                                },
+                                mouseout: function () {
+                                    countriesLayer.resetStyle(layer);
+                                }
+                            });
                         }
                     }).addTo(map);
-                }) .catch(error => console.error('Error loading GeoJSON:', error));
+                    geoJSONLoaded = true;
+                })
+                .catch(err => console.error("Error loading GeoJSON:", err));
         }
-         
-        // Calculate positions for multiple markers
-        function calculateMarkerPositions(center, count) {
-            const positions = [];
-            const radius = 0.5; // Offset from center in degrees
-            
-            if (count === 1) {
-                positions.push(center);
-            } else {
-                for (let i = 0; i < count; i++) {
-                    const angle = (i / count) * 2 * Math.PI;
-                    const x = center.lng + radius * Math.cos(angle);
-                    const y = center.lat + radius * Math.sin(angle);
-                    positions.push(L.latLng(y, x));
-                }
-            }
-            
-            return positions;
-        }
-        
+    
         // Debounce function
         function debounce(func, wait) {
             let timeout;
-            return function executedFunction(...args) {
-                const later = () => {
-                    clearTimeout(timeout);
-                    func(...args);
-                };
+            return function (...args) {
                 clearTimeout(timeout);
-                timeout = setTimeout(later, wait);
+                timeout = setTimeout(() => func(...args), wait);
             };
         }
-        
+    
         // Search function
-        document.getElementById('countrySearch').addEventListener('input', debounce(function(e) {
+        document.getElementById('countrySearch').addEventListener('input', debounce(function (e) {
             const country = e.target.value.trim();
             searchApps(country);
         }, 300));
-        
+    
         function searchApps(country) {
+            if (!geoJSONLoaded) {
+                setTimeout(() => searchApps(country), 500);
+                return;
+            }
             if (!country) {
                 hideResults();
                 resetMap();
                 return;
             }
-            
+    
             fetch(`/api/banned_apps/search/?country=${encodeURIComponent(country)}`)
                 .then(response => response.json())
                 .then(data => {
-                    if (data.apps.length === 0) {
+                    if (!data.apps || data.apps.length === 0) {
                         showNoResults();
-                        resetMap();
+                        highlightCountry(country, false);
                     } else {
                         showResults(data.apps);
-                        updateMap(data.apps);
+                        placeCountryMarker(country, data.apps);
+                        highlightCountry(country, true);
                     }
                 })
-                .catch(error => console.error('Error:', error));
+                .catch(err => console.error('Error:', err));
         }
-        
+    
+        // Highlight country 
+        function highlightCountry(country, hasApps) {
+            if (!map || !countriesLayer) return;
+            resetMap();
+    
+            const lower = country.toLowerCase();
+            const countryData = allCountriesData[lower];
+            if (!countryData) return;
+    
+            countryData.layer.setStyle({
+                fillColor: hasApps ? '#ef4444' : '#a1a1aa',
+                weight: 2,
+                color: hasApps ? '#b91c1c' : '#71717a',
+                fillOpacity: 0.8
+            });
+    
+            map.flyToBounds(countryData.layer.getBounds(), { duration: 1.2 });
+        }
+    
+        // Place marker
+        function placeCountryMarker(country, apps) {
+            if (!markerLayer) return;
+            markerLayer.clearLayers();
+    
+            const lower = country.toLowerCase();
+            const countryData = allCountriesData[lower];
+            if (!countryData) return;
+    
+            const center = countryData.center;
+            const count = apps.length;
+    
+            const displayCount = count;
+    
+            const markerHTML = `
+                <div style="position: relative; width: 42px; height: 42px;">
+                    <div style="width: 42px; height: 42px; border-radius: 50% 50% 50% 0; background: #dc2626; transform: rotate(-45deg); display: flex; align-items: center; justify-content: center; color: white; font-size: 16px; font-weight: 700; box-shadow: 0 0 10px rgba(0,0,0,0.25); animation: popIn 0.35s ease-out;">
+                        <div style="transform: rotate(45deg);">
+                            ${displayCount}
+                        </div>
+                    </div>
+                </div>`;
+    
+            const marker = L.marker(center, {
+                icon: L.divIcon({
+                    className: "map-pin-marker",
+                    html: markerHTML,
+                    iconSize: [42, 42],
+                    iconAnchor: [21, 42]
+                })
+            });
+    
+            marker.bindTooltip(
+                `${count} banned ${count === 1 ? "app" : "apps"}`,
+                { permanent: false, direction: "top", offset: [0, -5] }
+            );
+    
+            // Banned apps in map
+            marker.on("click", () => {
+                showCountryInfo(country, apps);
+            });
+    
+            markerLayer.addLayer(marker);
+        }
+    
         function showResults(apps) {
             const grid = document.getElementById('appsGrid');
             grid.innerHTML = '';
-            
+
             apps.forEach(app => {
-                const card = createAppCard(app);
+                const card = document.createElement('div');
+                card.className = 'bg-white rounded-lg shadow-md p-6 hover:shadow-lg transition-shadow';
+                card.innerHTML = `
+                    <h3 class="text-xl font-semibold mb-2 text-red-600">${app.app_name}</h3>
+                    <p class="text-sm text-gray-600 mb-2">${app.app_type}</p>
+                    <p class="text-gray-800 mb-4">${app.ban_reason}</p>
+                    <div class="text-sm text-gray-600">
+                        <p>Ban Date: ${new Date(app.ban_date).toLocaleDateString()}</p>
+                        ${app.source_url ? `<a href="${app.source_url}" target="_blank" class="text-red-600 hover:underline">Source →</a>` : ''}
+                    </div>`;
                 grid.appendChild(card);
             });
-            
+
             document.getElementById('resultsSection').classList.remove('hidden');
             document.getElementById('noResults').classList.add('hidden');
         }
-        
-        function createAppCard(app) {
-            const div = document.createElement('div');
-            div.className = 'bg-white rounded-lg shadow-md p-6 hover:shadow-lg transition-shadow';
-            
-            div.innerHTML = `
-                <h3 class="text-xl font-semibold mb-2 text-red-600">${app.app_name}</h3>
-                <p class="text-sm text-gray-600 mb-2">${app.app_type}</p>
-                <p class="text-gray-800 mb-4">${app.ban_reason}</p>
-                <div class="text-sm text-gray-600">
-                    <p>Ban Date: ${new Date(app.ban_date).toLocaleDateString()}</p>
-                    ${app.source_url ? `<a href="${app.source_url}" target="_blank" class="text-red-600 hover:underline">Source →</a>` : ''}
-                </div>
-            `;
-            
-            return div;
-        }
-        
-        function showNoResults() {
-            document.getElementById('resultsSection').classList.add('hidden');
-            document.getElementById('noResults').classList.remove('hidden');
-            document.getElementById('countryInfo').classList.add('hidden');
-        }
-        
-        function hideResults() {
-            document.getElementById('resultsSection').classList.add('hidden');
-            document.getElementById('noResults').classList.add('hidden');
-            document.getElementById('countryInfo').classList.add('hidden');
-        }
-        
-        function updateMap(apps) {
-            if (!map || !countriesLayer) return;
-            
-            resetMap();
-            
-            // Group apps by country
-            const appsByCountry = {};
-            apps.forEach(app => {
-                const country = app.country_name.toLowerCase();
-                if (!appsByCountry[country]) {
-                    appsByCountry[country] = [];
-                }
-                appsByCountry[country].push(app);
-            });
-            
-            // Highlight countries and add app markers
-            Object.keys(appsByCountry).forEach(country => {
-                if (allCountriesData[country]) {
-                    const countryData = allCountriesData[country];
-                    const layer = countryData.layer;
-                    
-                    // Highlight country
-                    layer.setStyle({
-                        fillColor: '#ef4444',
-                        weight: 2,
-                        color: '#b91c1c',
-                        fillOpacity: 0.7
-                    });
-                    currentCountry = country;
-                    
-                    // Add app markers
-                    const countryApps = appsByCountry[country];
-                    const center = countryData.center;
-                    
-                    // If more than 3 apps, show the apps count
-                    if (countryApps.length > 3) {
-                        const appCountMarker = L.marker(center, {
-                            icon: L.divIcon({
-                                className: 'app-count-marker',
-                                html: `<div class="flex items-center justify-center bg-red-600 text-white font-bold rounded-full w-10 h-10 shadow-lg" style="display: flex; align-items: center; justify-content: center; color: white; font-weight: bold; background-color: #dc2626; width: 40px; height: 40px; border-radius: 20px; box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);">${countryApps.length}</div>`,
-                                iconSize: [40, 40],
-                                iconAnchor: [20, 20]
-                            })
-                        });
-                        
-                        // Create popup with app names
-                        const appsList = countryApps.map(app => `<div class="py-1"><span class="font-semibold text-red-600">${app.app_name}</span> (${app.app_type})</div>`).join('');
-                        appCountMarker.bindPopup(`
-                            <div class="p-2">
-                                <h3 class="font-bold text-lg mb-2">${country.charAt(0).toUpperCase() + country.slice(1)}</h3>
-                                <p class="mb-2 text-sm text-red-600">${countryApps.length} Banned Apps</p>
-                                <div class="max-h-40 overflow-y-auto">
-                                    ${appsList}
-                                </div>
-                            </div>
-                        `, { maxWidth: 300 });
-                        
-                        markersLayer.addLayer(appCountMarker);
-                    }
-                    // If 3 or fewer apps, show individual app markers
-                    else {
-                        // Calculate positions around the center
-                        const positions = calculateMarkerPositions(center, countryApps.length);
-                        
-                        countryApps.forEach((app, index) => {
-                            const appMarker = L.marker(positions[index], {
-                                icon: L.divIcon({
-                                    className: 'app-marker',
-                                    html: `<div class="flex items-center justify-center bg-red-600 text-white font-bold rounded-full w-8 h-8 shadow-lg" style="display: flex; align-items: center; justify-content: center; color: white; font-weight: bold; background-color: #dc2626; width: 32px; height: 32px; border-radius: 16px; box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);">${app.app_name.charAt(0)}</div>`,
-                                    iconSize: [32, 32],
-                                    iconAnchor: [16, 16]
-                                })
-                            });
-                            
-                            // Create popup with app details
-                            appMarker.bindPopup(`
-                                <div class="p-2">
-                                    <h3 class="font-bold text-red-600">${app.app_name}</h3>
-                                    <p class="text-sm text-gray-600">${app.app_type}</p>
-                                    <p class="text-sm mt-2">${app.ban_reason}</p>
-                                    <p class="text-xs mt-2">Ban Date: ${new Date(app.ban_date).toLocaleDateString()}</p>
-                                </div>
-                            `, { maxWidth: 300 });
-                            
-                            markersLayer.addLayer(appMarker);
-                        });
-                    }
-                }
-            });
-            
-            // Show country info in the side panel
-            const countries = Object.keys(appsByCountry);
-            if (countries.length === 1) {
-                showCountryInfo(countries[0], appsByCountry[countries[0]]);
-            }
-        }
-        
+    
         function showCountryInfo(country, apps) {
             const countryInfoDiv = document.getElementById('countryInfo');
-            const countryNameDiv = document.getElementById('countryName');
-            const bannedAppsCountDiv = document.getElementById('bannedAppsCount');
-            const bannedAppsListDiv = document.getElementById('bannedAppsList');
             
             // Update country name
-            countryNameDiv.textContent = country.charAt(0).toUpperCase() + country.slice(1);
-            
+            document.getElementById('countryName').textContent = country.charAt(0).toUpperCase() + country.slice(1);
+           
             // Update banned apps count
-            bannedAppsCountDiv.textContent = `${apps.length} Banned Apps`;
+            document.getElementById('bannedAppsCount').textContent = `${apps.length} Banned Apps`;
             
             // Update banned apps list
-            bannedAppsListDiv.innerHTML = apps.map(app => `
+            document.getElementById('bannedAppsList').innerHTML = apps.map(app => `
                 <div class="py-2 border-b border-gray-200">
                     <h4 class="font-semibold text-red-600">${app.app_name}</h4>
                     <p class="text-sm text-gray-600">${app.app_type}</p>
@@ -361,29 +277,35 @@
                     <p class="text-xs mt-1">Ban Date: ${new Date(app.ban_date).toLocaleDateString()}</p>
                 </div>
             `).join('');
-            
+
             // Show the country info section
             countryInfoDiv.classList.remove('hidden');
         }
-        
+    
+        function showNoResults() {
+            document.getElementById('resultsSection').classList.add('hidden');
+            document.getElementById('noResults').classList.remove('hidden');
+            document.getElementById('countryInfo').classList.add('hidden');
+        }
+    
+        function hideResults() {
+            document.getElementById('resultsSection').classList.add('hidden');
+            document.getElementById('noResults').classList.add('hidden');
+            document.getElementById('countryInfo').classList.add('hidden');
+        }
+    
         function resetMap() {
-            if (!map || !countriesLayer || !markersLayer) return;
+            if (!map || !countriesLayer) return;
             
             // Reset country styles
             countriesLayer.eachLayer(layer => {
                 countriesLayer.resetStyle(layer);
             });
-            
-            // Clear markers
-            markersLayer.clearLayers();
-            
-            // Reset current country
-            currentCountry = '';
-            
+
             // Hide country info
             document.getElementById('countryInfo').classList.add('hidden');
         }
-        
+    
         // Initialization
         document.addEventListener('DOMContentLoaded', function() {
             // Set default view to List View

--- a/website/templates/banned_apps.html
+++ b/website/templates/banned_apps.html
@@ -269,54 +269,29 @@
             
             return div;
         }
-                
+
         function showCountryInfo(country, apps) {
             const countryInfoDiv = document.getElementById('countryInfo');
-
-            const countryData = allCountriesData[country.toLowerCase()];
-            const properName = countryData?.feature?.properties?.name || country;
-            document.getElementById('countryName').textContent = properName;
-
-            // Update banned apps count
-            document.getElementById('bannedAppsCount').textContent = `${apps.length} Banned Apps`;
-
-            // Update banned apps list 
-            const appsList = document.getElementById('bannedAppsList');
+            const countryNameDiv = document.getElementById('countryName');
+            const bannedAppsCountDiv = document.getElementById('bannedAppsCount');
+            const bannedAppsListDiv = document.getElementById('bannedAppsList');
             
-            while (appsList.firstChild) appsList.removeChild(appsList.firstChild);
-
-            apps.forEach(app => {
-                const appDiv = document.createElement('div');
-                appDiv.className = 'py-2 border-b border-gray-200';
-
-                const name = document.createElement('h4');
-                name.className = 'font-semibold text-red-600';
-                name.textContent = app.app_name || '';
-
-                const type = document.createElement('p');
-                type.className = 'text-sm text-gray-600';
-                type.textContent = app.app_type || '';
-
-                const reason = document.createElement('p');
-                reason.className = 'text-sm mt-1';
-                reason.textContent = app.ban_reason || '';
-
-                const date = document.createElement('p');
-                date.className = 'text-xs mt-1';
-                try {
-                    date.textContent = `Ban Date: ${new Date(app.ban_date).toLocaleDateString()}`;
-                } catch (e) {
-                    date.textContent = `Ban Date: ${app.ban_date || 'N/A'}`;
-                }
-
-                appDiv.appendChild(name);
-                appDiv.appendChild(type);
-                appDiv.appendChild(reason);
-                appDiv.appendChild(date);
-
-                appsList.appendChild(appDiv);
-            });
-
+            // Update country name
+            countryNameDiv.textContent = country.charAt(0).toUpperCase() + country.slice(1);
+            
+            // Update banned apps count
+            bannedAppsCountDiv.textContent = `${apps.length} Banned Apps`;
+            
+            // Update banned apps list
+            bannedAppsListDiv.innerHTML = apps.map(app => `
+                <div class="py-2 border-b border-gray-200">
+                    <h4 class="font-semibold text-red-600">${app.app_name}</h4>
+                    <p class="text-sm text-gray-600">${app.app_type}</p>
+                    <p class="text-sm mt-1">${app.ban_reason}</p>
+                    <p class="text-xs mt-1">Ban Date: ${new Date(app.ban_date).toLocaleDateString()}</p>
+                </div>
+            `).join('');
+            
             // Show the country info section
             countryInfoDiv.classList.remove('hidden');
         }

--- a/website/templates/banned_apps.html
+++ b/website/templates/banned_apps.html
@@ -63,7 +63,7 @@
         let geoJSONLoaded = false;
         
         // Initialize tabs
-        document.getElementById('listViewBtn').addEventListener('click', function () {
+        document.getElementById('listViewBtn').addEventListener('click', function() {
             document.getElementById('listView').classList.remove('hidden');
             document.getElementById('mapView').classList.add('hidden');
             this.classList.add('text-red-600', 'border-b-2', 'border-red-600');
@@ -72,7 +72,7 @@
             document.getElementById('mapViewBtn').classList.add('text-gray-500');
         });
         
-        document.getElementById('mapViewBtn').addEventListener('click', function () {
+        document.getElementById('mapViewBtn').addEventListener('click', function() {
             document.getElementById('mapView').classList.remove('hidden');
             document.getElementById('listView').classList.add('hidden');
             this.classList.add('text-red-600', 'border-b-2', 'border-red-600');
@@ -93,9 +93,11 @@
             L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
                 attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
             }).addTo(map);
-            
+
+            // Create layer for markers
             markerLayer = L.layerGroup().addTo(map);
-            
+
+            // Load countries GeoJSON
             fetch('https://raw.githubusercontent.com/datasets/geo-countries/master/data/countries.geojson')
                 .then(response => response.json())
                 .then(data => {
@@ -111,7 +113,7 @@
                             const countryName = (feature.properties.name || feature.properties.ADMIN || "").toLowerCase();
                             if (!countryName) return;
                             
-                            // store lowercase key for consistent lookup
+                            // Store country data for later use
                             allCountriesData[countryName.toLowerCase()] = {
                                 layer: layer,
                                 center: layer.getBounds().getCenter(),
@@ -145,7 +147,7 @@
         }
         
         // Search function
-        document.getElementById('countrySearch').addEventListener('input', debounce(function (e) {
+        document.getElementById('countrySearch').addEventListener('input', debounce(function(e) {
             const country = e.target.value.trim();
             searchApps(country);
         }, 300));
@@ -373,5 +375,6 @@
             // Set default view to List View
             document.getElementById('listViewBtn').click();
         });
+        
     </script>
 {% endblock %}


### PR DESCRIPTION
Fixes #4792 
This PR resolves the issue where the map in banned_apps.html did not zoom, pan, or highlight a country when searched.

Improvements ->
1.Automatically zooms to the selected country’s boundary on search
2.Highlights:
-Red → Countries with banned apps
-Grey → Countries with no banned apps
3.Displays a marker showing all banned apps for the selected country

After - 

https://github.com/user-attachments/assets/07aad4b4-ee38-42c0-92f3-31eabd3f78a9



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive single markers per country with banned-app count badges and click-to-open country info.
  * Country highlighting and map fly-to when searching or selecting a country.
  * Inline result cards and updated country info panel (name, count, list).
  * Clear/reset map and no-results state handling.

* **Bug Fixes**
  * Search now waits for map data to finish loading before executing.

* **Style**
  * Streamlined map and results UI for simpler, quicker interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->