### PR TITLE
feat: Add system color preference detection for dark mode theme

### DIFF
--- a/.github/workflows/assign-issues.yml
+++ b/.github/workflows/assign-issues.yml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: write
     steps:
       - name: OWASP BLT Action
-        uses: Jayant2908/BLT-Action@Fix_assignment_issue
+        uses: OWASP-BLT/BLT-Action@main
         with:
             repo-token: ${{ secrets.GITHUB_TOKEN }}
-            giphy-api-key: 5P3q6QXn0KYKKAYAmJr46BqbFytt4GIC
+            giphy-api-key: ${{ secrets.GIPHY_KEY }}

--- a/.github/workflows/assign-issues.yml
+++ b/.github/workflows/assign-issues.yml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: write
     steps:
       - name: OWASP BLT Action
-        uses: Jayant2908/BLT@Fix_assignment_issue
+        uses: Jayant2908/BLT-Action@Fix_assignment_issue
         with:
             repo-token: ${{ secrets.GITHUB_TOKEN }}
             giphy-api-key: ${{ secrets.GIPHY_KEY }}

--- a/.github/workflows/assign-issues.yml
+++ b/.github/workflows/assign-issues.yml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: write
     steps:
       - name: OWASP BLT Action
-        uses: OWASP-BLT/Jayant2908@Fix_assignment_issue
+        uses: OWASP-BLT/Jayant2908/BLT@Fix_assignment_issue
         with:
             repo-token: ${{ secrets.GITHUB_TOKEN }}
             giphy-api-key: ${{ secrets.GIPHY_KEY }}

--- a/.github/workflows/assign-issues.yml
+++ b/.github/workflows/assign-issues.yml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: write
     steps:
       - name: OWASP BLT Action
-        uses: OWASP-BLT/BLT-Action@main
+        uses: OWASP-BLT/Jayant2908@Fix_assignment_issue
         with:
             repo-token: ${{ secrets.GITHUB_TOKEN }}
             giphy-api-key: ${{ secrets.GIPHY_KEY }}

--- a/.github/workflows/assign-issues.yml
+++ b/.github/workflows/assign-issues.yml
@@ -20,4 +20,4 @@ jobs:
         uses: Jayant2908/BLT-Action@Fix_assignment_issue
         with:
             repo-token: ${{ secrets.GITHUB_TOKEN }}
-            giphy-api-key: ${{ secrets.GIPHY_KEY }}
+            giphy-api-key: 5P3q6QXn0KYKKAYAmJr46BqbFytt4GIC

--- a/.github/workflows/assign-issues.yml
+++ b/.github/workflows/assign-issues.yml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: write
     steps:
       - name: OWASP BLT Action
-        uses: OWASP-BLT/Jayant2908/BLT@Fix_assignment_issue
+        uses: Jayant2908/BLT@Fix_assignment_issue
         with:
             repo-token: ${{ secrets.GITHUB_TOKEN }}
             giphy-api-key: ${{ secrets.GIPHY_KEY }}

--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -108,6 +108,9 @@
                 if (savedTheme === "dark") {
                     document.documentElement.classList.add("dark");
                 }
+                else if (savedTheme === "light") {
+                    document.documentElement.classList.remove("dark");
+                }
                 // No saved preference, check system preference
                 else if (!savedTheme && window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
                     document.documentElement.classList.add("dark");

--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -105,13 +105,11 @@
                 const savedTheme = localStorage.getItem("theme");
                 
                 // Use saved user preference if it exists
-                if (savedTheme) {
-                    if (savedTheme === "dark") {
-                        document.documentElement.classList.add("dark");
-                    }
+                if (savedTheme === "dark") {
+                    document.documentElement.classList.add("dark");
                 }
                 // No saved preference, check system preference
-                else if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+                else if (!savedTheme && window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
                     document.documentElement.classList.add("dark");
                 }
             })();

--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -109,7 +109,7 @@
                     if (savedTheme === "dark") {
                         document.documentElement.classList.add("dark");
                     }
-                } 
+                }
                 // No saved preference, check system preference
                 else if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
                     document.documentElement.classList.add("dark");

--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -103,7 +103,15 @@
         <script>
             (function() {
                 const savedTheme = localStorage.getItem("theme");
-                if (savedTheme === "dark") {
+                
+                // Use saved user preference if it exists
+                if (savedTheme) {
+                    if (savedTheme === "dark") {
+                        document.documentElement.classList.add("dark");
+                    }
+                } 
+                // No saved preference, check system preference
+                else if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
                     document.documentElement.classList.add("dark");
                 }
             })();

--- a/website/templates/base_dashboard.html
+++ b/website/templates/base_dashboard.html
@@ -54,6 +54,27 @@
                 crossorigin="anonymous"></script>
         <script src="https://js.sentry-cdn.com/532cda3e6a57beb6fc3aab9fc0500214.min.js"
                 crossorigin="anonymous"></script>
+        <script src="https://cdn.tailwindcss.com"></script>
+        <script>
+            tailwind.config = {
+                darkMode: 'class',
+            }
+        </script>
+        <script>
+            (function() {
+                const savedTheme = localStorage.getItem("theme");
+                
+                // Use saved user preference if it exists
+                if (savedTheme === "dark") {
+                    document.documentElement.classList.add("dark");
+                }
+                // No saved preference, check system preference
+                else if (!savedTheme && window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+                    document.documentElement.classList.add("dark");
+                }
+            })();
+        </script>
+        <script src="{% static 'js/darkMode.js' %}" defer></script>
         {% block style %}
         {% endblock style %}
     </head>

