### PR TITLE
fix: update input text color in dark mode

### DIFF
--- a/website/templates/includes/header.html
+++ b/website/templates/includes/header.html
@@ -958,9 +958,9 @@
             <div class="flex flex-row gap-4 items-center mt-1 w-full"
                  id="chat-message-input-container">
                 <input id="chat-message-input"
-                        type="text"
-                        class="w-full p-2 border-2 border-gray-300 dark:border-gray-600 placeholder:text-base rounded-lg dark:text-black"
-                        placeholder="Enter your message...">
+                       type="text"
+                       class="w-full p-2 border-2 border-gray-300 dark:border-gray-600 placeholder:text-base rounded-lg dark:text-black"
+                       placeholder="Enter your message...">
                 <div class="flex flex-row gap-2 items-center shrink-0">
                     <button id="chat-message-submit"
                             class="bg-red-600 hover:bg-red-500 text-white p-2 rounded-lg">Send</button>

--- a/website/templates/includes/header.html
+++ b/website/templates/includes/header.html
@@ -958,9 +958,9 @@
             <div class="flex flex-row gap-4 items-center mt-1 w-full"
                  id="chat-message-input-container">
                 <input id="chat-message-input"
-                       type="text"
-                       class="w-full p-2 border-2 border-gray-300 dark:border-gray-600 placeholder:text-base rounded-lg"
-                       placeholder="Enter your message...">
+                        type="text"
+                        class="w-full p-2 border-2 border-gray-300 dark:border-gray-600 placeholder:text-base rounded-lg dark:text-black"
+                        placeholder="Enter your message...">
                 <div class="flex flex-row gap-2 items-center shrink-0">
                     <button id="chat-message-submit"
                             class="bg-red-600 hover:bg-red-500 text-white p-2 rounded-lg">Send</button>


### PR DESCRIPTION
## Improve Chat Message Input Text Visibility in Dark Mode

### What I Changed : 
- Updated the text color of the `chat-message-input` box to black in dark mode.
- The previous text color was extremely light, making it difficult or nearly impossible to read specifically in dark mode.

### Why This Change Was Needed
- In dark mode, the typed text was not visible due to low contrast.
- This caused readability and usability issues for users.
- The change improves accessibility and ensures that users can clearly see what they are typing.
- 
### Screenshots 
Before
<img width="300" height="500" alt="image" src="https://github.com/user-attachments/assets/3e7957bc-706d-4c34-a990-c520d5d8480c" />
After
<img width="300" height="500" alt="image" src="https://github.com/user-attachments/assets/3f2d7169-ae4c-4d8f-b922-664cd7496b4a" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated chat input text color in dark mode to display as black for improved readability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->