### PR TITLE
Fix TransactionManagementError in IP restriction middleware

### DIFF
--- a/blt/middleware/ip_restrict.py
+++ b/blt/middleware/ip_restrict.py
@@ -168,7 +168,7 @@ class IPRestrictMiddleware:
                     IP.objects.create(address=ip, agent=agent, count=1, path=path)
         except Exception as e:
             # Log the error but don't let it break the request
-            logger.error(f"Error recording IP {ip}: {str(e)}")
+            logger.error(f"Error recording IP {ip}: {str(e)}", exc_info=True)
 
     def __call__(self, request):
         return self.process_request_sync(request)


### PR DESCRIPTION
- Add try/except wrapper around _record_ip method to prevent IP logging failures from breaking requests
- Remove buggy 'if not transaction.get_autocommit()' check that always evaluated to True inside atomic block (autocommit is always False)
- Ensure duplicate record cleanup always runs within the atomic block

This fixes TransactionManagementError that occurs when exceptions (like Http404) are raised during request handling while a transaction is active.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * IP restriction middleware now supports asynchronous request handling for improved responsiveness.

* **Bug Fixes**
  * Improved IP tracking with atomic updates to counts and agent data, and automated cleanup of duplicate records to maintain data consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->