### PR TITLE
feat: Add recently registered organizations to registration page

### DIFF
--- a/website/models.py
+++ b/website/models.py
@@ -225,6 +225,11 @@ class Organization(models.Model):
     def __str__(self):
         return self.name
 
+    def get_absolute_url(self):
+        from django.urls import reverse
+
+        return reverse("organization_detail", kwargs={"slug": self.slug})
+
     def save(self, *args, **kwargs):
         if not self.slug:
             # Generate initial slug from name

--- a/website/models.py
+++ b/website/models.py
@@ -226,8 +226,6 @@ class Organization(models.Model):
         return self.name
 
     def get_absolute_url(self):
-        from django.urls import reverse
-
         return reverse("organization_detail", kwargs={"slug": self.slug})
 
     def save(self, *args, **kwargs):

--- a/website/templates/organization/register_organization.html
+++ b/website/templates/organization/register_organization.html
@@ -225,41 +225,44 @@
             </div>
         </div>
         {% if recent_organizations %}
-            <div class="mt-8">
-                <h3 class="text-lg font-medium leading-6 text-gray-900">Recently Registered Organizations</h3>
-                <p class="mt-1 text-sm text-gray-600">Check out the latest organizations that have joined our platform.</p>
-                <ul role="list"
-                    class="mt-3 grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">
-                    {% for org in recent_organizations %}
-                        <li class="col-span-1 flex rounded-md shadow-sm">
-                            <div class="flex-shrink-0 flex items-center justify-center w-16 h-16 bg-gray-200 rounded-l-md overflow-hidden">
-                                {% if org.logo %}
-                                    <img src="{{ org.logo.url }}"
-                                         alt="{{ org.name }} logo"
-                                         width="64"
-                                         height="64"
-                                         class="h-full w-full object-cover">
-                                {% else %}
-                                    <svg class="h-8 w-8 text-gray-600"
-                                         xmlns="http://www.w3.org/2000/svg"
-                                         fill="none"
-                                         viewBox="0 0 24 24"
-                                         stroke-width="1.5"
-                                         stroke="currentColor">
-                                        <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 21h16.5M4.5 3h15M5.25 3v18m13.5-18v18M8.25 6h7.5m-7.5 3h7.5m-7.5 3h7.5m-7.5 3h7.5m-7.5 3h7.5" />
-                                    </svg>
-                                {% endif %}
-                            </div>
-                            <div class="flex flex-1 items-center justify-between truncate rounded-r-md border-b border-r border-t border-gray-200 bg-white">
-                                <div class="flex-1 truncate px-4 py-2 text-sm">
+            <div class="mt-16 mb-12">
+                <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+                    <div class="text-center mb-8">
+                        <h3 class="text-2xl font-semibold text-gray-900 dark:text-gray-100">Recently Registered Organizations</h3>
+                        <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">
+                            Check out the latest organizations that have joined our platform.
+                        </p>
+                    </div>
+                    <div class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3 max-w-5xl mx-auto">
+                        {% for org in recent_organizations %}
+                            <div class="flex items-center bg-gray-50 dark:bg-gray-800 rounded-lg p-4 hover:shadow-md transition-shadow">
+                                <div class="flex-shrink-0 flex items-center justify-center w-16 h-16 bg-gray-200 dark:bg-gray-700 rounded-lg">
+                                    {% if org.logo %}
+                                        <img src="{{ org.logo.url }}"
+                                             alt="{{ org.name }} logo"
+                                             width="64"
+                                             height="64"
+                                             class="h-full w-full object-cover rounded-lg">
+                                    {% else %}
+                                        <svg class="h-8 w-8 text-gray-500 dark:text-gray-400"
+                                             xmlns="http://www.w3.org/2000/svg"
+                                             fill="none"
+                                             viewBox="0 0 24 24"
+                                             stroke-width="1.5"
+                                             stroke="currentColor">
+                                            <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 21h16.5M4.5 3h15M5.25 3v18m13.5-18v18M8.25 6h7.5m-7.5 3h7.5m-7.5 3h7.5m-7.5 3h7.5m-7.5 3h7.5" />
+                                        </svg>
+                                    {% endif %}
+                                </div>
+                                <div class="ml-4 flex-1 min-w-0">
                                     <a href="{{ org.get_absolute_url }}"
