### PR TITLE
Prevent infinite retry loop during Chart.js initialization

### DIFF
--- a/website/templates/includes/page_stats.html
+++ b/website/templates/includes/page_stats.html
@@ -20,7 +20,12 @@
     <div class="bg-white dark:bg-gray-800 shadow-lg rounded-lg p-3 w-72">
         <div class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Page Views (Last 30 Days)</div>
         <!-- Bar Chart -->
-        <div class="mb-3">
+        <div class="mb-3 relative h-[120px]">
+            <!-- Chart status message -->
+            <div id="pageViewsChartStatus"
+                 class="absolute inset-0 flex items-center justify-center text-xs text-[#e74c3c] text-center pointer-events-none">
+                Preparing chart…
+            </div>
             <canvas id="pageViewsChart" height="120"></canvas>
         </div>
         <!-- Vote Buttons -->
@@ -57,14 +62,24 @@
 </div>
 <script>
 document.addEventListener('DOMContentLoaded', function() {
+    const chartStatusEl = document.getElementById('pageViewsChartStatus');
+
     let chartInitAttempts = 0;
-    const MAX_CHART_INIT_ATTEMPTS = 50;
+    const MAX_CHART_INIT_ATTEMPTS = 50;  // 50 attempts × 100ms = 5 seconds total
     const initializeChart = function() {
         // Wait for Chart.js to be available
         if (typeof Chart === 'undefined') {
             chartInitAttempts++;
+        // Still retrying → show loading message
+        if (chartStatusEl) {
+            chartStatusEl.textContent = 'Preparing chart…';
+        }
 
             if (chartInitAttempts >= MAX_CHART_INIT_ATTEMPTS) {
+                if (chartStatusEl) {
+                    chartStatusEl.textContent =
+                    'Chart unavailable. Try refreshing the page.';
+                }
                 return;
             }
             setTimeout(initializeChart, 100);
@@ -72,6 +87,9 @@ document.addEventListener('DOMContentLoaded', function() {
         }
         
         const ctx = document.getElementById('pageViewsChart').getContext('2d');
+        if (chartStatusEl) {
+            chartStatusEl.style.display = 'none';
+        }
         
         // Initialize default empty data structure
         let viewsByDate = {};

--- a/website/templates/includes/page_stats.html
+++ b/website/templates/includes/page_stats.html
@@ -57,9 +57,16 @@
 </div>
 <script>
 document.addEventListener('DOMContentLoaded', function() {
+    let chartInitAttempts = 0;
+    const MAX_CHART_INIT_ATTEMPTS = 50;
     const initializeChart = function() {
         // Wait for Chart.js to be available
         if (typeof Chart === 'undefined') {
+            chartInitAttempts++;
+
+            if (chartInitAttempts >= MAX_CHART_INIT_ATTEMPTS) {
+                return;
+            }
             setTimeout(initializeChart, 100);
             return;
         }


### PR DESCRIPTION
## Summary

This PR improves the safety of the Chart.js initialization logic used in the Page Stats widget by adding a bounded retry mechanism.

Previously, the chart initialization relied on an unbounded `setTimeout` retry loop that could run indefinitely if Chart.js failed to load (for example due to a blocked CDN, network error, or content blocker). While functional in normal cases, this behavior could negatively impact performance and make failures harder to diagnose.

This change limits the number of retry attempts while preserving existing behavior when Chart.js loads successfully.

---

## Previous behavior

The previous implementation followed this pattern:

- On `DOMContentLoaded`, attempt to initialize the chart
- If the global `Chart` object was not yet available:
  - Retry initialization using `setTimeout(initializeChart, 100)`
  - Repeat this indefinitely until `Chart` becomes available

In the common case where Chart.js loads correctly, this works fine.

However, if the Chart.js script **never loads** (e.g. CDN blocked, offline network, ad-blocker, CSP restriction):

- The retry loop continues forever
- `initializeChart` keeps scheduling itself every 100ms
- There is no upper bound or exit condition

---

## Why this is a problem

While subtle, an infinite retry loop can cause:

- Unnecessary CPU wake-ups every 100ms
- Persistent background work on every page load
- Hard-to-trace performance degradation in production
- Silent failure with no clear indication that the chart will never initialize

This is especially relevant for users on constrained devices or restricted networks, where external scripts may not load reliably.

---

## What this PR changes

This PR introduces a simple retry counter with a maximum limit:

- The chart initialization will retry a finite number of times (e.g. ~5 seconds total)
- If Chart.js does not become available within that window, retries stop
- When Chart.js loads normally, behavior is unchanged
- No user-facing behavior is altered in the success case

The change is intentionally minimal and scoped only to the initialization guard.

---


## Result

- Prevents infinite retry loops in failure scenarios
- Improves performance robustness in production
- Keeps existing functionality unchanged when Chart.js loads correctly
- Makes the initialization logic safer and easier to reason about

---

### Thanks to @S3DFX-CYBER  for pointing out the unbounded retry loop risk in the Chart.js initialization.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Page statistics chart is more resilient to delayed library loading with automatic retry and graceful handling when unavailable.
* **User Experience**
  * Shows a loading status while the chart initializes and a clear message if the chart cannot be displayed. Hides the status once the chart is ready.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->