### PR TITLE
fix: improve notification text visibility in dark mode

### DIFF
--- a/website/templates/includes/header.html
+++ b/website/templates/includes/header.html
@@ -1500,7 +1500,7 @@
                 notifications.forEach(notification => {
                     const notificationItem = document.createElement("div");
                     notificationItem.classList.add(
-                        "flex", "items-start", "gap-3", "p-3", "rounded-lg", "hover:bg-gray-100", "transition-colors",
+                        "flex", "items-start", "gap-3", "p-3", "rounded-lg", "hover:bg-gray-100", "transition-colors", "dark:hover:bg-gray-700",
                         !notification.is_read ? "bg-gray-50" : "bg-white", 
                         !notification.is_read ? "font-semibold" : "font-normal" 
                     );

--- a/website/templates/includes/header.html
+++ b/website/templates/includes/header.html
@@ -1500,7 +1500,7 @@
                 notifications.forEach(notification => {
                     const notificationItem = document.createElement("div");
                     notificationItem.classList.add(
-                        "flex", "items-start", "gap-3", "p-3", "rounded-lg", "hover:bg-gray-100", "transition-colors", "dark:hover:bg-gray-700",
+                        "flex", "items-start", "gap-3", "p-3", "rounded-lg", "hover:bg-gray-100", "transition-colors", "dark:bg-gray-700",
                         !notification.is_read ? "bg-gray-50" : "bg-white", 
                         !notification.is_read ? "font-semibold" : "font-normal" 
                     );


### PR DESCRIPTION
## **Description**
Fixes : #5528 
notification body text in the header dropdown was too light and unreadable in dark mode.
this PR adjusts text colors to ensure proper contrast and readability.

## **Screenshot**

**Before**
<img width="243" height="362" alt="2026-01-23_20-46-02" src="https://github.com/user-attachments/assets/e3b55e8f-c727-420a-9412-0b9fb55ddf68" />

**After**
<img width="269" height="390" alt="2026-01-23_21-02-19" src="https://github.com/user-attachments/assets/af16ad1b-6dde-4116-b858-abcf91734234" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved dark-mode appearance of notification items by updating their background styling for better visual consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->