### PR TITLE
Security : block remote execution of generate_sample_data command

### DIFF
--- a/website/views/core.py
+++ b/website/views/core.py
@@ -2182,7 +2182,7 @@ def run_management_command(request):
         try:
             # Only allow running commands from the website app and exclude initsuperuser
             app_name = get_commands().get(command)
-            if app_name != "website" or command == "initsuperuser":
+            if app_name != "website" or command in ["initsuperuser", "generate_sample_data"]:
                 msg = f"Command {command} is not allowed to run from the web interface"
                 if request.headers.get("X-Requested-With") == "XMLHttpRequest":
                     return JsonResponse({"success": False, "error": msg})


### PR DESCRIPTION
This PR fixes a security gap where the generate_sample_data management command could be executed through the backend execution endpoint despite being hidden from the UI.

The management_commands view correctly filters generate_sample_data from the UI.
The run_management_command backend guard only blocked initsuperuser.
This allowed users to bypass UI restrictions and execute generate_sample_data directly via a POST request.

**Fix Implemented**

Updated the backend exclusion check to block both sensitive commands:
initsuperuser
generate_sample_data
This ensures UI filtering and backend execution rules are properly aligned.

**Security Impact**
Prevents unauthorized database wipes and regeneration
Restores expected access control for destructive management commands
Reduces risk of production data corruption

Reported by Sentry Bot: “run_management_command allows generate_sample_data execution despite UI filtering”
CLOSES: #5208 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted access to certain administrative commands through the web interface, preventing unintended execution of initialization and data generation operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->