### PR TITLE
security : protect gsoc refresh endpoint

### DIFF
--- a/website/views/issue.py
+++ b/website/views/issue.py
@@ -47,6 +47,7 @@ from django.utils.html import escape
 from django.views import View
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
+from django.views.decorators.throttle import throttle
 from django.views.generic import DetailView, ListView, TemplateView
 from django.views.generic.edit import CreateView
 from openai import OpenAI
@@ -2543,6 +2544,8 @@ class GsocView(View):
         return render(request, "gsoc.html", {"projects": sorted_project_data})
 
 
+@staff_member_required
+@throttle(rate="5/hour")
 def refresh_gsoc_project(request):
     """
     View to handle refreshing PRs for a specific GSoC project.

--- a/website/views/issue.py
+++ b/website/views/issue.py
@@ -2552,11 +2552,9 @@ def refresh_gsoc_project(request):
     View to handle refreshing PRs for a specific GSoC project.
     Only staff users can access this view.
     """
-    # Validate input first
     project_name = request.POST.get("project_name")
     reset_counter = request.POST.get("reset_counter") == "true"
 
-    # Check if project_name is provided and valid
     if not project_name:
         messages.error(request, "Project name is required.")
         return redirect("gsoc")
@@ -2565,20 +2563,17 @@ def refresh_gsoc_project(request):
         messages.error(request, "Invalid project name")
         return redirect("gsoc")
 
-    # Get the repositories for this project
     repos = GSOC25_PROJECTS.get(project_name, [])
 
     if not repos:
         messages.error(request, f"No repositories found for project {project_name}")
         return redirect("gsoc")
 
-    # Validate repository format
     for repo in repos:
         if not isinstance(repo, str) or repo.count("/") != 1:
             messages.error(request, f"Invalid repository format: {repo}")
             return redirect("gsoc")
 
-    # Rate limiting check - only after validation passes
     today = timezone.now().date()
     refresh_count = DailyStats.objects.filter(name=f"refresh_gsoc_{request.user.id}", created__date=today).count()
 
@@ -2586,24 +2581,20 @@ def refresh_gsoc_project(request):
         messages.error(request, "You have reached your daily limit of 5 refreshes.")
         return redirect("gsoc")
 
-    # Fixed start date: 2024-11-11
     since_date = timezone.make_aware(datetime(2024, 11, 11))
 
     try:
-        # Call the fetch_gsoc_prs command with the specific repositories
         repo_list = ",".join(repos)
         command_args = ["fetch_gsoc_prs", f"--repos={repo_list}", "--verbose"]
 
-        # Add reset flag if requested
         if reset_counter:
             command_args.append("--reset")
             messages.info(request, f"Resetting page counter for {project_name} repositories")
 
-        # Run the command
         call_command(*command_args)
 
-        # Debug: Count how many GitHubIssues were created with contributors
         repo_objs = Repo.objects.filter(name__in=[name.split("/")[-1] for name in repos])
+
         issue_count = GitHubIssue.objects.filter(
             repo__in=repo_objs, type="pull_request", is_merged=True, merged_at__gte=since_date
         ).count()
@@ -2618,53 +2609,54 @@ def refresh_gsoc_project(request):
 
         messages.info(request, f"Debug info: Found {issue_count} PRs, {contributor_count} with contributors linked")
 
-        # Update user profiles for PRs that don't have them
         for repo_full_name in repos:
             try:
                 owner, repo_name = repo_full_name.split("/")
                 repo = Repo.objects.filter(name=repo_name).first()
 
                 if repo:
-                    # Get PRs without user profiles
                     prs_without_profiles = GitHubIssue.objects.filter(
-                        repo=repo, type="pull_request", is_merged=True, merged_at__gte=since_date, user_profile=None
+                        repo=repo,
+                        type="pull_request",
+                        is_merged=True,
+                        merged_at__gte=since_date,
+                        user_profile=None,
                     )
 
-                    # Process in batches for efficiency
                     batch_size = 50
                     for i in range(0, prs_without_profiles.count(), batch_size):
                         batch = prs_without_profiles[i : i + batch_size]
 
                         for pr in batch:
                             try:
-                                # Extract username from PR URL
                                 pr_url_parts = pr.url.split("/")
                                 if len(pr_url_parts) >= 5 and pr_url_parts[2] == "github.com":
                                     github_url = f"https://github.com/{pr_url_parts[3]}"
 
-                                    # Skip bot accounts
                                     if github_url.endswith("[bot]") or "bot" in github_url.lower():
                                         continue
 
-                                    # Find existing user profile with this GitHub URL
                                     user_profile = UserProfile.objects.filter(github_url=github_url).first()
 
                                     if user_profile:
                                         pr.user_profile = user_profile
                                         pr.save()
+
                             except (IndexError, AttributeError):
                                 continue
+
             except Exception as e:
                 messages.warning(request, f"Error updating user profiles for {repo_full_name}: {str(e)}")
 
-        # Only increment counter AFTER successful completion
-        DailyStats.objects.create(name=f"refresh_gsoc_{request.user.id}", value="1", user=request.user)
-
         messages.success(
-            request, f"Successfully refreshed PRs for {project_name}. {len(repos)} repositories processed."
+            request,
+            f"Successfully refreshed PRs for {project_name}. {len(repos)} repositories processed.",
         )
 
     except Exception as e:
         messages.error(request, f"Error refreshing PRs for {project_name}: {str(e)}")
+        return redirect("gsoc")
+
+    DailyStats.objects.create(name=f"refresh_gsoc_{request.user.id}", value="1", user=request.user)
 
     return redirect("gsoc")


### PR DESCRIPTION
Problem: 
```python
def refresh_gsoc_project(request):
    """
    View to handle refreshing PRs for a specific GSoC project.
    Only staff users can access this view.  # ← This is just a comment!
    """
    if request.method == "POST":
        # ... no authentication check here ...
        call_command("fetch_gsoc_prs", f"--repos={repo_list}", "--verbose")
```

Impact:
 Anyone (including unauthenticated users) can POST to /gsoc/refresh/
 Triggers the fetch_gsoc_prs management command
 Makes expensive GitHub API calls
 Creates database records (GitHubIssue, UserProfile)
 Can be abused for DoS (exhaust GitHub API rate limits, database bloat)
CLOSES : #5242 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * GSOC refresh endpoint now requires login, is restricted to admin/staff, accepts POST only, and is rate-limited to 5 refreshes per user per day.
  * Adds input validation for project name and repository formats, rejects invalid requests early.
  * Ensures daily stats and user counters are updated only after a successful refresh; preserves existing success/error messaging.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->