### PR TITLE
fix: Use explicit UTC for month boundary calculations

### DIFF
--- a/.github/workflows/assign-issues.yml
+++ b/.github/workflows/assign-issues.yml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: write
     steps:
       - name: OWASP BLT Action
-        uses: Jayant2908/BLT-Action@Fix_assignment_issue
+        uses: OWASP-BLT/BLT-Action@main
         with:
             repo-token: ${{ secrets.GITHUB_TOKEN }}
-            giphy-api-key: 5P3q6QXn0KYKKAYAmJr46BqbFytt4GIC
+            giphy-api-key: ${{ secrets.GIPHY_KEY }}

--- a/.github/workflows/assign-issues.yml
+++ b/.github/workflows/assign-issues.yml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: write
     steps:
       - name: OWASP BLT Action
-        uses: Jayant2908/BLT@Fix_assignment_issue
+        uses: Jayant2908/BLT-Action@Fix_assignment_issue
         with:
             repo-token: ${{ secrets.GITHUB_TOKEN }}
             giphy-api-key: ${{ secrets.GIPHY_KEY }}

--- a/.github/workflows/assign-issues.yml
+++ b/.github/workflows/assign-issues.yml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: write
     steps:
       - name: OWASP BLT Action
-        uses: OWASP-BLT/Jayant2908@Fix_assignment_issue
+        uses: OWASP-BLT/Jayant2908/BLT@Fix_assignment_issue
         with:
             repo-token: ${{ secrets.GITHUB_TOKEN }}
             giphy-api-key: ${{ secrets.GIPHY_KEY }}

--- a/.github/workflows/assign-issues.yml
+++ b/.github/workflows/assign-issues.yml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: write
     steps:
       - name: OWASP BLT Action
-        uses: OWASP-BLT/BLT-Action@main
+        uses: OWASP-BLT/Jayant2908@Fix_assignment_issue
         with:
             repo-token: ${{ secrets.GITHUB_TOKEN }}
             giphy-api-key: ${{ secrets.GIPHY_KEY }}

--- a/.github/workflows/assign-issues.yml
+++ b/.github/workflows/assign-issues.yml
@@ -20,4 +20,4 @@ jobs:
         uses: Jayant2908/BLT-Action@Fix_assignment_issue
         with:
             repo-token: ${{ secrets.GITHUB_TOKEN }}
-            giphy-api-key: ${{ secrets.GIPHY_KEY }}
+            giphy-api-key: 5P3q6QXn0KYKKAYAmJr46BqbFytt4GIC

--- a/.github/workflows/assign-issues.yml
+++ b/.github/workflows/assign-issues.yml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: write
     steps:
       - name: OWASP BLT Action
-        uses: OWASP-BLT/Jayant2908/BLT@Fix_assignment_issue
+        uses: Jayant2908/BLT@Fix_assignment_issue
         with:
             repo-token: ${{ secrets.GITHUB_TOKEN }}
             giphy-api-key: ${{ secrets.GIPHY_KEY }}

--- a/.github/workflows/leaderboard-bot.yml
+++ b/.github/workflows/leaderboard-bot.yml
@@ -44,14 +44,14 @@ jobs:
               return;
             }
             
-            // Get current month date range
+            // Get current month date range(UTC)
             const now = new Date();
-            const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1);
-            const endOfMonth = new Date(now.getFullYear(), now.getMonth() + 1, 0, 23, 59, 59);
+            const startOfMonth = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1, 0, 0, 0, 0));
+            const endOfMonth = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 0, 23, 59, 59, 999));
             
             // Calculate a reasonable lookback period for fetching PRs to check for reviews
             // We look back 3 months to catch reviews on older PRs while avoiding unbounded queries
-            const threeMonthsAgo = new Date(now.getFullYear(), now.getMonth() - 3, 1);
+            const threeMonthsAgo = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - 3, 1));
             
             core.info(`Fetching stats for ${startOfMonth.toISOString()} to ${endOfMonth.toISOString()}`);
             


### PR DESCRIPTION
Fixes #5493 

The leaderboard bot workflow currently uses local timezone for calculating month boundaries, but the GitHub API returns timestamps in UTC. This can cause PRs merged near month boundaries (within ~24 hours of month end/start) to be counted in the wrong month.

Edge Case Example:-

Scenario: PR merged on Jan 31, 2026 at 11:00 PM PST (UTC-8)

UTC time: Feb 1, 7:00 AM
Impact: PR might be counted in January (wrong) or February (correct) depending on runner timezone

Changes:-

- Used explicit UTC methods for all date calculations to ensure consistency across all runners and timezones.
- Verified date calculations produce consistent UTC timestamps regardless of system timezone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed date calculations for leaderboard rankings to consistently use UTC-based time zone handling, ensuring accurate month boundaries and lookback windows regardless of user location.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->