### PR TITLE
Pre-commit workflow fix

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -34,8 +34,6 @@ env:
 # Default permissions for the workflow
 permissions:
   contents: read
-  pull-requests: write
-  issues: write
 
 concurrency:
   cancel-in-progress: true
@@ -276,10 +274,7 @@ jobs:
     needs: setup
     runs-on: ubuntu-latest
     permissions:
-      issues: write
-      pull-requests: write
-      contents: write
-      actions: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -298,6 +293,8 @@ jobs:
 
   docker-test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -31,6 +31,12 @@ env:
   FORCE_COLOR: 1
   POETRY_CACHE_DIR: ~/.cache/pypoetry
 
+# Default permissions for the workflow
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
 concurrency:
   cancel-in-progress: true
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -80,8 +86,9 @@ jobs:
 
   pre-commit:
     name: Run pre-commit
-    # Run on pull_request_target (for forked PRs with write permissions), pull_request (for same-repo PRs),
-    # push to main, or manual trigger. The concurrency group prevents duplicate runs.
+    # Only run on pull_request_target (for write permissions to comment/label), push to main, or manual trigger
+    # This prevents duplicate runs and ensures we have permissions for forked PRs
+    if: github.event_name != 'pull_request'
     needs: setup
     runs-on: ubuntu-latest
     permissions: 
@@ -111,7 +118,7 @@ jobs:
           set -e
         continue-on-error: true
       - name: Comment on PR if pre-commit fails
-        if: (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && steps.pre-commit.outputs.exit_code != '0'
+        if: github.event_name == 'pull_request_target' && steps.pre-commit.outputs.exit_code != '0'
         uses: actions/github-script@v7
         with:
           script: |
@@ -157,17 +164,24 @@ jobs:
             
             For more information, see the [pre-commit documentation](https://pre-commit.com/).`;
             
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body: message
-            });
+            try {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: message
+              });
+            } catch (error) {
+              if (error.status === 403) {
+                core.warning('Permission denied: Cannot comment on PR. Repository may need to enable "Allow GitHub Actions to create and approve pull requests" in Settings > Actions > General.');
+              } else {
+                throw error;
+              }
+            }
       - name: Add pre-commit status label
-        if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
+        if: github.event_name == 'pull_request_target'
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;
@@ -230,13 +244,21 @@ jobs:
             
             // Add the label if it isn't already present
             if (!currentNames.has(newLabel)) {
-              await github.rest.issues.addLabels({ 
-                owner, 
-                repo, 
-                issue_number: pull_number, 
-                labels: [newLabel] 
-              });
-              core.info(`Applied label ${newLabel} to PR #${pull_number}`);
+              try {
+                await github.rest.issues.addLabels({ 
+                  owner, 
+                  repo, 
+                  issue_number: pull_number, 
+                  labels: [newLabel] 
+                });
+                core.info(`Applied label ${newLabel} to PR #${pull_number}`);
+              } catch (error) {
+                if (error.status === 403) {
+                  core.warning(`Permission denied: Cannot add label to PR. Repository may need to enable "Allow GitHub Actions to create and approve pull requests" in Settings > Actions > General.`);
+                } else {
+                  throw error;
+                }
+              }
             } else {
               core.info(`Label ${newLabel} already present on PR #${pull_number}`);
             }


### PR DESCRIPTION
Fixes #4914

Splits workflow process as per read to pull_requests with read only permissions and pull_request_target for write permissions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Refined CI/CD workflow permissions to limit write scopes and add explicit read permissions where needed.
  * Adjusted job triggers to avoid redundant runs on standard pull requests and favor safer execution contexts.
  * Removed use of repository token in automation steps and simplified status labeling to specific run types.
  * Improved fork-aware handling and clarified comments around CI behavior while preserving concurrency and output reporting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->