### PR TITLE
docs: clarify Docker Desktop Linux containers behavior on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,21 @@ docker-compose up
 
 Access the application at **http://localhost:8000**
 
+
+##### Docker Desktop (Windows)
+
+This project uses Linux containers.
+
+On modern Docker Desktop (WSL 2–based), Linux containers are enabled by default.
+You may not see a “Switch to Linux containers” option in the Docker tray menu — this is expected.
+
+If Docker Desktop is running and the following command shows `OSType: linux`,
+then your setup is correct and no additional action is required:
+
+```bash
+docker info | findstr OSType
+```
+
 #### Using Poetry
 ```bash
 # Install dependencies


### PR DESCRIPTION
This PR improves Windows onboarding documentation by clarifying Docker Desktop Linux container behavior on WSL2-based setups.

It explains why the "Switch to Linux containers" option may not be visible and provides a simple command to verify the container OS type.

This should reduce confusion for first-time Windows contributors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Docker Desktop (Windows) guidance, including WSL 2 setup information and verification instructions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->