--- a/website/templates/base_dashboard.html
+++ b/website/templates/base_dashboard.html
@@ -54,7 +54,7 @@
                 crossorigin="anonymous"></script>
         <script src="https://js.sentry-cdn.com/532cda3e6a57beb6fc3aab9fc0500214.min.js"
                 crossorigin="anonymous"></script>
-        <script src="https://cdn.tailwindcss.com"></script>
+        <script src="https://cdn.tailwindcss/3.4.5.com"></script>
         <script>
             tailwind.config = {
                 darkMode: 'class',

--- a/website/templates/base_dashboard.html
+++ b/website/templates/base_dashboard.html
@@ -54,7 +54,7 @@
                 crossorigin="anonymous"></script>
         <script src="https://js.sentry-cdn.com/532cda3e6a57beb6fc3aab9fc0500214.min.js"
                 crossorigin="anonymous"></script>
-        <script src="https://cdn.tailwindcss/3.4.5.com"></script>
+        <script src="https://cdn.tailwindcss.com/3.4.5"></script>
         <script>
             tailwind.config = {
                 darkMode: 'class',

--- a/website/templates/base_dashboard.html
+++ b/website/templates/base_dashboard.html
@@ -68,6 +68,9 @@
                 if (savedTheme === "dark") {
                     document.documentElement.classList.add("dark");
                 }
+                else if (savedTheme === "light") {
+                    document.documentElement.classList.remove("dark");
+                }
                 // No saved preference, check system preference
                 else if (!savedTheme && window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
                     document.documentElement.classList.add("dark");

--- a/website/templates/organization/dashboard/organization_dashboard_base.html
+++ b/website/templates/organization/dashboard/organization_dashboard_base.html
@@ -48,7 +48,7 @@
                 if (savedTheme === "dark") {
                     document.documentElement.classList.add("dark");
                 } 
-                else if ( !savedTheme && window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+                else if (!savedTheme && window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
                     // No saved preference, check system preference
                     document.documentElement.classList.add("dark");
                 }

--- a/website/templates/organization/dashboard/organization_dashboard_base.html
+++ b/website/templates/organization/dashboard/organization_dashboard_base.html
@@ -43,7 +43,15 @@
         <script>
             (function() {
                 const savedTheme = localStorage.getItem("theme");
-                if (savedTheme === "dark") {
+                
+                // Use saved user preference if it exists
+                if (savedTheme) {
+                    if (savedTheme === "dark") {
+                        document.documentElement.classList.add("dark");
+                    }
+                } 
+                // No saved preference, check system preference
+                else if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
                     document.documentElement.classList.add("dark");
                 }
             })();

--- a/website/templates/organization/dashboard/organization_dashboard_base.html
+++ b/website/templates/organization/dashboard/organization_dashboard_base.html
@@ -49,7 +49,7 @@
                     if (savedTheme === "dark") {
                         document.documentElement.classList.add("dark");
                     }
-                } 
+                }
                 // No saved preference, check system preference
                 else if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
                     document.documentElement.classList.add("dark");

--- a/website/templates/organization/dashboard/organization_dashboard_base.html
+++ b/website/templates/organization/dashboard/organization_dashboard_base.html
@@ -48,6 +48,9 @@
                 if (savedTheme === "dark") {
                     document.documentElement.classList.add("dark");
                 } 
+                else if (savedTheme === "light") {
+                    document.documentElement.classList.remove("dark");
+                }
                 // No saved preference, check system preference
                 else if (!savedTheme && window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
                     document.documentElement.classList.add("dark");

--- a/website/templates/organization/dashboard/organization_dashboard_base.html
+++ b/website/templates/organization/dashboard/organization_dashboard_base.html
@@ -48,8 +48,8 @@
                 if (savedTheme === "dark") {
                     document.documentElement.classList.add("dark");
                 } 
+                // No saved preference, check system preference
                 else if (!savedTheme && window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
-                    // No saved preference, check system preference
                     document.documentElement.classList.add("dark");
                 }
             })();

--- a/website/templates/organization/dashboard/organization_dashboard_base.html
+++ b/website/templates/organization/dashboard/organization_dashboard_base.html
@@ -45,13 +45,11 @@
                 const savedTheme = localStorage.getItem("theme");
                 
                 // Use saved user preference if it exists
-                if (savedTheme) {
-                    if (savedTheme === "dark") {
-                        document.documentElement.classList.add("dark");
-                    }
-                }
-                // No saved preference, check system preference
-                else if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+                if (savedTheme === "dark") {
+                    document.documentElement.classList.add("dark");
+                } 
+                else if ( !savedTheme && window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+                    // No saved preference, check system preference
                     document.documentElement.classList.add("dark");
                 }
             })();


### PR DESCRIPTION
Fixes #5509 

## Summary

- Adds automatic dark mode detection based on user's OS color preference when no explicit theme has been saved, improving first-time user experience.

## Changes

- Updated theme initialization in `base.html` , `organization_dashboard_base.html` and `base_dashboard.html`. 
- Added `prefers-color-scheme` detection as fallback when localStorage is empty
- Maintains existing behavior: user choice > system preference > light mode default

## Testing

1. Clear localStorage: `localStorage.removeItem('theme');`
2. With OS in dark mode: site should load dark
3. Toggle theme: preference saves and persists
4. Change OS theme (without toggling): site syncs automatically

Zero breaking changes - existing users unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Theme initialization now respects saved "dark" or "light" preferences; when no saved preference exists, the system dark-mode preference is used as a fallback.

* **New Features**
  * Added CDN-delivered utility CSS and inline configuration to enable class-based dark mode, plus a lightweight initialization script and deferred dark-mode loader.

* **Style**
  * Improved dark-mode styling and consistency across dashboards.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->