-                                       class="font-medium text-gray-900 hover:text-gray-600">{{ org.name }}</a>
-                                    <p class="text-gray-500">{{ org.created|timesince }} ago</p>
+                                       class="text-base font-medium text-gray-900 dark:text-gray-100 hover:text-[#e74c3c] dark:hover:text-[#e74c3c] transition-colors truncate block">{{ org.name }}</a>
+                                    <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">{{ org.created|timesince }} ago</p>
                                 </div>
                             </div>
-                        </li>
-                    {% endfor %}
-                </ul>
+                        {% endfor %}
+                    </div>
+                </div>
             </div>
         {% endif %}
         <!-- Notification Messages -->

--- a/website/templates/organization/register_organization.html
+++ b/website/templates/organization/register_organization.html
@@ -224,6 +224,44 @@
                 </form>
             </div>
         </div>
+        {% if recent_organizations %}
+            <div class="mt-8">
+                <h3 class="text-lg font-medium leading-6 text-gray-900">Recently Registered Organizations</h3>
+                <p class="mt-1 text-sm text-gray-600">Check out the latest organizations that have joined our platform.</p>
+                <ul role="list"
+                    class="mt-3 grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">
+                    {% for org in recent_organizations %}
+                        <li class="col-span-1 flex rounded-md shadow-sm">
+                            <div class="flex-shrink-0 flex items-center justify-center w-16 h-16 bg-gray-200 rounded-l-md overflow-hidden">
+                                {% if org.logo %}
+                                    <img src="{{ org.logo.url }}"
+                                         alt="{{ org.name }} logo"
+                                         width="64"
+                                         height="64"
+                                         class="h-full w-full object-cover">
+                                {% else %}
+                                    <svg class="h-8 w-8 text-gray-600"
+                                         xmlns="http://www.w3.org/2000/svg"
+                                         fill="none"
+                                         viewBox="0 0 24 24"
+                                         stroke-width="1.5"
+                                         stroke="currentColor">
+                                        <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 21h16.5M4.5 3h15M5.25 3v18m13.5-18v18M8.25 6h7.5m-7.5 3h7.5m-7.5 3h7.5m-7.5 3h7.5m-7.5 3h7.5" />
+                                    </svg>
+                                {% endif %}
+                            </div>
+                            <div class="flex flex-1 items-center justify-between truncate rounded-r-md border-b border-r border-t border-gray-200 bg-white">
+                                <div class="flex-1 truncate px-4 py-2 text-sm">
+                                    <a href="{{ org.get_absolute_url }}"
+                                       class="font-medium text-gray-900 hover:text-gray-600">{{ org.name }}</a>
+                                    <p class="text-gray-500">{{ org.created|timesince }} ago</p>
+                                </div>
+                            </div>
+                        </li>
+                    {% endfor %}
+                </ul>
+            </div>
+        {% endif %}
         <!-- Notification Messages -->
         {% if messages %}
             <div id="notification-container"

--- a/website/views/company.py
+++ b/website/views/company.py
@@ -133,7 +133,9 @@ def dashboard_view(request, *args, **kwargs):
 
 class RegisterOrganizationView(View):
     def get(self, request, *args, **kwargs):
-        return render(request, "organization/register_organization.html")
+        recent_organizations = Organization.objects.filter(is_active=True).order_by("-created")[:5]
+        context = {"recent_organizations": recent_organizations}
+        return render(request, "organization/register_organization.html", context)
 
     def post(self, request, *args, **kwargs):
         user = request.user


### PR DESCRIPTION
## Overview
This PR adds a section to display the five most recently registered organizations on the organization registration page.

Closes #4802

## Changes Made

### 1. Model Update (`models.py`)
- Added `get_absolute_url()` to `Organization` for generating detail-page URLs via `reverse()`.

### 2. View Logic (`company.py`)
- Updated `RegisterOrganizationView.get()` to query the five most recently created active organizations.
- Ordered by creation date (descending).
- Added `recent_organizations` to the template context.

### 3. Template Update (`register_organization.html`)
- Added a "Recently Registered Organizations" section below the registration form.
- Implemented a responsive Tailwind grid (1 column mobile, 2 tablet, 3 desktop).
- For each organization, displays:
  - Logo or fallback icon
  - Name linked to detail page
  - Relative creation timestamp
- Section only renders when results exist.

## Tests
- Passes all pre-commit checks (Black, isort, ruff, djLint).
- No merge conflicts.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Organizations now have dedicated public URLs that can be shared and linked.
  * The organization registration page now shows a "Recently Registered Organizations" responsive grid with logos (or default icons), names, and relative registration timestamps to help discovery.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->