### PR TITLE
feat: Add GitHub integration fields to Issue model

### DIFF
--- a/website/migrations/0260_add_github_fields_to_issue.py
+++ b/website/migrations/0260_add_github_fields_to_issue.py
@@ -12,7 +12,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name="issue",
             name="github_comment_count",
-            field=models.IntegerField(default=0, help_text="Number of comments on the GitHub issue"),
+            field=models.PositiveIntegerField(default=0, help_text="Number of comments on the GitHub issue"),
         ),
         migrations.AddField(
             model_name="issue",

--- a/website/migrations/0260_add_github_fields_to_issue.py
+++ b/website/migrations/0260_add_github_fields_to_issue.py
@@ -1,0 +1,33 @@
+# Generated migration for adding GitHub integration fields to Issue model
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("website", "0259_add_domain_slug"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="issue",
+            name="github_comment_count",
+            field=models.IntegerField(default=0, help_text="Number of comments on the GitHub issue"),
+        ),
+        migrations.AddField(
+            model_name="issue",
+            name="github_state",
+            field=models.CharField(
+                blank=True,
+                choices=[("open", "Open"), ("closed", "Closed")],
+                help_text="Current state of the GitHub issue",
+                max_length=10,
+                null=True,
+            ),
+        ),
+        migrations.AddField(
+            model_name="issue",
+            name="github_fetch_status",
+            field=models.BooleanField(default=False, help_text="Whether GitHub data was successfully fetched"),
+        ),
+    ]

--- a/website/migrations/0260_add_github_fields_to_issue.py
+++ b/website/migrations/0260_add_github_fields_to_issue.py
@@ -5,7 +5,7 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
     dependencies = [
-        ("website", "0259_add_domain_slug"),
+        ("website", "0258_add_slackchannel_model"),
     ]
 
     operations = [
@@ -19,15 +19,27 @@ class Migration(migrations.Migration):
             name="github_state",
             field=models.CharField(
                 blank=True,
+                default="",
                 choices=[("open", "Open"), ("closed", "Closed")],
-                help_text="Current state of the GitHub issue",
+                help_text="Current state of the GitHub issue (open/closed) as reported by GitHub API",
                 max_length=10,
-                null=True,
             ),
         ),
         migrations.AddField(
             model_name="issue",
             name="github_fetch_status",
-            field=models.BooleanField(default=False, help_text="Whether GitHub data was successfully fetched"),
+            field=models.BooleanField(
+                default=False,
+                help_text="Whether GitHub data was successfully fetched from the API",
+            ),
+        ),
+        migrations.AddField(
+            model_name="issue",
+            name="github_last_fetched_at",
+            field=models.DateTimeField(
+                blank=True,
+                help_text="Timestamp of when GitHub data was last fetched",
+                null=True,
+            ),
         ),
     ]

--- a/website/models.py
+++ b/website/models.py
@@ -630,10 +630,15 @@ class Issue(models.Model):
         max_length=10,
         choices=GITHUB_STATE_CHOICES,
         blank=True,
-        null=True,
-        help_text="Current state of the GitHub issue",
+        default="",
+        help_text="Current state of the GitHub issue (open/closed) as reported by GitHub API",
     )
-    github_fetch_status = models.BooleanField(default=False, help_text="Whether GitHub data was successfully fetched")
+    github_fetch_status = models.BooleanField(
+        default=False, help_text="Whether GitHub data was successfully fetched from the API"
+    )
+    github_last_fetched_at = models.DateTimeField(
+        null=True, blank=True, help_text="Timestamp of when GitHub data was last fetched"
+    )
     created = models.DateTimeField(auto_now_add=True)
     modified = models.DateTimeField(auto_now=True)
     is_hidden = models.BooleanField(default=False)

--- a/website/models.py
+++ b/website/models.py
@@ -625,7 +625,7 @@ class Issue(models.Model):
     closed_by = models.ForeignKey(User, null=True, blank=True, related_name="closed_by", on_delete=models.CASCADE)
     closed_date = models.DateTimeField(default=None, null=True, blank=True)
     github_url = models.URLField(default="", null=True, blank=True)
