### PR TITLE
UI/UX: Add global “Back to Top” floating button for improved navigation

### DIFF
--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -413,6 +413,6 @@
         <script src="https://unpkg.com/leaflet.markercluster@1.5.3/dist/leaflet.markercluster.js"></script>
         <script src="https://unpkg.com/leaflet.fullscreen@1.6.0/Control.FullScreen.js"></script>
         <!-- include the Back to Top button -->
-         {% include "includes/back_to_top.html" %}
+        {% include "includes/back_to_top.html" %}
     </body>
 </html>

--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -412,5 +412,7 @@
         <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" crossorigin=""></script>
         <script src="https://unpkg.com/leaflet.markercluster@1.5.3/dist/leaflet.markercluster.js"></script>
         <script src="https://unpkg.com/leaflet.fullscreen@1.6.0/Control.FullScreen.js"></script>
+        <!-- include the Back to Top button -->
+         {% include "includes/back_to_top.html" %}
     </body>
 </html>

--- a/website/templates/includes/back_to_top.html
+++ b/website/templates/includes/back_to_top.html
@@ -1,7 +1,7 @@
 <!-- Back to Top button for all pages -->
 <button id="backToTopBtn"
         aria-label="Back to top"
-        class="hidden fixed bottom-3 right-20 z-50 bg-red-600 text-white p-3 rounded-full shadow-lg hover:bg-red-500 dark:hover:opacity-80 transition duration-200">
+        class="hidden fixed bottom-3 right-20 z-99 bg-red-600 text-white p-3 rounded-full shadow-lg hover:bg-red-500 dark:hover:opacity-80 transition duration-200">
     <svg class="w-8 h-8"
          viewBox="0 0 24 24"
          fill="currentColor"

--- a/website/templates/includes/back_to_top.html
+++ b/website/templates/includes/back_to_top.html
@@ -36,14 +36,26 @@
                     backToTopBtn.classList.add("hidden");
                 }
                 };
+                /* ---------- Optimized Scroll Handler ---------- */
 
-                // Attach listeners
-                if (scrollContainer) {
-                scrollContainer.addEventListener("scroll", toggleButton);
-                } else {
-                window.addEventListener("scroll", toggleButton);
+                let ticking = false;
+
+                const handleScroll = () => {
+                if (!ticking) {
+                    requestAnimationFrame(() => {
+                    toggleButton();
+                    ticking = false;
+                    });
+                    ticking = true;
                 }
+                };
 
+                // Attach listeners With passive listener
+                if (scrollContainer) {
+                    scrollContainer.addEventListener("scroll", handleScroll, { passive: true });
+                } else {
+                    window.addEventListener("scroll", handleScroll, { passive: true });
+                }                
                 backToTopBtn.addEventListener("click", scrollToTop);
-            });
+                });
 </script>

--- a/website/templates/includes/back_to_top.html
+++ b/website/templates/includes/back_to_top.html
@@ -1,0 +1,49 @@
+<!-- Back to Top button for all pages -->
+        <button
+            id="backToTopBtn"
+            aria-label="Back to top"
+            class="hidden fixed bottom-3 right-20 z-50 bg-red-600 text-white p-3 rounded-full shadow-lg hover:bg-red-500 dark:hover:opacity-80 transition duration-200"
+            >
+            <svg class="w-8 h-8" viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+                <path fill-rule="evenodd" clip-rule="evenodd" d="M12 3C12.2652 3 12.5196 3.10536 12.7071 3.29289L19.7071 10.2929C20.0976 10.6834 20.0976 11.3166 19.7071 11.7071C19.3166 12.0976 18.6834 12.0976 18.2929 11.7071L13 6.41421V20C13 20.5523 12.5523 21 12 21C11.4477 21 11 20.5523 11 20V6.41421L5.70711 11.7071C5.31658 12.0976 4.68342 12.0976 4.29289 11.7071C3.90237 11.3166 3.90237 10.6834 4.29289 10.2929L11.2929 3.29289C11.4804 3.10536 11.7348 3 12 3Z" />
+            </svg>
+        </button>
+
+        <script>
+            document.addEventListener("DOMContentLoaded", function () {
+                const backToTopBtn = document.getElementById("backToTopBtn");
+                if (!backToTopBtn) return;
+
+                // Explicit container only (if page provides one)
+                const scrollContainer = document.querySelector('[data-scroll-container="true"]');
+
+                const getScrollTop = () => {
+                return scrollContainer ? scrollContainer.scrollTop : window.scrollY;
+                };
+
+                const scrollToTop = () => {
+                if (scrollContainer) {
+                    scrollContainer.scrollTo({ top: 0, behavior: "smooth" });
+                } else {
+                    window.scrollTo({ top: 0, behavior: "smooth" });
+                }
+                };
+
+                const toggleButton = () => {
+                if (getScrollTop() > 300) {
+                    backToTopBtn.classList.remove("hidden");
+                } else {
+                    backToTopBtn.classList.add("hidden");
+                }
+                };
+
+                // Attach listeners
+                if (scrollContainer) {
+                scrollContainer.addEventListener("scroll", toggleButton);
+                } else {
+                window.addEventListener("scroll", toggleButton);
+                }
+
+                backToTopBtn.addEventListener("click", scrollToTop);
+            });
+        </script>

