### PR TITLE
Fix TLS certificate verification in domain URL validation

### DIFF
--- a/website/views/company.py
+++ b/website/views/company.py
@@ -1244,7 +1244,7 @@ class AddDomainView(View):
             if is_valid_https_url(domain_data["url"]):
                 safe_url = rebuild_safe_url(domain_data["url"])
                 try:
-                    response = requests.get(safe_url, timeout=5, verify=False)
+                    response = requests.get(safe_url, timeout=5)
                     if response.status_code != 200:
                         raise Exception
                 except requests.exceptions.RequestException:

--- a/website/views/company.py
+++ b/website/views/company.py
@@ -1244,7 +1244,7 @@ class AddDomainView(View):
             if is_valid_https_url(domain_data["url"]):
                 safe_url = rebuild_safe_url(domain_data["url"])
                 try:
-                    response = requests.get(safe_url, timeout=5)
+                    response = requests.get(safe_url, timeout=5, verify=True)
                     if response.status_code != 200:
                         raise Exception
                 except requests.exceptions.RequestException:


### PR DESCRIPTION
I saw the "no new issues" banner, but this is a legitimate security vulnerability (CWE-295) with a one-line fix. Figured a PR would be easier to review than a forum discussion — happy to move to the forum if preferred!

## Summary
Removes `verify=False` from HTTPS request in domain URL validation to enable proper TLS certificate verification.

## What changed
**File:** `website/views/company.py` (Line ~1247)

**Context:** Domain URL validation function that verifies user-provided company domains

**Before:**
```python
# validate domain url
try:
    if is_valid_https_url(domain_data["url"]):
        safe_url = rebuild_safe_url(domain_data["url"])
        try:
            response = requests.get(safe_url, timeout=5, verify=False)
            if response.status_code != 200:
After:
# validate domain url
try:
    if is_valid_https_url(domain_data["url"]):
        safe_url = rebuild_safe_url(domain_data["url"])
        try:
            response = requests.get(safe_url, timeout=5)
            if response.status_code != 200:
Change: Removed verify=False parameter to enable default certificate validation.
Why this matters
Current behavior: Disabling certificate verification allows Man-in-the-Middle (MITM) attacks where an attacker can present any certificate and the application will accept it without validation
Security impact: Enables identity spoofing and data poisoning during domain validation, potentially allowing invalid domains to pass validation checks
Fix: Relies on requests library's secure defaults for certificate validation
Classification:
CWE-295 (Improper Certificate Validation)
Severity: Medium (CVSS ~5.3-6.5)
Attack Vector: Network (requires MITM position)
Real-world threat scenario
User submits a company domain URL for validation
Application makes HTTPS request with verify=False to validate the domain
Attacker on the network (compromised Wi-Fi, malicious proxy, corporate MITM) intercepts the request
Attacker presents fake certificate and crafted response (e.g., 200 OK)
Domain validation logic operates on attacker-controlled data
Invalid or malicious domain passes validation checks
Why rebuild_safe_url() doesn't prevent this:
While the URL is sanitized before the request, disabling certificate verification means an attacker can still intercept the request to the legitimate domain and provide fraudulent responses.
Testing
✅ Verified requests still complete successfully with default certificate verification enabled
✅ No functional impact on legitimate HTTPS endpoints with valid certificates
✅ Invalid/self-signed certificates now properly rejected (expected secure behavior)
✅ Domain validation logic continues to work as intended for valid domains
Alternative approaches considered
If there's a legitimate need to support self-signed certificates for specific internal domains:
Use verify='/path/to/custom-ca-bundle.pem' for specific trusted CAs
Make verification configurable per environment (disabled only in local dev)
Use request mocking in test environments instead of disabling verification
I'm happy to implement any of these alternatives if needed!
References
CWE-295: Improper Certificate Validation
Python requests: SSL Cert Verification
OWASP: Transport Layer Protection Cheat Sheet
OWASP Top 10 2021: A07 - Identification and Authentication Failures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reinforced SSL certificate verification to improve security and reliability of network connections.
  * Error handling for network/SSL failures remains in place so connection errors are still surfaced and managed as before.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->