### PR TITLE
Fix duplicate quality labels on issues and PRs

### DIFF
--- a/.github/workflows/manage-quality-labels.yml
+++ b/.github/workflows/manage-quality-labels.yml
@@ -48,13 +48,16 @@ jobs:
               return
             }
 
-            const { data: labels } =
-              await github.rest.issues.listLabelsOnIssue({
+            const labels = await github.paginate(
+              github.rest.issues.listLabelsOnIssue,
+              {
                 owner,
                 repo,
                 issue_number: itemNumber,
                 per_page: 100
-              })
+              }
+            )
+
 
             for (const label of labels) {
               if (

--- a/.github/workflows/manage-quality-labels.yml
+++ b/.github/workflows/manage-quality-labels.yml
@@ -1,0 +1,71 @@
+name: Manage Quality Labels
+
+on:
+  issues:
+    types: [labeled]
+  pull_request_target:
+    types: [labeled]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  manage_quality_labels:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove conflicting quality labels
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            let itemNumber
+            let itemType
+
+            if (context.payload.pull_request) {
+              itemNumber = context.payload.pull_request.number
+              itemType = 'PR'
+            } else if (context.payload.issue) {
+              itemNumber = context.payload.issue.number
+              itemType = 'Issue'
+            } else {
+              return
+            }
+
+            const owner = context.repo.owner
+            const repo = context.repo.repo
+
+            const qualityLabels = [
+              'quality: high',
+              'quality: medium',
+              'quality: low'
+            ]
+
+            const newLabel = context.payload.label.name
+
+            if (!qualityLabels.includes(newLabel)) {
+              return
+            }
+
+            const { data: labels } =
+              await github.rest.issues.listLabelsOnIssue({
+                owner,
+                repo,
+                issue_number: itemNumber,
+                per_page: 100
+              })
+
+            for (const label of labels) {
+              if (
+                qualityLabels.includes(label.name) &&
+                label.name !== newLabel
+              ) {
+                await github.rest.issues.removeLabel({
+                  owner,
+                  repo,
+                  issue_number: itemNumber,
+                  name: label.name
+                })
+              }
+            }


### PR DESCRIPTION
This PR adds a GitHub Actions workflow to ensure only one quality label
(quality: high / medium / low) exists on an issue or PR at any time.

When a new quality label is applied, any existing quality label
is automatically removed to avoid confusion for reviewers.

Fixes #5533

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated management of quality labels on issues and pull requests so only one quality level (high, medium, low) is assigned at a time. When a quality label is added, any conflicting quality labels are removed automatically, helping keep issue and PR labeling consistent across the project.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->