### PR TITLE
Fix IOS/Flutter, Chrome extension and Github Actions dowload buttons …

### DIFF
--- a/website/templates/home.html
+++ b/website/templates/home.html
@@ -627,7 +627,7 @@
                                     {% endif %}
                                 {% endfor %}
                             </a>
-                            <a href="https://owaspblt.org/extension/"
+                            <a href="{% url 'extension' %}"
                                target="_blank"
                                class="inline-flex select-none items-center justify-center px-3 py-2 text-red-500 border-2 border-red-500 rounded-lg hover:bg-red-500 hover:text-white font-medium transition-colors duration-200">
                                 <i class="fab fa-chrome mr-2"></i> Install Extension

--- a/website/templates/home.html
+++ b/website/templates/home.html
@@ -599,6 +599,8 @@
                                 {% endfor %}
                             </a>
                             <a href="https://apps.apple.com/us/app/owasp-blt/id6448071954"
+                               target="_blank"
+                               rel="noopener noreferrer"
                                class="inline-flex select-none items-center justify-center px-3 py-2 text-red-500 border-2 border-red-500 rounded-lg hover:bg-red-500 hover:text-white font-medium transition-colors duration-200">
                                 <i class="fab fa-apple mr-2"></i> Download App
                             </a>

--- a/website/templates/home.html
+++ b/website/templates/home.html
@@ -628,6 +628,7 @@
                                 {% endfor %}
                             </a>
                             <a href="https://owaspblt.org/extension/"
+                               target="_blank"
                                class="inline-flex select-none items-center justify-center px-3 py-2 text-red-500 border-2 border-red-500 rounded-lg hover:bg-red-500 hover:text-white font-medium transition-colors duration-200">
                                 <i class="fab fa-chrome mr-2"></i> Install Extension
                             </a>

--- a/website/templates/home.html
+++ b/website/templates/home.html
@@ -598,7 +598,7 @@
                                     {% endif %}
                                 {% endfor %}
                             </a>
-                            <a href="#"
+                            <a href="https://apps.apple.com/us/app/owasp-blt/id6448071954"
                                class="inline-flex select-none items-center justify-center px-3 py-2 text-red-500 border-2 border-red-500 rounded-lg hover:bg-red-500 hover:text-white font-medium transition-colors duration-200">
                                 <i class="fab fa-apple mr-2"></i> Download App
                             </a>
@@ -627,7 +627,7 @@
                                     {% endif %}
                                 {% endfor %}
                             </a>
-                            <a href="#"
+                            <a href="https://owaspblt.org/extension/"
                                class="inline-flex select-none items-center justify-center px-3 py-2 text-red-500 border-2 border-red-500 rounded-lg hover:bg-red-500 hover:text-white font-medium transition-colors duration-200">
                                 <i class="fab fa-chrome mr-2"></i> Install Extension
                             </a>
@@ -656,7 +656,7 @@
                                     {% endif %}
                                 {% endfor %}
                             </a>
-                            <a href="#"
+                            <a href="https://github.com/marketplace/actions/owasp-blt-action-auto-assign-issue-and-unassign-after-5-days"
                                class="inline-flex select-none items-center justify-center px-3 py-2 text-red-500 border-2 border-red-500 rounded-lg hover:bg-red-500 hover:text-white font-medium transition-colors duration-200">
                                 <i class="fas fa-code-branch mr-2"></i> Use Latest
                             </a>


### PR DESCRIPTION
…on the website homepage

Previously, these buttons on the home page linked back to the home page because there was no link embedded in them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored navigation for previously inert buttons: Download App now opens the OWASP BLT page on the Apple App Store.
  * Install Extension now opens the extension page in a new tab.
  * Use Latest now links to the OWASP BLT action on the GitHub Marketplace.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #5196 