### PR TITLE
Fix: Leaderboard Sidebar Dark Mode Background

### DIFF
--- a/website/templates/hackathons/detail.html
+++ b/website/templates/hackathons/detail.html
@@ -266,7 +266,7 @@
                     {% if leaderboard %}
                         <div class="space-y-6">
                             {% for entry in leaderboard %}
-                                <div class="p-4 {% if forloop.counter <= 3 %}bg-gray-50{% endif %} rounded-lg border border-gray-200 dark:border-gray-700">
+                                <div class="p-4 {% if forloop.counter <= 3 %}bg-gray-50 dark:bg-gray-700 {% endif %} rounded-lg border border-gray-200 dark:border-gray-700">
                                     <div class="flex items-center mb-3">
                                         <div class="w-8 h-8 flex items-center justify-center mr-3 {% if forloop.counter == 1 %}bg-yellow-100 text-yellow-600{% elif forloop.counter == 2 %}bg-gray-100 text-gray-600{% elif forloop.counter == 3 %}bg-amber-100 text-amber-600{% else %}bg-gray-100 text-gray-500{% endif %} rounded-full font-bold">
                                             {{ forloop.counter }}


### PR DESCRIPTION
fixes: #4913 

## What I Changed

Updated the leaderboard sidebar card styles so the background matches dark mode.

Removed the light background that was breaking the dark theme UI.

## Why
Card was staying light in dark mode → looked ugly + inconsistent with the rest of the page.

## Screenshot / Proof

<img width="1465" height="798" alt="2025-11-20_21-33-32" src="https://github.com/user-attachments/assets/629669d7-c27c-401c-82b7-bdf251da8b51" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced dark mode appearance for the top 3 leaderboard positions on the hackathons detail page.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->