-    github_comment_count = models.IntegerField(default=0, help_text="Number of comments on the GitHub issue")
+    github_comment_count = models.PositiveIntegerField(default=0, help_text="Number of comments on the GitHub issue")
     github_state = models.CharField(
         max_length=10,
         choices=GITHUB_STATE_CHOICES,

--- a/website/models.py
+++ b/website/models.py
@@ -587,6 +587,13 @@ class HuntPrize(models.Model):
         return self.hunt.name + self.name
 
 
+# GitHub state choices for Issue model
+GITHUB_STATE_CHOICES = (
+    ("open", "Open"),
+    ("closed", "Closed"),
+)
+
+
 class Issue(models.Model):
     labels = (
         (0, "General"),
@@ -618,6 +625,15 @@ class Issue(models.Model):
     closed_by = models.ForeignKey(User, null=True, blank=True, related_name="closed_by", on_delete=models.CASCADE)
     closed_date = models.DateTimeField(default=None, null=True, blank=True)
     github_url = models.URLField(default="", null=True, blank=True)
+    github_comment_count = models.IntegerField(default=0, help_text="Number of comments on the GitHub issue")
+    github_state = models.CharField(
+        max_length=10,
+        choices=GITHUB_STATE_CHOICES,
+        blank=True,
+        null=True,
+        help_text="Current state of the GitHub issue",
+    )
+    github_fetch_status = models.BooleanField(default=False, help_text="Whether GitHub data was successfully fetched")
     created = models.DateTimeField(auto_now_add=True)
     modified = models.DateTimeField(auto_now=True)
     is_hidden = models.BooleanField(default=False)

--- a/website/templates/includes/_bug.html
+++ b/website/templates/includes/_bug.html
@@ -122,6 +122,81 @@
            class="mt-1 ml-1 text-sm text-gray-500 dark:text-gray-500 hover:text-[#e74c3c] transition-colors break-all inline-block">
             {{ bug.url|truncatechars:60 }}
         </a>
+        <!-- GitHub Information -->
+        {% if bug.github_url %}
+            <div class="mt-3 pt-3 border-t border-gray-100 dark:border-gray-700">
+                <div class="flex flex-wrap items-center gap-3">
+                    <!-- GitHub Link -->
+                    <a href="{{ bug.github_url }}"
+                       target="_blank"
+                       rel="noopener noreferrer"
+                       class="inline-flex items-center gap-2 px-3 py-1.5 text-sm font-medium text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors">
+                        <svg class="w-4 h-4"
+                             fill="currentColor"
+                             viewBox="0 0 24 24"
+                             aria-hidden="true">
+                            <path fill-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clip-rule="evenodd">
+                            </path>
+                        </svg>
+                        <span>View on GitHub</span>
+                    </a>
+                    <!-- GitHub State Badge -->
+                    {% if bug.github_fetch_status %}
+                        {% if bug.github_state == "open" %}
+                            <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium bg-green-100 dark:bg-green-900 text-green-800 dark:text-green-100 border border-green-200 dark:border-green-700">
+                                <svg class="w-3 h-3"
+                                     fill="currentColor"
+                                     viewBox="0 0 16 16"
+                                     aria-hidden="true">
+                                    <path d="M8 9.5a1.5 1.5 0 100-3 1.5 1.5 0 000 3z"></path>
+                                    <path fill-rule="evenodd" d="M8 0a8 8 0 100 16A8 8 0 008 0zM1.5 8a6.5 6.5 0 1113 0 6.5 6.5 0 01-13 0z"></path>
+                                </svg>
+                                Open
+                            </span>
+                        {% elif bug.github_state == "closed" %}
+                            <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium bg-purple-100 dark:bg-purple-900 text-purple-800 dark:text-purple-100 border border-purple-200 dark:border-purple-700">
+                                <svg class="w-3 h-3"
+                                     fill="currentColor"
+                                     viewBox="0 0 16 16"
+                                     aria-hidden="true">
+                                    <path fill-rule="evenodd" d="M11.28 6.78a.75.75 0 00-1.06-1.06L7.25 8.69 5.78 7.22a.75.75 0 00-1.06 1.06l2 2a.75.75 0 001.06 0l3.5-3.5z">
+                                    </path>
+                                    <path fill-rule="evenodd" d="M16 8A8 8 0 110 8a8 8 0 0116 0zm-1.5 0a6.5 6.5 0 11-13 0 6.5 6.5 0 0113 0z"></path>
+                                </svg>
+                                Closed
+                            </span>
+                        {% endif %}
+                        <!-- Comment Count -->
+                        {% if bug.github_comment_count > 0 %}
+                            <span class="inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium text-gray-600 dark:text-gray-400">
+                                <svg class="w-3.5 h-3.5"
+                                     fill="none"
+                                     stroke="currentColor"
+                                     viewBox="0 0 24 24"
+                                     aria-hidden="true">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z">
+                                    </path>
+                                </svg>
+                                {{ bug.github_comment_count }} comment{{ bug.github_comment_count|pluralize }}
+                            </span>
+                        {% endif %}
+                    {% else %}
+                        <!-- Fetch Failed or Not Yet Fetched -->
+                        <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400 border border-gray-200 dark:border-gray-600">
+                            <svg class="w-3 h-3"
+                                 fill="none"
+                                 stroke="currentColor"
+                                 viewBox="0 0 24 24"
+                                 aria-hidden="true">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z">
+                                </path>
+                            </svg>
+                            Data unavailable
+                        </span>
+                    {% endif %}
+                </div>
+            </div>
+        {% endif %}
     </div>
     <!-- Screenshot -->
     {% if bug.screenshot or bugs_screenshots %}

--- a/website/tests/test_issues.py
+++ b/website/tests/test_issues.py
@@ -115,7 +115,7 @@ class GitHubIntegrationFieldsTests(TestCase):
 
         # Check default values
         self.assertEqual(issue.github_comment_count, 0)
-        self.assertIsNone(issue.github_state)
+        self.assertEqual(issue.github_state, "")  # Default is empty string, not None
         self.assertFalse(issue.github_fetch_status)
         self.assertEqual(issue.github_url, "")
 
@@ -184,7 +184,7 @@ class GitHubIntegrationFieldsTests(TestCase):
         )
 
         self.assertFalse(issue.github_fetch_status)
-        self.assertIsNone(issue.github_state)
+        self.assertEqual(issue.github_state, "")  # Default is empty string, not None
         self.assertEqual(issue.github_comment_count, 0)
 
     def test_issue_update_github_fields(self):
@@ -197,7 +197,7 @@ class GitHubIntegrationFieldsTests(TestCase):
 
         # Initially no GitHub data
         self.assertEqual(issue.github_comment_count, 0)
-        self.assertIsNone(issue.github_state)
+        self.assertEqual(issue.github_state, "")  # Default is empty string, not None
         self.assertFalse(issue.github_fetch_status)
 
         # Update with GitHub data
@@ -287,24 +287,10 @@ class GitHubIntegrationFieldsTests(TestCase):
         # Verify all issues maintain their states
         self.assertEqual(Issue.objects.get(pk=issue1.pk).github_state, "open")
         self.assertEqual(Issue.objects.get(pk=issue2.pk).github_state, "closed")
-        self.assertIsNone(Issue.objects.get(pk=issue3.pk).github_state)
-
-    def test_issue_github_state_null_allowed(self):
-        """Test that github_state can be null"""
-        issue = Issue.objects.create(
-            url="http://example.com",
-            description="Test Issue Null State",
-            user=self.user,
-            github_url="https://github.com/test/repo/issues/12",
-            github_state=None,
-            github_fetch_status=False,
-        )
-
-        self.assertIsNone(issue.github_state)
-        self.assertFalse(issue.github_fetch_status)
+        self.assertEqual(Issue.objects.get(pk=issue3.pk).github_state, "")  # Default is empty string
 
     def test_issue_github_state_blank_string(self):
-        """Test that github_state can be blank"""
+        """Test that github_state defaults to blank string"""
         issue = Issue.objects.create(
             url="http://example.com",
             description="Test Issue Blank State",


### PR DESCRIPTION
This PR adds comprehensive test coverage for the GitHub integration fields on the Issue model and improves data integrity by using `PositiveIntegerField` for comment counts.

## GitHub Integration Fields Added

This PR works with the following 4 GitHub integration fields that were added to the Issue model:

* **`github_comment_count`** (`PositiveIntegerField`) - Number of comments on the GitHub issue
* **`github_state`** (`CharField`) - Current state of the GitHub issue (open/closed) as reported by GitHub API
* **`github_fetch_status`** (`BooleanField`) - Whether GitHub data was successfully fetched from the API
* **`github_last_fetched_at`** (`DateTimeField`) - Timestamp of when GitHub data was last fetched (tracks freshness of GitHub data)

## Changes Made

### Model Improvements
* Changed `github_comment_count` from `IntegerField` to `PositiveIntegerField` to prevent negative values and ensure data integrity.
* Updated migration (0260) to use `PositiveIntegerField` to match model definition.

### Test Coverage Added
* **`test_issue_github_last_fetched_at`** - Verifies timestamp tracking for GitHub data fetches:
    * Default value is `None` for new issues.
    * Timestamp is set when GitHub data is successfully fetched.
    * Timestamp is updated on subsequent fetches.
* **`test_issue_github_state_invalid_choice`** - Ensures invalid state values are rejected:
    * Uses Django's `full_clean()` validation.
    * Expects `ValidationError` for invalid choices.
* **`test_issue_github_comment_count_rejects_negative`** (updated) - Verifies negative values are rejected:
    * Previously documented that negative values were allowed.
    * Now properly tests that `PositiveIntegerField` rejects negative values.