### PR TITLE
Create a github_webhook url that will update the hackathon PRs

### DIFF
--- a/blt/settings.py
+++ b/blt/settings.py
@@ -24,7 +24,7 @@ print(f"DATABASE_URL: {os.environ.get('DATABASE_URL', 'not set')}")
 PROJECT_ROOT = os.path.dirname(os.path.abspath(__file__))
 GITHUB_TOKEN = os.environ.get("GITHUB_TOKEN", "blank")
 DISCORD_BOT_TOKEN = os.environ.get("DISCORD_BOT_TOKEN", "blank")
-
+GITHUB_WEBHOOK_SECRET = os.environ.get("GITHUB_WEBHOOK_SECRET", "")
 
 PROJECT_NAME = "BLT"
 DOMAIN_NAME = "blt.owasp.org"

--- a/website/tests/test_github_webhook.py
+++ b/website/tests/test_github_webhook.py
@@ -47,8 +47,8 @@ class GitHubWebhookIssuesTestCase(TestCase):
             body="Test issue description",
             state="open",
             type="issue",
-            created_at=datetime(2024, 1, 1, 12, 0, 0),
-            updated_at=datetime(2024, 1, 1, 12, 0, 0),
+            created_at=timezone.make_aware(datetime(2024, 1, 1, 12, 0, 0)),
+            updated_at=timezone.make_aware(datetime(2024, 1, 1, 12, 0, 0)),
             url="https://github.com/testorg/test-repo/issues/123",
             repo=self.repo,
         )

--- a/website/tests/test_github_webhook.py
+++ b/website/tests/test_github_webhook.py
@@ -454,39 +454,39 @@ class GitHubWebhookPullRequestTestCase(TestCase):
         self.assertEqual(response.status_code, 403)
         self.assertEqual(GitHubIssue.objects.count(), 0)
 
-        def test_missing_signature_returns_403(self):
-            """Missing signature header should return 403."""
-            payload = {
-                "action": "opened",
-                "pull_request": {
-                    "id": self.pr_global_id,
-                    "number": self.pr_number,
-                    "state": "open",
-                    "title": "No sig test",
-                    "body": "",
-                    "html_url": f"{self.repo_url}/pull/{self.pr_number}",
-                    "merged": False,
-                    "created_at": timezone.now().isoformat(),
-                    "updated_at": timezone.now().isoformat(),
-                    "user": {
-                        "login": "octocat",
-                        "html_url": "https://github.com/octocat",
-                        "avatar_url": "",
-                    },
+    def test_missing_signature_returns_403(self):
+        """Missing signature header should return 403."""
+        payload = {
+            "action": "opened",
+            "pull_request": {
+                "id": self.pr_global_id,
+                "number": self.pr_number,
+                "state": "open",
+                "title": "No sig test",
+                "body": "",
+                "html_url": f"{self.repo_url}/pull/{self.pr_number}",
+                "merged": False,
+                "created_at": timezone.now().isoformat(),
+                "updated_at": timezone.now().isoformat(),
+                "user": {
+                    "login": "octocat",
+                    "html_url": "https://github.com/octocat",
+                    "avatar_url": "",
                 },
-                "repository": {
-                    "full_name": "OWASP-BLT/demo-repo",
-                    "html_url": self.repo_url,
-                },
-            }
-            body = json.dumps(payload).encode("utf-8")
+            },
+            "repository": {
+                "full_name": "OWASP-BLT/demo-repo",
+                "html_url": self.repo_url,
+            },
+        }
+        body = json.dumps(payload).encode("utf-8")
 
-            response = self.client.post(
-                self.webhook_url,
-                data=body,
-                content_type="application/json",
-                HTTP_X_GITHUB_EVENT="pull_request",
-                # Intentionally no HTTP_X_HUB_SIGNATURE_256 header
-            )
+        response = self.client.post(
+            self.webhook_url,
+            data=body,
+            content_type="application/json",
+            HTTP_X_GITHUB_EVENT="pull_request",
+            # Intentionally no HTTP_X_HUB_SIGNATURE_256 header
+        )
 
-            self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, 403)

--- a/website/tests/test_github_webhook.py
+++ b/website/tests/test_github_webhook.py
@@ -1,21 +1,26 @@
+import hashlib
+import hmac
 import json
 from datetime import datetime
 from unittest.mock import patch
 
 from django.contrib.auth.models import User
-from django.test import Client, TestCase
+from django.test import Client, TestCase, override_settings
 from django.urls import reverse
