### PR TITLE
Fix inconsistent Page Stats panel behavior across desktop and mobile

### DIFF
--- a/website/templates/includes/page_stats.html
+++ b/website/templates/includes/page_stats.html
@@ -7,7 +7,10 @@
 <div id="pageStatsContainer"
      class="fixed bottom-0 left-4 z-50 transition-all duration-300 transform translate-y-[calc(100%-40px)] group">
     <!-- Chart Icon and Handle here -->
-    <div class="flex justify-center items-center h-10 w-16 mx-auto bg-white dark:bg-gray-800 rounded-t-lg shadow-md cursor-pointer">
+    <button type="button"
+            class="flex justify-center items-center h-10 w-16 mx-auto bg-white dark:bg-gray-800 rounded-t-lg shadow-md cursor-pointer"
+            aria-expanded="false"
+            aria-label="Toggle page statistics">
         <svg xmlns="http://www.w3.org/2000/svg"
              class="h-6 w-6 text-[#e74c3c]"
              fill="none"
@@ -15,7 +18,7 @@
              stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
         </svg>
-    </div>
+    </button>
     <!-- Stats Content -->
     <div class="bg-white dark:bg-gray-800 shadow-lg rounded-lg p-3 w-72">
         <div class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Page Views (Last 30 Days)</div>
