### PR TITLE
Adding myself (Preetham) as GSoC 2026 mentee under Vinamra Vaswani

### DIFF
--- a/website/templates/gsoc.html
+++ b/website/templates/gsoc.html
@@ -680,7 +680,7 @@
                                     <span class="text-sm font-medium text-gray-500 dark:text-gray-500 bg-gray-100 dark:bg-gray-800 px-3 py-1 rounded-full">GSoC Mentor</span>
                                 </div>
                             </div>
-                            <p class="text-gray-700 dark:text-gray-300 leading-relaxed">
+                            <p class="text-gray-700 dark:text-gray-300 leading-relaxed mb-6">
                                 I am a software engineer experienced in building production-grade backend systems using Python,
                                 FastAPI, and MongoDB, with a focus on clean architecture and real-world problem solving.
                                 Through open-source style projects and mentorship programs,
@@ -689,6 +689,27 @@
                                 real-world contributors, while giving back to open source by supporting their
                                 technical and professional growth in a learning-first environment.
                             </p>
+                            <!-- Mentees Section -->
+                            <div class="border-t border-gray-200 dark:border-gray-600 pt-4">
+                                <h4 class="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-3 flex items-center">
+                                    <i class="fas fa-users text-[#e74c3c] mr-2"></i>
+                                    GSoC 2026 Mentees
+                                </h4>
+                                <div class="flex items-center space-x-3">
+                                    <div class="w-10 h-10 bg-red-100 rounded-full flex items-center justify-center">
+                                        <i class="fab fa-github text-[#e74c3c] text-lg"></i>
+                                    </div>
+                                    <div>
+                                        <a href="https://github.com/Pritz395"
+                                           target="_blank"
+                                           rel="noopener noreferrer"
+                                           class="text-gray-900 dark:text-gray-100 font-medium hover:text-[#e74c3c] transition-colors">
+                                            Preetham
+                                        </a>
+                                        <p class="text-sm text-gray-500 dark:text-gray-400">GSoC 2026 Mentee</p>
+                                    </div>
+                                </div>
+                            </div>
                         </div>
                     </div>
                     <!-- Manikandan Chandran -->


### PR DESCRIPTION
Added myself as a GSoC 2026 mentee under Vinamra Vaswani's mentor card.

## Changes
- Added mentee section under Vinamra Vaswani's mentor card
- Includes name, GitHub link, and role badge

Following the same pattern as other mentees. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a new GSoC 2026 Mentees section displaying mentor-mentee relationships with direct GitHub profile links for easy access to contributor profiles.

* **Style**
  * Updated visual layout and spacing to enhance readability and improve visual hierarchy for biographical content.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->