### PR TITLE
Fix: Add send_weekly_stats management command

### DIFF
--- a/website/management/commands/send_weekly_stats.py
+++ b/website/management/commands/send_weekly_stats.py
@@ -70,10 +70,13 @@ class Command(BaseCommand):
                     report_data.append("-" * 50 + "\n")
                     for issue in issues:
                         description = issue.description
-                        views = issue.views
+                        views = issue.views if issue.views is not None else 0  
                         label = issue.get_label_display()
                         report_data.append(
-                            f"\nDescription: {description}\n" f"Views: {views}\n" f"Labels: {label}\n" f"{'-' * 50}\n"
+                        f"\nDescription: {description}\n" 
+                        f"Views: {views}\n" 
+                        f"Labels: {label}\n" 
+                        f"{'-' * 50}\n"
                         )
                 else:
                     report_data.append("No issues reported this week.\n")

--- a/website/management/commands/send_weekly_stats.py
+++ b/website/management/commands/send_weekly_stats.py
@@ -23,10 +23,10 @@ class Command(BaseCommand):
 
         # Filter domains: must have organization AND organization must have owner (admin)
         domains = Domain.objects.filter(
-            organization__isnull=False,  
-            organization__admin__isnull=False,  
-            email__isnull=False, 
-        ).exclude(email="") 
+            organization__isnull=False,
+            organization__admin__isnull=False,
+            email__isnull=False,
+        ).exclude(email="")
 
         total_domains = domains.count()
         successful_sends = 0
@@ -43,12 +43,12 @@ class Command(BaseCommand):
                 # Generate report data for this domain - FILTER BY WEEK
                 open_issues = domain.open_issues.filter(created__gte=week_ago)
                 closed_issues = domain.closed_issues.filter(created__gte=week_ago)
-                
+
                 # Store counts to avoid redundant queries
                 open_count = open_issues.count()
                 closed_count = closed_issues.count()
                 total_issues = open_count + closed_count
-                
+
                 issues = Issue.objects.filter(domain=domain, created__gte=week_ago)
 
                 # Build the email message
@@ -73,10 +73,7 @@ class Command(BaseCommand):
                         views = issue.views
                         label = issue.get_label_display()
                         report_data.append(
-                            f"\nDescription: {description}\n"
-                            f"Views: {views}\n"
-                            f"Labels: {label}\n"
-                            f"{'-' * 50}\n"
+                            f"\nDescription: {description}\n" f"Views: {views}\n" f"Labels: {label}\n" f"{'-' * 50}\n"
                         )
                 else:
                     report_data.append("No issues reported this week.\n")
@@ -99,7 +96,9 @@ class Command(BaseCommand):
             except Exception as e:
                 failed_sends += 1
                 logger.error(f"Failed to send weekly stats to {domain.organization.name} ({domain.email}): {str(e)}")
-                self.stdout.write(self.style.ERROR(f"✗ Failed to send to {domain.organization.name} ({domain.email}): {str(e)}"))
+                self.stdout.write(
+                    self.style.ERROR(f"✗ Failed to send to {domain.organization.name} ({domain.email}): {str(e)}")
+                )
 
         self.stdout.write("\n" + "=" * 60)
         self.stdout.write(

--- a/website/management/commands/send_weekly_stats.py
+++ b/website/management/commands/send_weekly_stats.py
@@ -26,7 +26,7 @@ class Command(BaseCommand):
             organization__isnull=False,
             organization__admin__isnull=False,
             email__isnull=False,
-        ).exclude(email="")
+        ).exclude(email="").select_related('organization')
 
         total_domains = domains.count()
         successful_sends = 0
@@ -70,13 +70,10 @@ class Command(BaseCommand):
                     report_data.append("-" * 50 + "\n")
                     for issue in issues:
                         description = issue.description
-                        views = issue.views if issue.views is not None else 0  
+                        views = issue.views if issue.views is not None else 0
                         label = issue.get_label_display()
                         report_data.append(
-                        f"\nDescription: {description}\n" 
-                        f"Views: {views}\n" 
-                        f"Labels: {label}\n" 
-                        f"{'-' * 50}\n"
+                            f"\nDescription: {description}\n" f"Views: {views}\n" f"Labels: {label}\n" f"{'-' * 50}\n"
                         )
                 else:
                     report_data.append("No issues reported this week.\n")

