### PR TITLE
Fix dark mode toggle button and add animation

### DIFF
--- a/website/templates/dark_mode_toggle.html
+++ b/website/templates/dark_mode_toggle.html
@@ -1,6 +1,8 @@
 <button id="theme-toggle"
         class="relative inline-flex items-center justify-center p-2 text-[#e74c3c] dark:text-[#e74c3c] border-2 border-[#e74c3c] dark:border-[#e74c3c] rounded-lg hover:bg-[#e74c3c] dark:hover:bg-red-600 hover:text-white dark:hover:text-white w-10 h-10 transition-colors"
         aria-label="Toggle dark mode">
-    <i id="sun-icon" class="fas fa-sun text-xl absolute dark:hidden"></i>
-    <i id="moon-icon" class="fas fa-moon text-xl absolute hidden dark:block"></i>
+    <i id="sun-icon"
+       class="fas fa-sun text-xl absolute transition-all duration-300 ease-in-out opacity-0 -rotate-90 dark:opacity-100 dark:rotate-0"></i>
+    <i id="moon-icon"
+       class="fas fa-moon text-xl absolute transition-all duration-300 ease-in-out opacity-100 rotate-0 dark:opacity-0 dark:rotate-90"></i>
 </button>


### PR DESCRIPTION
Fixes the dark mode toggle button where both icons were visible in light mode and adds a smooth transition animation.

---before---

https://github.com/user-attachments/assets/694c6f64-c112-49ca-a7db-ff8aa190aa46

---after---


https://github.com/user-attachments/assets/54b658cd-3a97-4d1b-9841-0529abe71463



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved dark mode toggle with smooth CSS transitions. Sun and moon icons now smoothly animate using opacity and rotation effects instead of abrupt visibility changes, providing a more polished interaction experience when switching between dark and light modes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->