+from django.utils import timezone
 
 from website.models import GitHubIssue, Repo, UserProfile
 
 
-class GitHubWebhookTestCase(TestCase):
-    """Test GitHub webhook handling for issue events"""
+@override_settings(GITHUB_WEBHOOK_SECRET="testsecret")
+class GitHubWebhookIssuesTestCase(TestCase):
+    """Test GitHub webhook handling for ISSUE events"""
 
     def setUp(self):
         """Set up test data"""
         self.client = Client()
         self.webhook_url = reverse("github-webhook")
+        self.secret = "testsecret"
 
         # Create test user with GitHub profile
         self.user = User.objects.create_user(username="testuser", password="testpass")
@@ -43,9 +48,36 @@ class GitHubWebhookTestCase(TestCase):
             repo=self.repo,
         )
 
+    def _sign(self, body: bytes) -> str:
+        """Generate X-Hub-Signature-256 header for a given body."""
+        return (
+            "sha256="
+            + hmac.new(
+                self.secret.encode("utf-8"),
+                body,
+                hashlib.sha256,
+            ).hexdigest()
+        )
+
+    def _post(self, payload: dict, event: str = "issues", *, signature=None):
+        """Helper to POST to /github-webhook/ with correct headers."""
+        body = json.dumps(payload).encode("utf-8")
+        headers = {
+            "HTTP_X_GITHUB_EVENT": event,
+        }
+        if signature is None:
+            signature = self._sign(body)
+        headers["HTTP_X_HUB_SIGNATURE_256"] = signature
+
+        return self.client.post(
+            self.webhook_url,
+            data=body,
+            content_type="application/json",
+            **headers,
+        )
+
     def test_webhook_closes_issue_on_github_close(self):
         """Test that webhook closes GitHubIssue when GitHub issue is closed"""
-        # Create webhook payload for issue closed event
         payload = {
             "action": "closed",
             "issue": {
@@ -64,19 +96,11 @@ class GitHubWebhookTestCase(TestCase):
             },
         }
 
-        # Send webhook request
-        response = self.client.post(
-            self.webhook_url,
-            data=json.dumps(payload),
-            content_type="application/json",
-            HTTP_X_GITHUB_EVENT="issues",
-        )
+        response = self._post(payload, event="issues")
 
-        # Check response
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["status"], "success")
 
-        # Verify GitHubIssue was updated
         self.github_issue.refresh_from_db()
         self.assertEqual(self.github_issue.state, "closed")
         self.assertIsNotNone(self.github_issue.closed_at)
@@ -87,7 +111,6 @@ class GitHubWebhookTestCase(TestCase):
         self.github_issue.state = "closed"
         self.github_issue.save()
 
-        # Create webhook payload for issue opened/reopened event
         payload = {
             "action": "reopened",
             "issue": {
@@ -105,19 +128,11 @@ class GitHubWebhookTestCase(TestCase):
             },
         }
 
-        # Send webhook request
-        response = self.client.post(
-            self.webhook_url,
-            data=json.dumps(payload),
-            content_type="application/json",
-            HTTP_X_GITHUB_EVENT="issues",
-        )
+        response = self._post(payload, event="issues")
 
-        # Check response
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["status"], "success")
 
-        # Verify GitHubIssue was updated
         self.github_issue.refresh_from_db()
         self.assertEqual(self.github_issue.state, "open")
 
@@ -141,15 +156,8 @@ class GitHubWebhookTestCase(TestCase):
             },
         }
 
-        # Send webhook request
-        response = self.client.post(
-            self.webhook_url,
-            data=json.dumps(payload),
-            content_type="application/json",
-            HTTP_X_GITHUB_EVENT="issues",
-        )
+        response = self._post(payload, event="issues")
 
-        # Should still return success even if issue not found
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["status"], "success")
 
@@ -173,15 +181,8 @@ class GitHubWebhookTestCase(TestCase):
             },
         }
 
-        # Send webhook request
-        response = self.client.post(
-            self.webhook_url,
-            data=json.dumps(payload),
-            content_type="application/json",
-            HTTP_X_GITHUB_EVENT="issues",
-        )
+        response = self._post(payload, event="issues")
 
-        # Should still return success even if repo not found
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["status"], "success")
 
@@ -193,7 +194,6 @@ class GitHubWebhookTestCase(TestCase):
 
     def test_webhook_handles_malformed_payload(self):
         """Test that webhook handles malformed payloads gracefully"""
-        # Missing required fields
         payload = {
             "action": "closed",
             "issue": {
@@ -205,15 +205,18 @@ class GitHubWebhookTestCase(TestCase):
             },
         }
 