--- a/website/management/commands/send_weekly_stats.py
+++ b/website/management/commands/send_weekly_stats.py
@@ -1,0 +1,102 @@
+import logging
+
+from django.conf import settings
+from django.core.mail import send_mail
+from django.core.management.base import BaseCommand
+
+from website.models import Domain, Issue
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = "Send weekly statistics emails to all domains with organization owners"
+
+    def handle(self, *args, **options):
+        """
+        Main function that runs when command is executed.
+        Sends weekly reports to domains that have organizations with owners.
+        """
+        self.stdout.write(self.style.WARNING("Starting weekly statistics email delivery..."))
+
+        # Filter domains: must have organization AND organization must have owner (admin)
+        # This follows DonnieBLT's requirement
+        domains = Domain.objects.filter(
+            organization__isnull=False,  # Must have an organization
+            organization__admin__isnull=False,  # Organization must have an owner
+            email__isnull=False,  # Must have an email address
+        ).exclude(email="")  # Exclude empty email strings
+
+        total_domains = domains.count()
+        successful_sends = 0
+        failed_sends = 0
+
+        self.stdout.write(self.style.NOTICE(f"Found {total_domains} domains to process"))
+
+        # Process each domain individually
+        for domain in domains:
+            try:
+                # Generate report data for this domain
+                open_issues = domain.open_issues
+                closed_issues = domain.closed_issues
+                total_issues = open_issues.count() + closed_issues.count()
+                issues = Issue.objects.filter(domain=domain)
+
+                # Build the email message
+                report_data = [
+                    "Hey! This is a weekly report from OWASP BLT regarding the bugs reported for your organization!\n\n"
+                ]
+
+                report_data.append(
+                    f"Organization Name: {domain.name}\n"
+                    f"Open issues: {open_issues.count()}\n"
+                    f"Closed issues: {closed_issues.count()}\n"
+                    f"Total issues: {total_issues}\n\n"
+                )
+
+                # Add individual issue details
+                if issues.exists():
+                    report_data.append("Issue Details:\n")
+                    report_data.append("-" * 50 + "\n")
+                    for issue in issues:
+                        description = issue.description
+                        views = issue.views
+                        label = issue.get_label_display()
+                        report_data.append(
+                            f"\nDescription: {description}\n" f"Views: {views}\n" f"Labels: {label}\n" f"{'-' * 50}\n"
+                        )
+                else:
+                    report_data.append("No issues reported this week.\n")
+
+                report_string = "".join(report_data)
+
+                # Send the email
+                send_mail(
+                    subject="Weekly Report from OWASP BLT",
+                    message=report_string,
+                    from_email=settings.EMAIL_HOST_USER,
+                    recipient_list=[domain.email],
+                    fail_silently=False,
+                )
+
+                successful_sends += 1
+                logger.info(f"Successfully sent weekly stats to {domain.name} ({domain.email})")
+                self.stdout.write(self.style.SUCCESS(f"✓ Sent to {domain.name} ({domain.email})"))
+
+            except Exception as e:
+                failed_sends += 1
+                logger.error(f"Failed to send weekly stats to {domain.name} ({domain.email}): {str(e)}")
+                self.stdout.write(self.style.ERROR(f"✗ Failed to send to {domain.name} ({domain.email}): {str(e)}"))
+
+        # Print summary
+        self.stdout.write("\n" + "=" * 60)
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"\n📊 Weekly statistics delivery complete!"
+                f"\n✓ Successful: {successful_sends}"
+                f"\n✗ Failed: {failed_sends}"
+                f"\n📧 Total processed: {total_domains}\n"
+            )
+        )
+
+        logger.info(f"Weekly stats delivery completed. Success: {successful_sends}, Failed: {failed_sends}")

--- a/website/management/commands/send_weekly_stats.py
+++ b/website/management/commands/send_weekly_stats.py
@@ -22,11 +22,15 @@ class Command(BaseCommand):
         self.stdout.write(self.style.WARNING("Starting weekly statistics email delivery..."))
 
         # Filter domains: must have organization AND organization must have owner (admin)
-        domains = Domain.objects.filter(
-            organization__isnull=False,
-            organization__admin__isnull=False,
-            email__isnull=False,
-        ).exclude(email="").select_related('organization')
+        domains = (
+            Domain.objects.filter(
+                organization__isnull=False,
+                organization__admin__isnull=False,
+                email__isnull=False,
+            )
+            .exclude(email="")
+            .select_related("organization")
+        )
 
         total_domains = domains.count()
         successful_sends = 0


### PR DESCRIPTION
Fixes #2182.

Adds a `send_weekly_stats` management command and moves the weekly stats logic there.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Weekly statistics emails are now sent to domain administrators, summarizing issues created in the past week with counts for open/closed/total and per-issue details (description, views, label).
  * Delivery is resilient: failures for one domain won’t stop others; processing continues per domain and a final summary reports totals processed, successful deliveries, and failures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->