### PR TITLE
Fix Django collectstatic failure in CI

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -102,7 +102,14 @@ jobs:
       - run: pip install poetry
       - run: poetry lock
       - run: poetry install --with dev
-      - run: poetry run python manage.py collectstatic --noinput
+      - name: Prepare static directory
+        run: mkdir -p staticfiles
+
+      - name: Django collectstatic
+        env:
+             CI: true
+        run: poetry run python manage.py collectstatic --noinput
+
       - name: Run tests
         run: poetry run xvfb-run --auto-servernum python manage.py test -v 3 --failfast
 

--- a/blt/settings.py
+++ b/blt/settings.py
@@ -10,6 +10,7 @@ import sentry_sdk
 from django.utils.translation import gettext_lazy as _
 from google.oauth2 import service_account
 from sentry_sdk.integrations.django import DjangoIntegration
+from pathlib import Path
 
 environ.Env.read_env()
 
@@ -631,3 +632,12 @@ THROTTLE_LIMITS = {
 }
 THROTTLE_WINDOW = 60  # 60 seconds (1 minute)
 THROTTLE_EXEMPT_PATHS = ["/admin/", "/static/", "/media/"]
+
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+
+STATIC_URL = "/static/"
+STATIC_ROOT = BASE_DIR / "staticfiles"
+
+os.makedirs(STATIC_ROOT, exist_ok=True)
+COLLECTSTATIC_NO_POST_PROCESS = True


### PR DESCRIPTION
What changed
- Ensured STATIC_ROOT exists in settings.py
- Added COLLECTSTATIC_NO_POST_PROCESS for CI environments
- Updated ci-cd.yml to prepare static files explicitly before collectstatic

### Why
CI was failing because the static folder didn’t exist and post-processing caused errors.
This ensures consistent builds across environments.

### Scope
- CI and settings only
- No functional changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified CI/CD workflow to explicitly create staticfiles directory before running collection
  * Updated static file configuration with explicit path definitions and directory initialization during deployment setup

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->