@@ -254,12 +257,14 @@ document.addEventListener('DOMContentLoaded', function() {
 
     function openStats(mode) {
         openMode = mode;
+        handleElement.setAttribute('aria-expanded', 'true');
         pageStatsContainer.classList.remove('translate-y-[calc(100%-40px)]');
         pageStatsContainer.classList.add('translate-y-0');
     }
 
     function closeStats() {
         openMode = null;
+        handleElement.setAttribute('aria-expanded', 'false');
         pageStatsContainer.classList.remove('translate-y-0');
         pageStatsContainer.classList.add('translate-y-[calc(100%-40px)]');
     }
@@ -268,43 +273,46 @@ document.addEventListener('DOMContentLoaded', function() {
         return openMode !== null;
     }
 
-    handleElement.addEventListener('mouseenter', () => {
-        if (!isOpen()) {
-            openStats('hover');
-        }
-    });
+    const canHover = window.matchMedia('(hover: hover)').matches;
 
-    handleElement.addEventListener('click', (e) => {
-        e.preventDefault();
-        e.stopPropagation();
-        // If hover-open, convert to click-open (DO NOT toggle)
-        if (openMode === 'hover') {
-            openStats('click');
-            return;
-        }
-        // Normal toggle for click-open
-        if (openMode === 'click') {
-            closeStats();
-        } else {
-            openStats('click');
-        }
-    });
+    if(handleElement) {
+        // ✅ Hover preview ONLY on hover-capable devices
+    if (canHover) {
+        handleElement.addEventListener('mouseenter', () => {
+            if (!isOpen()) {
+                openStats('hover');
+            }
+        });
 
-    pageStatsContainer.addEventListener('mouseleave', () => {
-        if (openMode === 'hover') {
-            closeStats();
-        }
-    });
+        pageStatsContainer.addEventListener('mouseleave', () => {
+            if (openMode === 'hover') {
+                closeStats();
+            }
+        });
+    }
 
-    document.addEventListener('click', (e) => {
-        if (openMode !== 'click') return;
-        if (
-            !pageStatsContainer.contains(e.target) &&
-            !handleElement.contains(e.target)
-        ) {
-            closeStats();
-        }
-    });
+        // ✅ Click = mouse + touch + keyboard
+        handleElement.addEventListener('click', (e) => {
+            // Convert hover preview to persistent
+            if (openMode === 'hover') {
+                openStats('click');
+                return;
+            }
+            // Normal toggle for click-open
+            if (openMode === 'click') {
+                closeStats();
+            } else {
+                openStats('click');
+            }
+        });
+        // ✅ Click outside closes only persistent open
+        document.addEventListener('click', (e) => {
+            if (openMode !== 'click') return;
+            if ( !pageStatsContainer.contains(e.target )) {
+                closeStats();
+            }
+        });
+    }
     
     // CSRF token helper
     function getCookie(name) {

--- a/website/templates/includes/page_stats.html
+++ b/website/templates/includes/page_stats.html
@@ -5,7 +5,7 @@
 {% get_page_votes current_template as upvotes %}
 {% get_page_votes current_template "downvote" as downvotes %}
 <div id="pageStatsContainer"
-     class="fixed bottom-0 left-4 z-50 transition-all duration-300 transform translate-y-[calc(100%-40px)] hover:translate-y-0 group">
+     class="fixed bottom-0 left-4 z-50 transition-all duration-300 transform translate-y-[calc(100%-40px)] group">
     <!-- Chart Icon and Handle here -->
     <div class="flex justify-center items-center h-10 w-16 mx-auto bg-white dark:bg-gray-800 rounded-t-lg shadow-md cursor-pointer">
         <svg xmlns="http://www.w3.org/2000/svg"
@@ -249,31 +249,60 @@ document.addEventListener('DOMContentLoaded', function() {
     
     // Toggle container on click of the handle
     const handleElement = pageStatsContainer.querySelector('.flex.justify-center');
-    if (handleElement) {
-        handleElement.addEventListener('click', function(e) {
-            e.preventDefault();
-            if (pageStatsContainer.classList.contains('translate-y-0')) {
-                pageStatsContainer.classList.remove('translate-y-0');
-                pageStatsContainer.classList.add('translate-y-[calc(100%-40px)]');
-            } else {
-                pageStatsContainer.classList.remove('translate-y-[calc(100%-40px)]');
-                pageStatsContainer.classList.add('translate-y-0');
-            }
-        });
+
+    let openMode = null; // 'hover' | 'click' | null
+
+    function openStats(mode) {
+        openMode = mode;
+        pageStatsContainer.classList.remove('translate-y-[calc(100%-40px)]');
+        pageStatsContainer.classList.add('translate-y-0');
     }
-    
-    // Add touch support for mobile devices
-    pageStatsContainer.addEventListener('touchstart', function(e) {
-        // Only handle touch events on the handle element
-        if (e.target.closest('.flex.justify-center')) {
-            e.preventDefault();
-            if (pageStatsContainer.classList.contains('translate-y-0')) {
-                pageStatsContainer.classList.remove('translate-y-0');
-                pageStatsContainer.classList.add('translate-y-[calc(100%-40px)]');
-            } else {
-                pageStatsContainer.classList.remove('translate-y-[calc(100%-40px)]');
-                pageStatsContainer.classList.add('translate-y-0');
-            }
+
+    function closeStats() {
+        openMode = null;
+        pageStatsContainer.classList.remove('translate-y-0');
+        pageStatsContainer.classList.add('translate-y-[calc(100%-40px)]');
+    }
+
+    function isOpen() {
+        return openMode !== null;
+    }
+
+    handleElement.addEventListener('mouseenter', () => {
+        if (!isOpen()) {
+            openStats('hover');
+        }
+    });
+
+    handleElement.addEventListener('click', (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        // If hover-open, convert to click-open (DO NOT toggle)
+        if (openMode === 'hover') {
+            openStats('click');
+            return;
+        }
+        // Normal toggle for click-open
+        if (openMode === 'click') {
+            closeStats();
+        } else {
+            openStats('click');
+        }
+    });
+
+    pageStatsContainer.addEventListener('mouseleave', () => {
+        if (openMode === 'hover') {
+            closeStats();
+        }
+    });
+
+    document.addEventListener('click', (e) => {
+        if (openMode !== 'click') return;
+        if (
+            !pageStatsContainer.contains(e.target) &&
+            !handleElement.contains(e.target)
+        ) {
+            closeStats();
         }
     });
     


### PR DESCRIPTION
## Fix Page Stats panel interaction issues (closes #5501)

### Summary
This PR fixes multiple UX issues with the Page Stats panel, where the container was opening unintentionally, **like hovering ( clicking in mobile ) to the left or right side of the icon ( in the width of the panel )**, closing unexpectedly, and behaving inconsistently across desktop and mobile devices.

The interaction logic has been refined to clearly distinguish between **hover-based preview behavior** and **click-based intentional behavior**, resulting in a more predictable and user-friendly experience.

---

### Problems Addressed

- The Page Stats panel could open when the cursor was merely near the icon, rather than directly interacting with it.
- On desktop, the panel could close unexpectedly when the mouse moved out of the container, even after an intentional click.
- On mobile devices, clicking to the left or right of the icon opens the panel, and closing the panel by clicking outside does not work on desktop and mobile devices.
- Hover and click interactions were previously treated the same, leading to conflicting behavior.

---

### What Changed

- Introduced a clear distinction between **hover-opened (temporary preview)** and **click-opened (persistent)** panel states.
- Hovering over the stats icon now opens the panel as a preview.
- Clicking the icon while hovered converts the panel into a persistent, click-opened state instead of closing it.
- The panel now:
  - Closes on mouse leave only if it was opened via hover.
  - Remains open on mouse leave if it was opened via click.
  - Closes reliably when clicking outside or clicking the icon again.
- Mobile behavior is now consistent, opens only on clicking the icon, and closes on clicking the icon or outside the panel.

---

### Resulting Behavior

- Hover on icon → panel opens (preview)
- Mouse leaves container (hover-open) → panel closes
- Click on icon → panel opens and stays open
- Mouse leaves container (click-open) → panel remains open
- Click outside panel → panel closes
- Click icon again → panel closes
- Mobile interactions now work without requiring repeated taps

---

### Why This Approach

- Prevents accidental activation while preserving quick hover previews on desktop.
- Ensures intentional user actions (clicks) are respected.
- Avoids hover-only or proximity-based logic that causes unpredictable behavior.
- Keeps changes scoped and non-invasive to existing layout and animations.

---

### The changes could be seen in these videos:


https://github.com/user-attachments/assets/60e28804-52ae-442a-bd1d-f0f7d7984b01


https://github.com/user-attachments/assets/0b1b8651-3703-4961-8b18-1d72091a0c77



### Related Issue
Closes **#5501**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Page stats panel now supports explicit open/close modes with hover and click behaviors, including persistent open via click.
  * Click-outside closes the panel when in click-open mode.
* **Accessibility**
  * Toggle control updated with ARIA attributes and improved keyboard/mouse interaction for better screen-reader support.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->