-        # Send webhook request
+        # malformed payload still needs *a* signature header
+        body = json.dumps(payload).encode("utf-8")
+        sig = self._sign(body)
+
         response = self.client.post(
             self.webhook_url,
-            data=json.dumps(payload),
+            data=body,
             content_type="application/json",
             HTTP_X_GITHUB_EVENT="issues",
+            HTTP_X_HUB_SIGNATURE_256=sig,
         )
 
-        # Should handle gracefully
         self.assertEqual(response.status_code, 400)
 
     @patch("website.views.user.assign_github_badge")
@@ -237,18 +240,9 @@ class GitHubWebhookTestCase(TestCase):
             },
         }
 
-        # Send webhook request
-        response = self.client.post(
-            self.webhook_url,
-            data=json.dumps(payload),
-            content_type="application/json",
-            HTTP_X_GITHUB_EVENT="issues",
-        )
+        response = self._post(payload, event="issues")
 
-        # Check response
         self.assertEqual(response.status_code, 200)
-
-        # Verify badge assignment was called
         mock_assign_badge.assert_called_once_with(self.user, "First Issue Closed")
 
     def test_webhook_updates_timestamps_correctly(self):
@@ -271,21 +265,202 @@ class GitHubWebhookTestCase(TestCase):
             },
         }
 
-        # Send webhook request
-        response = self.client.post(
-            self.webhook_url,
-            data=json.dumps(payload),
-            content_type="application/json",
-            HTTP_X_GITHUB_EVENT="issues",
-        )
+        response = self._post(payload, event="issues")
 
-        # Check response
         self.assertEqual(response.status_code, 200)
 
-        # Verify timestamps were updated
         self.github_issue.refresh_from_db()
         self.assertIsNotNone(self.github_issue.closed_at)
         self.assertIsNotNone(self.github_issue.updated_at)
-        # Verify the time is approximately correct (within a few seconds due to parsing)
         self.assertEqual(self.github_issue.closed_at.day, 2)
         self.assertEqual(self.github_issue.closed_at.hour, 14)
