### PR TITLE
Revert "Fix ImproperlyConfigured Error on Hunt Creation by Adding Success URL"

### DIFF
--- a/website/views/organization.py
+++ b/website/views/organization.py
@@ -985,9 +985,6 @@ class HuntCreate(CreateView):
 
         self.object.save()
         return super(HuntCreate, self).form_valid(form)
-        
-    def get_success_url(self):
-        return reverse('organization_dashboard_hunt_detail', kwargs={'pk': self.object.pk})
 
     def get_success_url(self):
         try:


### PR DESCRIPTION
Reverts OWASP-BLT/BLT#4244

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed post-hunt creation navigation flow. After creating a hunt, users are now redirected to their organization's detail page instead of the newly created hunt's detail page. The system intelligently uses the hunt's organization association when available and provides a fallback to the organizations listing page, ensuring smoother navigation and improved experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->