### PR TITLE
Update GSoC 2026 page: Use '2026 Contributors' heading and labels 

### DIFF
--- a/website/templates/gsoc.html
+++ b/website/templates/gsoc.html
@@ -650,7 +650,7 @@
             </div>
             <!-- GSoC 2026 Students Section -->
             <div class="mb-20">
-                <h2 class="text-3xl font-bold text-center text-gray-900 dark:text-gray-100 mb-2">GSoC 2026 Students & Mentors</h2>
+                <h2 class="text-3xl font-bold text-center text-gray-900 dark:text-gray-100 mb-2">2026 Contributors</h2>
                 <div class="w-20 h-1 bg-[#e74c3c] mx-auto mb-12 rounded-full"></div>
                 <div class="flex items-start space-x-6 mb-8">
                     <div class="bg-red-100 rounded-full p-3 flex-shrink-0">
@@ -670,7 +670,7 @@
                             </div>
                             <div class="flex-1">
                                 <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100">Md Kaif Ansari</h3>
-                                <p class="text-lg text-gray-600 dark:text-gray-400 mb-2">GSoC 2026 Student</p>
+                                <p class="text-lg text-gray-600 dark:text-gray-400 mb-2">2026 Contributor</p>
                                 <div class="flex gap-4">
                                     <a href="https://github.com/mdkaifansari04"
                                        target="_blank"
@@ -749,7 +749,7 @@
                             </div>
                             <div class="flex-1">
                                 <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100">Preetham</h3>
-                                <p class="text-lg text-gray-600 dark:text-gray-400 mb-2">GSoC 2026 Student</p>
+                                <p class="text-lg text-gray-600 dark:text-gray-400 mb-2">2026 Contributor</p>
                                 <div class="flex gap-4">
                                     <a href="https://github.com/Pritz395"
                                        target="_blank"
@@ -830,7 +830,7 @@
                             </div>
                             <div class="flex-1">
                                 <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100">Siddharth Bansal</h3>
-                                <p class="text-lg text-gray-600 dark:text-gray-400 mb-2">GSoC 2026 Student</p>
+                                <p class="text-lg text-gray-600 dark:text-gray-400 mb-2">2026 Contributor</p>
                                 <div class="flex gap-4">
                                     <a href="https://github.com/sidd190"
                                        target="_blank"
@@ -906,7 +906,7 @@
                             </div>
                             <div class="flex-1">
                                 <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100">Sakshee Suman</h3>
-                                <p class="text-lg text-gray-600 dark:text-gray-400 mb-2">GSoC 2026 Student</p>
+                                <p class="text-lg text-gray-600 dark:text-gray-400 mb-2">2026 Contributor</p>
                                 <div class="flex gap-4">
                                     <a href="https://github.com/e-esakman"
                                        target="_blank"
@@ -934,7 +934,7 @@
                             </div>
                             <div class="flex-1">
                                 <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100">Arnav Kirti</h3>
-                                <p class="text-lg text-gray-600 dark:text-gray-400 mb-2">GSoC 2026 Student</p>
+                                <p class="text-lg text-gray-600 dark:text-gray-400 mb-2">2026 Contributor</p>
                                 <div class="flex gap-4">
                                     <a href="https://github.com/arnavkirti"
                                        target="_blank"


### PR DESCRIPTION
- Change section heading from 'GSoC 2026 Students & Mentors' to '2026 Contributors'
- Change contributor labels from 'GSoC 2026 Student' to '2026 Contributor' under each name

## Before
<img width="1470" height="712" alt="Screenshot 2026-02-07 at 1 44 39 AM" src="https://github.com/user-attachments/assets/073f757f-310f-4a8b-9de6-6bbcae473591" />

## After

https://github.com/user-attachments/assets/6778c416-a972-44f5-8b3c-978d1e521dad



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated GSoC 2026 section heading from "GSoC 2026 Students & Mentors" to "2026 Contributors"
  * Updated contributor labels throughout the page from "GSoC 2026 Student" to "2026 Contributor" for consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->