--- a/website/templates/includes/back_to_top.html
+++ b/website/templates/includes/back_to_top.html
@@ -1,15 +1,15 @@
 <!-- Back to Top button for all pages -->
-        <button
-            id="backToTopBtn"
-            aria-label="Back to top"
-            class="hidden fixed bottom-3 right-20 z-50 bg-red-600 text-white p-3 rounded-full shadow-lg hover:bg-red-500 dark:hover:opacity-80 transition duration-200"
-            >
-            <svg class="w-8 h-8" viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
-                <path fill-rule="evenodd" clip-rule="evenodd" d="M12 3C12.2652 3 12.5196 3.10536 12.7071 3.29289L19.7071 10.2929C20.0976 10.6834 20.0976 11.3166 19.7071 11.7071C19.3166 12.0976 18.6834 12.0976 18.2929 11.7071L13 6.41421V20C13 20.5523 12.5523 21 12 21C11.4477 21 11 20.5523 11 20V6.41421L5.70711 11.7071C5.31658 12.0976 4.68342 12.0976 4.29289 11.7071C3.90237 11.3166 3.90237 10.6834 4.29289 10.2929L11.2929 3.29289C11.4804 3.10536 11.7348 3 12 3Z" />
-            </svg>
-        </button>
-
-        <script>
+<button id="backToTopBtn"
+        aria-label="Back to top"
+        class="hidden fixed bottom-3 right-20 z-50 bg-red-600 text-white p-3 rounded-full shadow-lg hover:bg-red-500 dark:hover:opacity-80 transition duration-200">
+    <svg class="w-8 h-8"
+         viewBox="0 0 24 24"
+         fill="currentColor"
+         xmlns="http://www.w3.org/2000/svg">
+        <path fill-rule="evenodd" clip-rule="evenodd" d="M12 3C12.2652 3 12.5196 3.10536 12.7071 3.29289L19.7071 10.2929C20.0976 10.6834 20.0976 11.3166 19.7071 11.7071C19.3166 12.0976 18.6834 12.0976 18.2929 11.7071L13 6.41421V20C13 20.5523 12.5523 21 12 21C11.4477 21 11 20.5523 11 20V6.41421L5.70711 11.7071C5.31658 12.0976 4.68342 12.0976 4.29289 11.7071C3.90237 11.3166 3.90237 10.6834 4.29289 10.2929L11.2929 3.29289C11.4804 3.10536 11.7348 3 12 3Z" />
+    </svg>
+</button>
+<script>
             document.addEventListener("DOMContentLoaded", function () {
                 const backToTopBtn = document.getElementById("backToTopBtn");
                 if (!backToTopBtn) return;
@@ -46,4 +46,4 @@
 
                 backToTopBtn.addEventListener("click", scrollToTop);
             });
-        </script>
+</script>


### PR DESCRIPTION
### Description

#### Problem

Many OWASP BLT pages are content-heavy and require significant vertical scrolling.  
Currently, users must manually scroll back to the top to access navigation elements, which impacts usability—especially on long lists such as activity feeds, organizations, and issues.

---

#### Solution

This PR introduces a **global “Back to Top” floating button** that:

- Appears only after the user scrolls down a reasonable distance
- Smoothly scrolls the user back to the top on click
- Works across **all pages**
- Supports both:
  - Page-level scrolling (`window`)
  - Container-level scrolling (used by some pages like Global Activity Feed)

---

#### UX & Placement Considerations

- The button is positioned **to the left of the existing chat widget**
- This avoids overlap with third-party UI injected by Mouseflow
- Placement is intentional and independent of external widget internals

---

#### Technical Notes

- Frontend-only change (HTML + JavaScript)
- No backend changes required
- No external libraries introduced
- JavaScript follows project standards (no console statements)
- Dark mode styling included with a subtle dimmed hover effect
- Button remains hidden by default and appears after scrolling

---

#### Scope

- Global UI enhancement
- Self-contained feature
- No impact on existing functionality

---

#### Testing

- Verified on long pages (e.g. Global Activity Feed)
- Verified with both window scrolling and container scrolling
- Verified in light and dark modes

---

#### Screenshot

The following screenshot shows the “Back to Top” button as it appears after scrolling, positioned to the left of the chat widget to avoid overlap:

## Light-Mode

<img width="1916" height="910" alt="Screenshot 2026-01-15 153912" src="https://github.com/user-attachments/assets/4e0e6ee7-b267-435f-905d-501227fa2a5e" />

## Dark-Mode

<img width="1916" height="912" alt="back_to_top_button" src="https://github.com/user-attachments/assets/f0f5c8d0-e5cb-4eb4-bf91-b9e75eb19bac" />



If this approach aligns with the project’s direction, I’m happy to refine or adjust based on feedback.

Thanks !


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable "Back to Top" button site-wide via the base layout.
  * Button appears after scrolling, offers smooth scroll to top, and supports an explicit scroll container for correct behavior within scrollable regions.
  * Initializes on page load for consistent UX across pages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->