### PR TITLE
add carla to gsoc add_carla_gsoc_mentors

### DIFF
--- a/website/templates/gsoc.html
+++ b/website/templates/gsoc.html
@@ -796,6 +796,30 @@
                                     </p>
                                 </div>
                             </div>
+                               <!-- Carla Voorhees -->
+                            <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4 border border-gray-200 dark:border-gray-700">
+                                <div class="flex items-center gap-3 mb-3">
+                                    <div class="w-10 h-10 bg-red-100 rounded-full flex items-center justify-center">
+                                        <i class="fas fa-code text-[#e74c3c] text-sm"></i>
+                                    </div>
+                                    <div>
+                                        <h4 class="text-lg font-bold text-gray-900 dark:text-gray-100">Carla Voorhees</h4>
+                                        <p class="text-sm text-gray-600 dark:text-gray-400">Technical Product Manager</p>
+                                    </div>
+                                </div>
+                                <div class="mentor-description-container">
+                                    <p class="text-gray-600 dark:text-gray-400 text-base leading-relaxed mentor-description-text">
+                                        I am a technical product manager with a background in cybersecurity 
+                                        and data management. I have experience mentoring students, 
+                                        helping them navigate complex requirements and understand best practices. 
+                                        I focus on guiding students through the product development lifecycle, 
+                                        from ideation to deployment, while fostering a collaborative and 
+                                        inclusive learning environment. I help them to understand how to take 
+                                        requirements and designs and turn them into working code. My goal is to empower 
+                                        students to become confident contributors to open source communities.
+                                    </p>
+                                </div>
+                            </div>
                         </div>
                     </div>
                     <!-- Siddharth Bansal -->

--- a/website/templates/gsoc.html
+++ b/website/templates/gsoc.html
@@ -796,7 +796,7 @@
                                     </p>
                                 </div>
                             </div>
-                               <!-- Carla Voorhees -->
+                            <!-- Carla Voorhees -->
                             <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4 border border-gray-200 dark:border-gray-700">
                                 <div class="flex items-center gap-3 mb-3">
                                     <div class="w-10 h-10 bg-red-100 rounded-full flex items-center justify-center">

--- a/website/templates/gsoc.html
+++ b/website/templates/gsoc.html
@@ -809,13 +809,13 @@
                                 </div>
                                 <div class="mentor-description-container">
                                     <p class="text-gray-600 dark:text-gray-400 text-base leading-relaxed mentor-description-text">
-                                        I am a technical product manager with a background in cybersecurity 
-                                        and data management. I have experience mentoring students, 
-                                        helping them navigate complex requirements and understand best practices. 
-                                        I focus on guiding students through the product development lifecycle, 
-                                        from ideation to deployment, while fostering a collaborative and 
-                                        inclusive learning environment. I help them to understand how to take 
-                                        requirements and designs and turn them into working code. My goal is to empower 
+                                        I am a technical product manager with a background in cybersecurity
+                                        and data management. I have experience mentoring students,
+                                        helping them navigate complex requirements and understand best practices.
+                                        I focus on guiding students through the product development lifecycle,
+                                        from ideation to deployment, while fostering a collaborative and
+                                        inclusive learning environment. I help them to understand how to take
+                                        requirements and designs and turn them into working code. My goal is to empower
                                         students to become confident contributors to open source communities.
                                     </p>
                                 </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new mentor profile for Carla Voorhees to the GSoC 2026 Students & Mentors section, placed immediately after the Vinamra Vaswani mentor tile.
  * No other mentor entries or site behavior were changed; placement preserves existing layout and styling.
  * Low-risk content addition with minimal impact.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->