### PR TITLE
docs: add optional uv-based setup and Windows notes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,6 +132,7 @@ This option is useful for contributors who prefer faster dependency resolution a
 
 ```bash
 pip install uv
+```
 
 
 1. Install Python 3.11.2 (using pyenv or another tool):

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,6 +134,21 @@ This option is useful for contributors who prefer faster dependency resolution a
 pip install uv
 ```
 
+#### Set up the BLT project using `uv`
+
+From the project root, run:
+
+```bash
+uv sync
+
+To start the development server:
+
+uv run python manage.py migrate
+uv run python manage.py runserver
+
+Open your browser at:
+http://localhost:8000
+
 
 1. Install Python 3.11.2 (using pyenv or another tool):
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,6 +113,27 @@ Before you start contributing, you'll need to set up your development environmen
 
 ### Python Virtual Environment Setup
 
+
+### Optional: Python Virtual Environment Setup using `uv`
+
+BLT can also be set up using [`uv`](https://github.com/astral-sh/uv), a fast Python package manager
+and virtual environment tool. This is an **optional** alternative to the Poetry-based setup
+described above.
+
+This option is useful for contributors who prefer faster dependency resolution and installation.
+
+#### Install `uv`
+
+> ⚠️ Note (Windows):  
+> On some Windows setups, `uv` may fail to auto-detect Python installations
+> due to registry or PATH resolution issues. In such cases, explicitly
+> specifying the Python interpreter or using Docker/Poetry is recommended.
+
+
+```bash
+pip install uv
+
+
 1. Install Python 3.11.2 (using pyenv or another tool):
 
    ```bash


### PR DESCRIPTION
Fixes #3646

This PR documents an optional uv-based Python setup for BLT.

During evaluation, uv was found to have Python discovery limitations
on some Windows environments, which is now documented as well.

Existing Docker and Poetry workflows remain unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an optional virtual environment setup using uv as an alternative to the existing Poetry workflow, including pip-based installation, a Windows Python-detection caveat, retention of the Python 3.11.2 prerequisite, and guidance for syncing dependencies, running migrations, and starting the development server with uv. Notes that uv may offer faster dependency resolution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->