### PR TITLE
feature: implement weekly Slack report (#2484)

### DIFF
--- a/website/management/commands/run_weekly.py
+++ b/website/management/commands/run_weekly.py
@@ -26,3 +26,10 @@ class Command(BaseCommand):
             logger.info("Completed sample invites cleanup")
         except Exception:
             logger.exception("Error cleaning up sample invites")
+
+        # Send weekly Slack report
+        try:
+            management.call_command("slack_weekly_report")
+            logger.info("Completed weekly Slack report")
+        except Exception:
+            logger.exception("Error sending weekly Slack report")

--- a/website/management/commands/slack_weekly_report.py
+++ b/website/management/commands/slack_weekly_report.py
@@ -28,7 +28,7 @@ class Command(BaseCommand):
         summary = (
             "* Weekly OWASP BLT Report*\n\n"
             f"*New Issues:* {new_issues}\n"
-            f"*✔️ Closed Issues:* {closed_issues}\n"
+            f"*Closed Issues:* {closed_issues}\n"
             f"*New Users:* {new_users}\n"
             f"*Total Projects:* {total_projects}\n\n"
             "_Report generated automatically._"

--- a/website/management/commands/slack_weekly_report.py
+++ b/website/management/commands/slack_weekly_report.py
@@ -1,0 +1,56 @@
+import logging
+from datetime import datetime, timedelta
+
+from django.core.management.base import BaseCommand
+from slack_bolt import App
+
+from website.models import SlackIntegration, Issue, User, Project
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = "Send weekly Slack report every Saturday at 1pm EST"
+
+    def handle(self, *args, **kwargs):
+        now = datetime.utcnow()
+        last_week = now - timedelta(days=7)
+
+        # Pull weekly stats
+        new_issues = Issue.objects.filter(created__gte=last_week).count()
+        closed_issues = Issue.objects.filter(status="closed", closed_date__gte=last_week).count()
+        new_users = User.objects.filter(date_joined__gte=last_week).count()
+        total_projects = Project.objects.count()
+
+        summary = (
+            "*📊 Weekly OWASP BLT Report*\n\n"
+            f"*🆕 New Issues:* {new_issues}\n"
+            f"*✔️ Closed Issues:* {closed_issues}\n"
+            f"*👤 New Users:* {new_users}\n"
+            f"*📁 Total Projects:* {total_projects}\n\n"
+            "_Report generated automatically._"
+        )
+
+        # Send to all Slack integrations
+        slack_integrations = SlackIntegration.objects.all()
+
+        for integration in slack_integrations:
+            if not integration.default_channel_id or not integration.bot_access_token:
+                continue
+
+            self.send_message(
+                integration.default_channel_id,
+                integration.bot_access_token,
+                summary,
+            )
+
+        logger.info("Weekly Slack report sent successfully.")
+
+    def send_message(self, channel_id, bot_token, message):
+        """Send a message to the Slack channel."""
+        try:
+            app = App(token=bot_token)
+            app.client.conversations_join(channel=channel_id)
+            app.client.chat_postMessage(channel=channel_id, text=message)
+        except Exception as e:
+            logger.error(f"Failed to send weekly report: {e}")

--- a/website/management/commands/slack_weekly_report.py
+++ b/website/management/commands/slack_weekly_report.py
@@ -1,24 +1,27 @@
 import logging
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 from django.core.management.base import BaseCommand
+from django.utils import timezone
 from slack_bolt import App
 
-from website.models import SlackIntegration, Issue, User, Project
+from website.models import Issue, Project, SlackIntegration, User
 
 logger = logging.getLogger(__name__)
 
 
 class Command(BaseCommand):
-    help = "Send weekly Slack report every Saturday at 1pm EST"
+    help = "Generate and send weekly project statistics to configured Slack integrations"
 
     def handle(self, *args, **kwargs):
-        now = datetime.utcnow()
+        now = timezone.now()
         last_week = now - timedelta(days=7)
 
-        # Pull weekly stats
+        # Weekly Stats
         new_issues = Issue.objects.filter(created__gte=last_week).count()
-        closed_issues = Issue.objects.filter(status="closed", closed_date__gte=last_week).count()
+        closed_issues = Issue.objects.filter(
+            status="closed", closed_date__isnull=False, closed_date__gte=last_week
+        ).count()
         new_users = User.objects.filter(date_joined__gte=last_week).count()
         total_projects = Project.objects.count()
 
@@ -31,26 +34,26 @@ class Command(BaseCommand):
             "_Report generated automatically._"
         )
 
-        # Send to all Slack integrations
-        slack_integrations = SlackIntegration.objects.all()
+        success = 0
+        fail = 0
 
-        for integration in slack_integrations:
+        for integration in SlackIntegration.objects.all():
             if not integration.default_channel_id or not integration.bot_access_token:
                 continue
 
-            self.send_message(
-                integration.default_channel_id,
-                integration.bot_access_token,
-                summary,
-            )
+            if self.send_message(integration.default_channel_id, integration.bot_access_token, summary):
+                success += 1
+            else:
+                fail += 1
 
-        logger.info("Weekly Slack report sent successfully.")
+        logger.info(f"Weekly Slack report: {success} sent, {fail} failed.")
 
     def send_message(self, channel_id, bot_token, message):
-        """Send a message to the Slack channel."""
         try:
             app = App(token=bot_token)
             app.client.conversations_join(channel=channel_id)
             app.client.chat_postMessage(channel=channel_id, text=message)
+            return True
         except Exception as e:
             logger.error(f"Failed to send weekly report: {e}")
+            return False

--- a/website/management/commands/slack_weekly_report.py
+++ b/website/management/commands/slack_weekly_report.py
@@ -26,11 +26,11 @@ class Command(BaseCommand):
         total_projects = Project.objects.count()
 
         summary = (
-            "*📊 Weekly OWASP BLT Report*\n\n"
-            f"*🆕 New Issues:* {new_issues}\n"
+            "* Weekly OWASP BLT Report*\n\n"
+            f"*New Issues:* {new_issues}\n"
             f"*✔️ Closed Issues:* {closed_issues}\n"
-            f"*👤 New Users:* {new_users}\n"
-            f"*📁 Total Projects:* {total_projects}\n\n"
+            f"*New Users:* {new_users}\n"
+            f"*Total Projects:* {total_projects}\n\n"
             "_Report generated automatically._"
         )
 


### PR DESCRIPTION

Fixes #2484

The report summarizes key project metrics and sends them to all configured Slack integrations every Saturday at 1 PM EST.

### What This PR Adds
- New management command `slack_weekly_report` to generate weekly organization-wide statistics.
- Automatically collects:
  - New issues created in the past week
  - Issues closed in the past week
  - Newly registered users
  - Total active projects
- Sends a formatted Slack message using the existing `SlackIntegration` model.
- Updated `run_weekly` to call the new command.
- Added timezone-safe scheduling logic and error handling.

### How It Works
- Admin configures Slack bot + default channel in **Slack Integration** section.
- Cron job runs:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated weekly Slack reports now generate and deliver summaries to configured Slack integrations, including counts of new and closed issues, new user registrations, and total projects from the previous week.
  * The scheduled weekly run now triggers publishing of the Slack weekly report as part of its flow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


<img width="1440" height="372" alt="Screenshot 2025-12-11 at 1 37 48 PM" src="https://github.com/user-attachments/assets/8006893d-e786-4198-817b-eecf9a418676" />