+
+
+@override_settings(GITHUB_WEBHOOK_SECRET="testsecret")
+class GitHubWebhookPullRequestTestCase(TestCase):
+    """Test GitHub webhook handling for PULL REQUEST events + security."""
+
+    def setUp(self):
+        """Set up a test client, webhook URL, secret, and a test Repo instance."""
+        self.client = Client()
+        self.webhook_url = reverse("github-webhook")
+        self.secret = "testsecret"
+
+        # Repo must exist to be linked by webhook
+        self.repo_url = "https://github.com/OWASP-BLT/demo-repo"
+        self.repo = Repo.objects.create(
+            name="demo-repo",
+            repo_url=self.repo_url,
+            slug="owasp-blt-demo-repo",
+        )
+
+        self.pr_global_id = 987654321  # pull_request["id"]
+        self.pr_number = 42  # pull_request["number"]
+
+    def _sign(self, body: bytes) -> str:
+        """Generate a valid X-Hub-Signature-256 header for the given request body."""
+        return (
+            "sha256="
+            + hmac.new(
+                self.secret.encode("utf-8"),
+                body,
+                hashlib.sha256,
+            ).hexdigest()
+        )
+
+    def _post(self, payload: dict, *, signature=None):
+        """Helper to POST a signed pull_request webhook payload to /github-webhook/."""
+        body = json.dumps(payload).encode("utf-8")
+        headers = {
+            "HTTP_X_GITHUB_EVENT": "pull_request",
+        }
+        if signature is None:
+            signature = self._sign(body)
+        headers["HTTP_X_HUB_SIGNATURE_256"] = signature
+
+        return self.client.post(
+            self.webhook_url,
+            data=body,
+            content_type="application/json",
+            **headers,
+        )
+
+    def test_pr_opened_creates_github_issue(self):
+        """PR opened event should create a GitHubIssue of type pull_request."""
+        created_at = timezone.now()
+        updated_at = timezone.now()
+
+        payload = {
+            "action": "opened",
+            "pull_request": {
+                "id": self.pr_global_id,
+                "number": self.pr_number,
+                "state": "open",
+                "title": "Add hackathon feature",
+                "body": "This PR is for the hackathon.",
+                "html_url": f"{self.repo_url}/pull/{self.pr_number}",
+                "merged": False,
+                "created_at": created_at.isoformat().replace("+00:00", "Z"),
+                "updated_at": updated_at.isoformat().replace("+00:00", "Z"),
+                "user": {
+                    "login": "octocat",
+                    "html_url": "https://github.com/octocat",
+                    "avatar_url": "https://avatars.githubusercontent.com/u/1?v=4",
+                },
+            },
+            "repository": {
+                "full_name": "OWASP-BLT/demo-repo",
+                "html_url": self.repo_url,
+            },
+        }
+
+        response = self._post(payload)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(GitHubIssue.objects.count(), 1)
+
+        issue = GitHubIssue.objects.first()
+        self.assertEqual(issue.issue_id, self.pr_global_id)
+        self.assertEqual(issue.type, "pull_request")
+        self.assertEqual(issue.state, "open")
+        self.assertFalse(issue.is_merged)
+        self.assertEqual(issue.repo, self.repo)
+
+    def test_pr_merged_updates_issue_and_sets_merged_at(self):
+        """PR closed with merged=true should update GitHubIssue and set merged_at/closed_at."""
+        # Seed with opened PR via webhook
+        opened_payload = {
+            "action": "opened",
+            "pull_request": {
+                "id": self.pr_global_id,
+                "number": self.pr_number,
+                "state": "open",
+                "title": "Add hackathon feature",
+                "body": "This PR is for the hackathon.",
+                "html_url": f"{self.repo_url}/pull/{self.pr_number}",
+                "merged": False,
+                "created_at": timezone.now().isoformat(),
+                "updated_at": timezone.now().isoformat(),
+                "user": {
+                    "login": "octocat",
+                    "html_url": "https://github.com/octocat",
+                    "avatar_url": "https://avatars.githubusercontent.com/u/1?v=4",
+                },
+            },
+            "repository": {
+                "full_name": "OWASP-BLT/demo-repo",
+                "html_url": self.repo_url,
+            },
+        }
+        self._post(opened_payload)
+        self.assertEqual(GitHubIssue.objects.count(), 1)
+
+        merged_at = timezone.now()
+        closed_payload = {
+            "action": "closed",
+            "pull_request": {
+                "id": self.pr_global_id,
+                "number": self.pr_number,
+                "state": "closed",
+                "title": "Add hackathon feature",
+                "body": "This PR is for the hackathon.",
+                "html_url": f"{self.repo_url}/pull/{self.pr_number}",
+                "merged": True,
+                "created_at": opened_payload["pull_request"]["created_at"],
+                "updated_at": merged_at.isoformat().replace("+00:00", "Z"),
+                "closed_at": merged_at.isoformat().replace("+00:00", "Z"),
+                "merged_at": merged_at.isoformat().replace("+00:00", "Z"),
+                "user": {
+                    "login": "octocat",
+                    "html_url": "https://github.com/octocat",
+                    "avatar_url": "https://avatars.githubusercontent.com/u/1?v=4",
+                },
+            },
+            "repository": {
+                "full_name": "OWASP-BLT/demo-repo",
+                "html_url": self.repo_url,
+            },
+        }
+
+        response = self._post(closed_payload)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(GitHubIssue.objects.count(), 1)
+
+        issue = GitHubIssue.objects.get(issue_id=self.pr_global_id, repo=self.repo)
+        self.assertEqual(issue.state, "closed")
+        self.assertTrue(issue.is_merged)
+        self.assertIsNotNone(issue.merged_at)
+        self.assertIsNotNone(issue.closed_at)
+
+    def test_invalid_signature_returns_403_and_does_not_create_pr_issue(self):
+        """Invalid signature should return 403 and not create any GitHubIssue records."""
+        payload = {
+            "action": "opened",
+            "pull_request": {
+                "id": self.pr_global_id,
+                "number": self.pr_number,
+                "state": "open",
+                "title": "Bad sig test",
+                "body": "",
+                "html_url": f"{self.repo_url}/pull/{self.pr_number}",
+                "merged": False,
+                "created_at": timezone.now().isoformat(),
+                "updated_at": timezone.now().isoformat(),
+                "user": {
+                    "login": "octocat",
+                    "html_url": "https://github.com/octocat",
+                    "avatar_url": "https://avatars.githubusercontent.com/u/1?v=4",
+                },
+            },
+            "repository": {
+                "full_name": "OWASP-BLT/demo-repo",
+                "html_url": self.repo_url,
+            },
+        }
+
+        # Explicit wrong signature
+        response = self._post(payload, signature="sha256=wrong")
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(GitHubIssue.objects.count(), 0)

