### PR TITLE
fix: filter bot username from global leaderboard

### DIFF
--- a/website/views/user.py
+++ b/website/views/user.py
@@ -584,14 +584,15 @@ class GlobalLeaderboardView(LeaderboardBase, ListView):
         # Dynamically filters for OWASP-BLT repos (will include any new BLT repos added to database)
         # Filter for PRs merged in the last 6 months
         from dateutil.relativedelta import relativedelta
+
         bots = ["copilot", "[bot]"]
         since_date = timezone.now() - relativedelta(months=6)
-        
+
         # Create dynamic bot exclusion query
         bot_exclusions = Q()
         for bot in bots:
             bot_exclusions |= Q(contributor__name__icontains=bot)
-        
+
         pr_leaderboard = (
             GitHubIssue.objects.filter(
                 type="pull_request",

--- a/website/views/user.py
+++ b/website/views/user.py
@@ -585,7 +585,7 @@ class GlobalLeaderboardView(LeaderboardBase, ListView):
         # Filter for PRs merged in the last 6 months
         from dateutil.relativedelta import relativedelta
 
-        bots = ["copilot", "[bot]"]
+        bots = ["copilot", "[bot]", "dependabot", "github-actions", "renovate"]
         since_date = timezone.now() - relativedelta(months=6)
 
         # Create dynamic bot exclusion query


### PR DESCRIPTION
## Filter out bot contributions from global leaderboard

This pr removes bot accounts from the global leaderboard to keep rankings fair and human-focused.
known automated users (dependabot, copilot, github-actions, etc.) are excluded from all calculations.

Fixes: #5364 