### PR TITLE
Revert "Add clickable button badges to pre-commit failure comments"

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -126,35 +126,9 @@ jobs:
             const last100Lines = lines.slice(-100).join('\n');
             const truncated = lines.length > 100;
             
-            // Build dynamic URLs for buttons
-            const prNumber = context.issue.number;
-            const addLabelUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/issues/${prNumber}/labels`;
-            const workflowUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/workflows/pre-commit-fix.yaml`;
-            
-            // Build shield.io badge URLs for button appearance
-            const labelBadge = 'https://img.shields.io/badge/Add_Label-fix--pre--commit-blue?style=for-the-badge&logo=github';
-            const workflowBadge = 'https://img.shields.io/badge/Run_Workflow-Pre--commit_Fix-green?style=for-the-badge&logo=github-actions';
-            
             const message = `## ❌ Pre-commit checks failed
             
-            The pre-commit hooks found issues that need to be fixed. 
-            
-            ### 🤖 **Automatic Fix Options**
-            
-            You can automatically fix most issues by using one of these methods:
-            
-            | Action | Button |
-            |--------|--------|
-            | **Add the \`fix-pre-commit\` label** to trigger automatic fixes | [![Add Label](${labelBadge})](${addLabelUrl}) |
-            | **Run the pre-commit fix workflow** manually | [![Run Workflow](${workflowBadge})](${workflowUrl}) |
-            
-            > **How to use:**
-            > - Click the **Add Label** button → Add \`fix-pre-commit\` label → Workflow runs automatically
-            > - Or click **Run Workflow** → Click "Run workflow" dropdown → Select this PR's branch
-            
-            ### 💻 **Manual Fix (Local)**
-            
-            Alternatively, you can run the following commands locally to fix them:
+            The pre-commit hooks found issues that need to be fixed. Please run the following commands locally to fix them:
             
             \`\`\`bash
             # Install pre-commit if you haven't already


### PR DESCRIPTION
Reverts OWASP-BLT/BLT#5039

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified CI/CD workflow feedback by replacing interactive PR buttons with streamlined text-based instructions for resolving pre-commit issues locally, while retaining pre-commit output visibility for reference.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->