### PR TITLE
Add Rinkit as GSoC Mentor

### DIFF
--- a/website/templates/gsoc.html
+++ b/website/templates/gsoc.html
@@ -602,6 +602,32 @@
                     </div>
                 </div>
                 <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
+                    <!-- Rinkit Adhana -->
+                    <div class="bg-white dark:bg-gray-800 rounded-lg shadow-lg transition-all border border-gray-200 dark:border-gray-700 overflow-hidden">
+                        <div class="h-3 bg-gradient-to-r from-[#e74c3c] to-red-400"></div>
+                        <div class="p-8">
+                            <div class="flex items-center mb-4">
+                                <div class="w-16 h-16 bg-red-100 rounded-full flex items-center justify-center mr-4">
+                                    <i class="fas fa-code text-[#e74c3c] text-2xl"></i>
+                                </div>
+                                <div>
+                                    <h3 class="text-2xl font-bold text-gray-900 dark:text-gray-100">Rinkit Adhana</h3>
+                                    <span class="text-sm font-medium text-gray-500 dark:text-gray-500 bg-gray-100 dark:bg-gray-800 px-3 py-1 rounded-full">Full Stack Development mentor</span>
+                                </div>
+                            </div>
+                            <p class="text-gray-700 dark:text-gray-300 leading-relaxed">
+                                As a full stack engineer and active BLT contributor, I bring
+                                hands-on experience from both sides of the development process.
+                                Having participated in GSoC 2025, I understand the challenges new
+                                contributors face and can guide you through your open source
+                                journey. I specialize in helping developers build scalable web
+                                applications, navigate complex codebases, and contribute
+                                effectively to real-world projects. My goal is to share practical
+                                knowledge and help you grow as a developer while making meaningful
+                                contributions to BLT.
+                            </p>
+                        </div>
+                    </div>
                     <!-- Ahmed ElSheikh -->
                     <div class="bg-white dark:bg-gray-800 rounded-lg shadow-lg transition-all border border-gray-200 dark:border-gray-700 overflow-hidden">
                         <div class="h-3 bg-gradient-to-r from-[#e74c3c] to-red-400"></div>


### PR DESCRIPTION
Adds Rinkit as a mentor on the BLT website for Google Summer of Code 2026. Includes mentor profile details and ensures visibility on the GSoC mentors section.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added mentor profile card for Rinkit Adhana to the Current GSoC 2026 Mentors section.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->