### PR TITLE
Bug: FieldError fixed

### DIFF
--- a/website/api/views.py
+++ b/website/api/views.py
@@ -770,13 +770,20 @@ class ProjectViewSet(viewsets.ModelViewSet):
     @action(detail=False, methods=["get"])
     def search(self, request, *args, **kwargs):
         query = request.query_params.get("q", "")
-        projects = Project.objects.filter(
-            Q(name__icontains=query)
-            | Q(description__icontains=query)
-            | Q(tags__name__icontains=query)
-            | Q(stars__icontains=query)
-            | Q(forks__icontains=query)
-        ).distinct()
+        try:
+            query_int = int(query)
+            projects = Project.objects.filter(
+                Q(name__icontains=query)
+                | Q(description__icontains=query)
+                | Q(tags__name__icontains=query)
+                | Q(stars=query_int)
+                | Q(forks=query_int)
+            ).distinct()
+        except ValueError:
+            # If query is not a number, exclude stars/forks from search
+            projects = Project.objects.filter(
+                Q(name__icontains=query) | Q(description__icontains=query) | Q(tags__name__icontains=query)
+            ).distinct()
 
         project_data = []
         for project in projects:

--- a/website/views/issue.py
+++ b/website/views/issue.py
@@ -483,11 +483,15 @@ def search_issues(request, template="search.html"):
         issues_base_qs = (
             Issue.objects.filter(label__in=label_values, hunt=None) if label_values else Issue.objects.none()
         )
+        if request.user.is_anonymous:
+            issues_qs = issues_base_qs.exclude(is_hidden=True)
+        else:
+            issues_qs = issues_base_qs.exclude(Q(is_hidden=True) & ~Q(user_id=request.user.id))
 
         context = {
             "query": query,
             "type": stype,
-            "issues": issues_base_qs.exclude(Q(is_hidden=True) & ~Q(user_id=request.user.id))[0:20],
+            "issues": issues_qs[0:20],
         }
 
     if request.user.is_authenticated:

--- a/website/views/issue.py
+++ b/website/views/issue.py
@@ -484,14 +484,14 @@ def search_issues(request, template="search.html"):
             Issue.objects.filter(label__in=label_values, hunt=None) if label_values else Issue.objects.none()
         )
         if request.user.is_anonymous:
-            issues_qs = issues_base_qs.exclude(is_hidden=True)
+            issues_qs = issues_base_qs.exclude(is_hidden=True)[0:20]
         else:
-            issues_qs = issues_base_qs.exclude(Q(is_hidden=True) & ~Q(user_id=request.user.id))
+            issues_qs = issues_base_qs.exclude(Q(is_hidden=True) & ~Q(user_id=request.user.id))[0:20]
 
         context = {
             "query": query,
             "type": stype,
-            "issues": issues_qs[0:20],
+            "issues": issues_qs,
         }
 
     if request.user.is_authenticated:

--- a/website/views/issue.py
+++ b/website/views/issue.py
@@ -468,12 +468,26 @@ def search_issues(request, template="search.html"):
         }
 
     if stype == "label" or stype is None:
+        label_values = []
+        q_lower = query.lower()
+
+        # Allow numeric label ID
+        if query.isdigit():
+            label_values.append(int(query))
+
+        # Match against label display names
+        for value, name in Issue._meta.get_field("label").choices:
+            if q_lower in str(name).lower():
+                label_values.append(value)
+
+        issues_base_qs = (
+            Issue.objects.filter(label__in=label_values, hunt=None) if label_values else Issue.objects.none()
+        )
+
         context = {
             "query": query,
             "type": stype,
-            "issues": Issue.objects.filter(Q(label__icontains=query), hunt=None).exclude(
-                Q(is_hidden=True) & ~Q(user_id=request.user.id)
-            )[0:20],
+            "issues": issues_base_qs.exclude(Q(is_hidden=True) & ~Q(user_id=request.user.id))[0:20],
         }
 
     if request.user.is_authenticated:


### PR DESCRIPTION
CLOSES : #5203 
Follow-up to solve the left critical error in the PR #5204 
Flag by coderabbit :
⚠️ Potential issue | 🔴 Critical

🧩 Analysis chain
Fix labels search: label__icontains lookup will crash on integer field

The "labels" branch contains a critical bug:

issues_qs = Issue.objects.filter(Q(label__icontains=query), hunt=None)...
Issue.label is a PositiveSmallIntegerField, and Django's icontains lookup is only supported on text fields (CharField/TextField). This will raise a FieldError at runtime and break the labels search entirely.

Map the user's query to numeric label values via the field's choices and filter with label__in instead:
```python
-        elif stype == "labels":
-            if request.user.is_authenticated:
-                issues_qs = Issue.objects.filter(Q(label__icontains=query), hunt=None).exclude(
-                    Q(is_hidden=True) & ~Q(user_id=request.user.id)
-                )[0:20]
-            else:
-                issues_qs = Issue.objects.filter(Q(label__icontains=query), hunt=None).exclude(is_hidden=True)[0:20]
-
-            context = {
-                "request": request,
-                "query": query,
-                "type": stype,
-                "issues": issues_qs,
-            }
+        elif stype == "labels":
+            # Map query to numeric label values (by id or display name)
+            label_values = []
+            q_lower = query.lower()
+
+            # Allow direct numeric id search, e.g. "3"
+            if query.isdigit():
+                label_values.append(int(query))
+
+            # Also match by human-readable label names (e.g. "Performance")
+            for value, name in Issue._meta.get_field("label").choices:
+                if q_lower in str(name).lower():
+                    label_values.append(value)
+
+            issues_base_qs = (
+                Issue.objects.filter(label__in=label_values, hunt=None) if label_values else Issue.objects.none()
+            )
+
+            if request.user.is_authenticated:
+                issues_qs = issues_base_qs.exclude(Q(is_hidden=True) & ~Q(user_id=request.user.id))[0:20]
+            else:
+                issues_qs = issues_base_qs.exclude(is_hidden=True)[0:20]
+
+            context = {
+                "request": request,
+                "query": query,
+                "type": stype,
+                "issues": issues_qs,
+            }
```
This preserves the access-control logic while enabling both numeric and human-readable label name searches.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Label search now matches both numeric IDs and display names for more accurate results.
  * Search results properly respect item visibility (hidden) depending on authentication.

* **Improvements**
  * Project/API search treats numeric queries as exact numeric matches for numeric fields (e.g., stars/forks); non-numeric queries search text fields only.
* **Other**
  * Label searches now return a consistent, limited result set for clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->