### PR TITLE
chore: Add Akshay as a GSoC mentor

### DIFF
--- a/website/templates/gsoc.html
+++ b/website/templates/gsoc.html
@@ -925,6 +925,34 @@
                                 </div>
                             </div>
                         </div>
+                        <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+                            <!-- Akshay Behl -->
+                            <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4 border border-gray-200 dark:border-gray-700">
+                                <div class="flex items-center gap-3 mb-3">
+                                    <div class="w-10 h-10 bg-red-100 rounded-full flex items-center justify-center">
+                                        <i class="fas fa-code text-[#e74c3c] text-sm"></i>
+                                    </div>
+                                    <div>
+                                        <h4 class="text-lg font-bold text-gray-900 dark:text-gray-100">Akshay Behl</h4>
+                                        <p class="text-sm text-gray-600 dark:text-gray-400">Full Stack / Systems Firmware</p>
+                                    </div>
+                                </div>
+                                <div class="mentor-description-container">
+                                    <p class="text-gray-600 dark:text-gray-400 text-base leading-relaxed mentor-description-text">
+                                        I’m a full-stack developer at Akatsuki AI Technologies in Japan,
+                                        blending a love for building scalable applications with a deep,
+                                        technical foundation in system firmware. My journey through GSoC
+                                        where I contributed with OWASP Project Nettacker and then with the
+                                        RISC-V community's OpenSBI and EDKII have made me a lifelong advocate for
+                                        open source. I know exactly how it feels to stare at a massive,
+                                        complex codebase for the first time, which is why I believe in
+                                        mentorships like GSoC. I believe the best software isn't built in isolation,
+                                        it’s the result of curiosity, community, and the collective push
+                                        of open source that makes the most meaningful impact.
+                                    </p>
+                                </div>
+                            </div>
+                        </div>
                     </div>
                     <!-- Arnav Kirti -->
                     <div class="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-100 dark:border-gray-800 p-8">


### PR DESCRIPTION
Added a new mentor profile for myself (Akshay Behl) to the GSoC 2026 Students & Mentors section, placed immediately after Sakshee Suman mentor tile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new mentor profile to the GSOC section (name, role, biography, and social links). The profile is integrated into the existing mentor layout alongside the current mentor and does not change any existing behavior or public interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->