--- a/website/views/user.py
+++ b/website/views/user.py
@@ -1370,12 +1370,12 @@ def handle_pull_request_event(payload):
         logger.error(f"Error getting/creating Contributor for PR: {e}")
         contributor = None
 
-        # --- Timestamps (using same style as handle_issue_event) ---
-        created_at = safe_parse_github_datetime(
-            pr_data.get("created_at"),
-            default=timezone.now(),
-            field_name="pull_request.created_at",
-        )
+    # --- Timestamps (using same style as handle_issue_event) ---
+    created_at = safe_parse_github_datetime(
+        pr_data.get("created_at"),
+        default=timezone.now(),
+        field_name="pull_request.created_at",
+    )
     updated_at = safe_parse_github_datetime(
         pr_data.get("updated_at"),
         default=timezone.now(),

--- a/website/views/user.py
+++ b/website/views/user.py
@@ -1354,7 +1354,9 @@ def handle_pull_request_event(payload):
                 defaults={
                     "github_url": gh_github_url or "",
                     "name": gh_login or extract_github_username(gh_github_url) or "",
-                    "avatar_url": gh_avatar,
+                    "avatar_url": gh_avatar or "",
+                    "contributor_type": "User",
+                    "contributions": 0,
                 },
             )
         elif gh_github_url:

--- a/website/views/user.py
+++ b/website/views/user.py
@@ -3,7 +3,7 @@ import hmac
 import json
 import logging
 import os
-from datetime import datetime, timezone
+from datetime import datetime
 
 from allauth.account.signals import user_signed_up
 from dateutil import parser as dateutil_parser
@@ -1358,14 +1358,10 @@ def handle_pull_request_event(payload):
                 },
             )
         elif gh_github_url:
-            # Fallback for rare cases where id is missing (e.g. some bots)
-            contributor, _ = Contributor.objects.get_or_create(
-                github_url=gh_github_url,
-                defaults={
-                    "name": gh_login or extract_github_username(gh_github_url) or "",
-                    "avatar_url": gh_avatar,
-                },
-            )
+            # Fallback: try to find existing contributor by URL, but don't create
+            # without github_id, since it's a required unique field
+            contributor = Contributor.objects.filter(github_url=gh_github_url).first()
+
     except Exception as e:
         logger.error(f"Error getting/creating Contributor for PR: {e}")
         contributor = None

--- a/website/views/user.py
+++ b/website/views/user.py
@@ -1261,6 +1261,17 @@ def github_webhook(request):
     and returns a JSON response indicating success or error.
     """
     if request.method == "POST":
+        # Fail closed if secret is not configured
+        if not getattr(settings, "GITHUB_WEBHOOK_SECRET", None):
+            logger.error("GITHUB_WEBHOOK_SECRET is not configured; refusing webhook request.")
+            return JsonResponse(
+                {
+                    "status": "error",
+                    "message": "Webhook secret not configured",
+                },
+                status=503,
+            )
+
         signature = request.headers.get("X-Hub-Signature-256")
 
         if not validate_github_signature(request.body, signature):


### PR DESCRIPTION
Closes #4004 

**Phase 1 – PR Tracking:**

- Added handle_pull_request_event to persist pull request events into GitHubIssue (type="pull_request").

- Updates fields such as state, is_merged, merged_at, closed_at, etc.

- Reuses the existing GitHubIssue model, keyed by (issue_id, repo), enabling hackathons to query merged PRs by merged_at.

**Phase 2 – Webhook Security:**

- Implemented validate_github_signature using HMAC-SHA256 with GITHUB_WEBHOOK_SECRET.
 
- The github_webhook view now validates X-Hub-Signature-256 and returns 403 for missing or invalid signatures.
 
**Phase 3 – Tests:**

- Added website/tests/test_github_webhook.py covering:

- Issue events: open, close, reopen, timestamp updates, badge assignment.

- Pull request events: opened/merged PRs create or update GitHubIssue.

- Security tests: invalid or missing signatures return 403 and database remains unchanged.

**How to test:**
-python manage.py test website.tests.test_github_webhook

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public GitHub webhook endpoint to ingest issue and pull request events, sync platform items, and award "First PR Merged" badges for merged PRs.

* **Security / Bug Fixes**
  * HMAC-SHA256 signature validation for webhook requests with clear error responses; returns service-unavailable if webhook secret is not configured and rejects invalid/malformed payloads.

* **Tests**
  * Expanded tests for issue/PR flows, signature handling, idempotency, malformed payloads, and response behaviors.

* **Chores**
  * Added configurable webhook secret and safer parsing for GitHub timestamps.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->