### PR TITLE
Fix check-peer-review workflow blocking Dependabot auto-merge

### DIFF
--- a/.github/workflows/check-peer-review.yml
+++ b/.github/workflows/check-peer-review.yml
@@ -60,6 +60,7 @@ jobs:
           # Skip Dependabot PRs entirely (defense in depth)
           if [[ "$PR_AUTHOR" == "dependabot[bot]" || "$PR_AUTHOR" == "dependabot-preview[bot]" ]]; then
           echo "Dependabot PR detected. Skipping peer review check."
+          echo "has_peer_review=true" >> "$GITHUB_OUTPUT"
           exit 0
           fi
           

--- a/.github/workflows/check-peer-review.yml
+++ b/.github/workflows/check-peer-review.yml
@@ -27,8 +27,11 @@ jobs:
   check_peer_review:
     runs-on: ubuntu-latest
     if: >
-     github.event.pull_request.user.login != 'dependabot[bot]'
-     && github.event.pull_request.user.login != 'dependabot-preview[bot]'
+     github.actor != 'dependabot[bot]'
+      && github.actor != 'dependabot-preview[bot]'
+      && github.actor != 'dependabot'
+      && github.actor != 'DonnieBLT'
+      && !contains(github.actor, 'copilot')
     steps:
       - name: Check for Peer Review and Add Label
         id: check_peer_review

--- a/.github/workflows/check-peer-review.yml
+++ b/.github/workflows/check-peer-review.yml
@@ -27,12 +27,8 @@ jobs:
   check_peer_review:
     runs-on: ubuntu-latest
     if: >
-      github.actor != 'dependabot[bot]'
-      && github.actor != 'dependabot-preview[bot]'
-      && github.actor != 'dependabot'
-      && github.actor != 'DonnieBLT'
-      && github.actor != 'Copilot'
-      && github.actor != 'copilot-swe-agent[bot]'
+     github.event.pull_request.user.login != 'dependabot[bot]'
+     && github.event.pull_request.user.login != 'dependabot-preview[bot]'
     steps:
       - name: Check for Peer Review and Add Label
         id: check_peer_review
@@ -57,6 +53,12 @@ jobs:
           
           PR_AUTHOR=$(echo "$PR_RESPONSE" | jq -r '.user.login')
           echo "PR Author: $PR_AUTHOR"
+
+          # Skip Dependabot PRs entirely (defense in depth)
+          if [[ "$PR_AUTHOR" == "dependabot[bot]" || "$PR_AUTHOR" == "dependabot-preview[bot]" ]]; then
+          echo "Dependabot PR detected. Skipping peer review check."
+          exit 0
+          fi
           
           # Get all reviews for the PR
           REVIEWS_RESPONSE=$(curl -s -X GET \

--- a/.github/workflows/check-peer-review.yml
+++ b/.github/workflows/check-peer-review.yml
@@ -27,11 +27,11 @@ jobs:
   check_peer_review:
     runs-on: ubuntu-latest
     if: >
-     github.actor != 'dependabot[bot]'
-      && github.actor != 'dependabot-preview[bot]'
-      && github.actor != 'dependabot'
-      && github.actor != 'DonnieBLT'
-      && !contains(github.actor, 'copilot')
+     github.event.pull_request.user.login != 'dependabot[bot]'
+     && github.event.pull_request.user.login != 'dependabot-preview[bot]'
+     && github.event.pull_request.user.login != 'dependabot'
+     && github.event.pull_request.user.login != 'DonnieBLT'
+     && !contains(github.event.pull_request.user.login, 'copilot')
     steps:
       - name: Check for Peer Review and Add Label
         id: check_peer_review
@@ -58,7 +58,7 @@ jobs:
           echo "PR Author: $PR_AUTHOR"
 
           # Skip Dependabot PRs entirely (defense in depth)
-          if [[ "$PR_AUTHOR" == "dependabot[bot]" || "$PR_AUTHOR" == "dependabot-preview[bot]" ]]; then
+          if [[ "$PR_AUTHOR" == "dependabot[bot]" || "$PR_AUTHOR" == "dependabot-preview[bot]" || "$PR_AUTHOR" == "dependabot" ]]; then
           echo "Dependabot PR detected. Skipping peer review check."
           echo "has_peer_review=true" >> "$GITHUB_OUTPUT"
           exit 0


### PR DESCRIPTION
### Summary
This PR fixes a regression where the `check-peer-review` workflow incorrectly runs on Dependabot pull requests and applies the `needs-peer-review` label, blocking the auto-merge process.

### Root Cause
The workflow was relying on `github.actor`, which does not reliably represent the PR author for `pull_request_target` events. As a result, Dependabot PRs were no longer excluded.

### Fix
- Skip execution based on `pull_request.user.login`
- Add a defensive early-exit for Dependabot-authored PRs

This restores the intended auto-approve and auto-merge behavior for dependency updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Workflow now skips Dependabot pull requests earlier, exiting the peer-review process for dependency updates.
  * Simplified automated-author detection with a generalized check to identify bot-generated PRs.
  * Core peer-review behavior (review fetching, reviewer filtering, commenting, labeling) remains unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->