### PR TITLE
Add lazy-loading to high-priority frontend templates

### DIFF
--- a/website/templates/bacon.html
+++ b/website/templates/bacon.html
@@ -31,7 +31,8 @@
                             <!-- Overview Section -->
                             <section class="bg-white dark:bg-gray-800 rounded-xl shadow-sm p-8 mb-8">
                                 <div class="mb-8 -mx-8 -mt-8">
-                                    <img src="{% static 'images/bacon.webp' %}"
+                                    <img loading="lazy"
+                                         src="{% static 'images/bacon.webp' %}"
                                          alt="BACON Project Image"
                                          class="w-full h-auto object-cover rounded-t-xl"
                                          height="auto"
@@ -230,13 +231,15 @@
                                             <div class="flex items-start justify-between mb-4">
                                                 <div class="flex items-center gap-3">
                                                     {% if submission.user.userprofile.avatar %}
-                                                        <img src="{{ submission.user.userprofile.avatar }}"
+                                                        <img loading="lazy"
+                                                             src="{{ submission.user.userprofile.avatar }}"
                                                              alt="{{ submission.user.username }}"
                                                              class="w-10 h-10 rounded-full"
                                                              width="40"
                                                              height="40">
                                                     {% else %}
-                                                        <img src="{% gravatar_url submission.user.email 40 %}"
+                                                        <img loading="lazy"
+                                                             src="{% gravatar_url submission.user.email 40 %}"
                                                              alt="{{ submission.user.username }}"
                                                              class="w-10 h-10 rounded-full"
                                                              width="40"
@@ -259,7 +262,8 @@
                                             <div class="space-y-2 text-sm text-gray-600 dark:text-gray-400">
                                                 <p class="flex items-center gap-2">
                                                     <i class="fas fa-code-branch w-5"></i>
-                                                    <span class="font-medium">Type:</span> {{ submission.get_contribution_type_display }}
+                                                    <span class="font-medium">Type:</span> {{
+                                                    submission.get_contribution_type_display }}
                                                 </p>
                                                 <p class="flex items-center gap-2">
                                                     <i class="fas fa-exchange-alt w-5"></i>
@@ -345,22 +349,22 @@
     </div>
     <script>
         document.getElementById("baconForm").addEventListener("submit", function(event) {
-            event.preventDefault();
-        
-            const formData = {
-                github_url: document.getElementById("github_url").value,
-                contribution_type: document.getElementById("contribution_type").value,
-                description: document.getElementById("description").value
-            };
+        event.preventDefault();
 
-            fetch("/api/bacon/submit/", {
-                method: "POST",
-                headers: {
-                    "Content-Type": "application/json",
-                    "X-CSRFToken": "{{ csrf_token }}"
-                },
-                body: JSON.stringify(formData)
-            })
+        const formData = {
+            github_url: document.getElementById("github_url").value,
+            contribution_type: document.getElementById("contribution_type").value,
+            description: document.getElementById("description").value
+        };
+
+        fetch("/api/bacon/submit/", {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                "X-CSRFToken": "{{ csrf_token }}"
+            },
+            body: JSON.stringify(formData)
+        })
             .then(response => response.json())
             .then(data => {
                 if (data.message) {
@@ -375,32 +379,32 @@
                 console.error("Error:", error);
                 alert("An unexpected error occurred.");
             });
-        });
+    });
 
-        function toggleDescription(id) {
-            let desc = document.getElementById("description-" + id);
-            desc.classList.toggle("hidden");
-        }
+    function toggleDescription(id) {
+        let desc = document.getElementById("description-" + id);
+        desc.classList.toggle("hidden");
+    }
 
-        function toggleInspect(id) {
-            let inspectBox = document.getElementById("inspect-" + id);
-            inspectBox.classList.toggle("hidden");
-        }
+    function toggleInspect(id) {
+        let inspectBox = document.getElementById("inspect-" + id);
+        inspectBox.classList.toggle("hidden");
+    }
 
-        function updateSubmission(id, status) {
-            let baconAmount = document.getElementById("bacon-input-" + id).value;
+    function updateSubmission(id, status) {
+        let baconAmount = document.getElementById("bacon-input-" + id).value;
 
-            fetch(`/update-submission-status/${id}/`, {
-                method: "POST",
-                headers: {
-                    "X-CSRFToken": "{{ csrf_token }}",
-                    "Content-Type": "application/json"
-                },
-                body: JSON.stringify({
-                    status: status,
-                    bacon_amount: baconAmount
-                })
+        fetch(`/update-submission-status/${id}/`, {
+            method: "POST",
+            headers: {
+                "X-CSRFToken": "{{ csrf_token }}",
+                "Content-Type": "application/json"
+            },
+            body: JSON.stringify({
+                status: status,
+                bacon_amount: baconAmount
             })
+        })
             .then(response => response.json())
             .then(data => {
                 if (data.success) {
@@ -412,6 +416,6 @@
                 }
             })
             .catch(error => console.error("Error:", error));
-        }
+    }
     </script>
 {% endblock content %}

--- a/website/templates/blog/post_list.html
+++ b/website/templates/blog/post_list.html
@@ -53,7 +53,8 @@
                     <!-- Card Image with Gradient Overlay (Square) -->
                     <div class="relative aspect-square overflow-hidden">
                         {% if post.image %}
-                            <img src="{{ post.image.url }}"
+                            <img loading="lazy"
+                                 src="{{ post.image.url }}"
                                  alt="{{ post.title }}"
                                  width="300"
                                  height="300"

--- a/website/templates/contribute.html
+++ b/website/templates/contribute.html
@@ -52,7 +52,8 @@
                         <ul class="space-y-4">
                             <li class="flex items-center space-x-3 group">
                                 <div class="bg-gray-100 dark:bg-gray-800 p-2 rounded-lg group-hover:bg-gray-200 transition-colors duration-200">
-                                    <img src="{% static 'images/tech/react.svg' %}"
+                                    <img loading="lazy"
+                                         src="{% static 'images/tech/react.svg' %}"
                                          alt="React"
                                          width="200"
                                          height="200"
@@ -63,7 +64,8 @@
                             </li>
                             <li class="flex items-center space-x-3 group">
                                 <div class="bg-gray-100 dark:bg-gray-800 p-2 rounded-lg group-hover:bg-gray-200 transition-colors duration-200">
-                                    <img src="{% static 'images/tech/nextjs.svg' %}"
+                                    <img loading="lazy"
+                                         src="{% static 'images/tech/nextjs.svg' %}"
                                          alt="Next.js"
                                          width="200"
                                          height="200"
@@ -74,7 +76,8 @@
                             </li>
                             <li class="flex items-center space-x-3 group">
                                 <div class="bg-gray-100 dark:bg-gray-800 p-2 rounded-lg group-hover:bg-gray-200 transition-colors duration-200">
-                                    <img src="{% static 'images/tech/tailwind.svg' %}"
+                                    <img loading="lazy"
+                                         src="{% static 'images/tech/tailwind.svg' %}"
                                          alt="Tailwind"
                                          width="200"
                                          height="200"
@@ -85,7 +88,8 @@
                             </li>
                             <li class="flex items-center space-x-3 group">
                                 <div class="bg-gray-100 dark:bg-gray-800 p-2 rounded-lg group-hover:bg-gray-200 transition-colors duration-200">
-                                    <img src="{% static 'images/tech/html.svg' %}"
+                                    <img loading="lazy"
+                                         src="{% static 'images/tech/html.svg' %}"
                                          alt="HTML/CSS"
                                          width="200"
                                          height="200"
@@ -101,7 +105,8 @@
                         <ul class="space-y-4">
                             <li class="flex items-center space-x-3 group">
                                 <div class="bg-gray-100 dark:bg-gray-800 p-2 rounded-lg group-hover:bg-gray-200 transition-colors duration-200">
-                                    <img src="{% static 'images/tech/python.svg' %}"
+                                    <img loading="lazy"
+                                         src="{% static 'images/tech/python.svg' %}"
                                          alt="Python"
                                          width="200"
                                          height="200"
@@ -112,7 +117,8 @@
                             </li>
                             <li class="flex items-center space-x-3 group">
                                 <div class="bg-gray-100 dark:bg-gray-800 p-2 rounded-lg group-hover:bg-gray-200 transition-colors duration-200">
-                                    <img src="{% static 'images/tech/django.svg' %}"
+                                    <img loading="lazy"
+                                         src="{% static 'images/tech/django.svg' %}"
                                          alt="Django"
                                          width="200"
                                          height="200"
@@ -123,7 +129,8 @@
                             </li>
                             <li class="flex items-center space-x-3 group">
                                 <div class="bg-gray-100 dark:bg-gray-800 p-2 rounded-lg group-hover:bg-gray-200 transition-colors duration-200">
-                                    <img src="{% static 'images/tech/django.svg' %}"
+                                    <img loading="lazy"
+                                         src="{% static 'images/tech/django.svg' %}"
                                          alt="Django Ninja"
                                          width="200"
                                          height="200"
@@ -134,7 +141,8 @@
                             </li>
                             <li class="flex items-center space-x-3 group">
                                 <div class="bg-gray-100 dark:bg-gray-800 p-2 rounded-lg group-hover:bg-gray-200 transition-colors duration-200">
-                                    <img src="{% static 'images/tech/sql.svg' %}"
+                                    <img loading="lazy"
+                                         src="{% static 'images/tech/sql.svg' %}"
                                          alt="SQL"
                                          width="200"
                                          height="200"
@@ -150,7 +158,8 @@
                         <ul class="space-y-4">
                             <li class="flex items-center space-x-3 group">
                                 <div class="bg-gray-100 dark:bg-gray-800 p-2 rounded-lg group-hover:bg-gray-200 transition-colors duration-200">
-                                    <img src="{% static 'images/tech/bitcoin.svg' %}"
+                                    <img loading="lazy"
+                                         src="{% static 'images/tech/bitcoin.svg' %}"
                                          alt="Bitcoin"
                                          width="200"
                                          height="200"
@@ -161,7 +170,8 @@
                             </li>
                             <li class="flex items-center space-x-3 group">
                                 <div class="bg-gray-100 dark:bg-gray-800 p-2 rounded-lg group-hover:bg-gray-200 transition-colors duration-200">
-                                    <img src="{% static 'images/tech/solana.svg' %}"
+                                    <img loading="lazy"
+                                         src="{% static 'images/tech/solana.svg' %}"
                                          alt="Solana"
                                          width="200"
                                          height="200"
@@ -172,7 +182,8 @@
                             </li>
                             <li class="flex items-center space-x-3 group">
                                 <div class="bg-gray-100 dark:bg-gray-800 p-2 rounded-lg group-hover:bg-gray-200 transition-colors duration-200">
-                                    <img src="{% static 'images/tech/smartcontracts.svg' %}"
+                                    <img loading="lazy"
+                                         src="{% static 'images/tech/smartcontracts.svg' %}"
                                          alt="Smart Contracts"
                                          width="200"
                                          height="200"
@@ -188,7 +199,8 @@
                         <ul class="space-y-4">
                             <li class="flex items-center space-x-3 group">
                                 <div class="bg-gray-100 dark:bg-gray-800 p-2 rounded-lg group-hover:bg-gray-200 transition-colors duration-200">
-                                    <img src="{% static 'images/tech/github.svg' %}"
+                                    <img loading="lazy"
+                                         src="{% static 'images/tech/github.svg' %}"
                                          alt="GitHub"
                                          width="200"
                                          height="200"
@@ -199,7 +211,8 @@
                             </li>
                             <li class="flex items-center space-x-3 group">
                                 <div class="bg-gray-100 dark:bg-gray-800 p-2 rounded-lg group-hover:bg-gray-200 transition-colors duration-200">
-                                    <img src="{% static 'images/tech/restapi.svg' %}"
+                                    <img loading="lazy"
+                                         src="{% static 'images/tech/restapi.svg' %}"
                                          alt="REST API"
                                          width="200"
                                          height="200"
@@ -210,7 +223,8 @@
                             </li>
                             <li class="flex items-center space-x-3 group">
                                 <div class="bg-gray-100 dark:bg-gray-800 p-2 rounded-lg group-hover:bg-gray-200 transition-colors duration-200">
-                                    <img src="{% static 'images/tech/oauth.svg' %}"
+                                    <img loading="lazy"
+                                         src="{% static 'images/tech/oauth.svg' %}"
                                          alt="OAuth"
                                          width="200"
                                          height="200"
@@ -221,7 +235,8 @@
                             </li>
                             <li class="flex items-center space-x-3 group">
                                 <div class="bg-gray-100 dark:bg-gray-800 p-2 rounded-lg group-hover:bg-gray-200 transition-colors duration-200">
-                                    <img src="{% static 'images/tech/authentication.svg' %}"
+                                    <img loading="lazy"
+                                         src="{% static 'images/tech/authentication.svg' %}"
                                          alt="Authentication"
                                          width="200"
                                          height="200"
@@ -232,7 +247,8 @@
                             </li>
                             <li class="flex items-center space-x-3 group">
                                 <div class="bg-gray-100 dark:bg-gray-800 p-2 rounded-lg group-hover:bg-gray-200 transition-colors duration-200">
-                                    <img src="{% static 'images/tech/nlp.svg' %}"
+                                    <img loading="lazy"
+                                         src="{% static 'images/tech/nlp.svg' %}"
                                          alt="NLP"
                                          width="200"
                                          height="200"
@@ -243,7 +259,8 @@
                             </li>
                             <li class="flex items-center space-x-3 group">
                                 <div class="bg-gray-100 dark:bg-gray-800 p-2 rounded-lg group-hover:bg-gray-200 transition-colors duration-200">
-                                    <img src="{% static 'images/tech/ml.svg' %}"
+                                    <img loading="lazy"
+                                         src="{% static 'images/tech/ml.svg' %}"
                                          alt="Machine Learning"
                                          width="200"
                                          height="200"

--- a/website/templates/contributors.html
+++ b/website/templates/contributors.html
@@ -54,7 +54,8 @@
                         </div>
                         <div class="relative -mt-12 flex justify-center">
                             <div class="w-24 h-24 rounded-full overflow-hidden ring-4 ring-white shadow-lg group-hover:ring-[#e74c3c] transition-all duration-300">
-                                <img src="{{ contributor.img }}"
+                                <img loading="lazy"
+                                     src="{{ contributor.img }}"
                                      class="w-full h-full object-cover transform group-hover:scale-110 transition-transform duration-300"
                                      width="96"
                                      height="96"

--- a/website/templates/features.html
+++ b/website/templates/features.html
@@ -93,7 +93,8 @@
             </div>
             <!-- AI-Powered Project Summary  Generator-->
             <div class="bg-white dark:bg-gray-800 shadow-md rounded-lg p-4 hover:scale-105 transition-transform w-full sm:w-[300px] md:w-[320px] lg:w-[350px] flex flex-col h-full">
-                <img src="{% static 'img/features/ai-summary.webp' %}"
+                <img loading="lazy"
+                     src="{% static 'img/features/ai-summary.webp' %}"
                      alt="ai_summary"
                      height="100"
                      width="200"
@@ -115,7 +116,8 @@
             </div>
             <!-- similarity-scan -->
             <div class="bg-white dark:bg-gray-800 shadow-md rounded-lg p-4 hover:scale-105 transition-transform w-full sm:w-[300px] md:w-[320px] lg:w-[350px] flex flex-col h-full">
-                <img src="{% static 'img/features/similarity-scan.webp' %}"
+                <img loading="lazy"
+                     src="{% static 'img/features/similarity-scan.webp' %}"
                      alt="similarity_scan"
                      height="100"
                      width="200"
@@ -137,7 +139,8 @@
             </div>
             <!-- Activity feed -->
             <div class="bg-white dark:bg-gray-800 shadow-md rounded-lg p-4 hover:scale-105 transition-transform w-full sm:w-[300px] md:w-[320px] lg:w-[350px] flex flex-col h-full">
-                <img src="{% static 'img/features/activity-feed.webp' %}"
+                <img loading="lazy"
+                     src="{% static 'img/features/activity-feed.webp' %}"
                      alt="feed"
                      height="100"
                      width="200"
@@ -156,7 +159,8 @@
             </div>
             <!-- BACON (Coin) -->
             <div class="bg-white dark:bg-gray-800 shadow-md rounded-lg p-4 hover:scale-105 transition-transform w-full sm:w-[300px] md:w-[320px] lg:w-[350px] flex flex-col h-full">
-                <img src="{% static 'images/bacon.webp' %}"
+                <img loading="lazy"
+                     src="{% static 'images/bacon.webp' %}"
                      alt="bacon coin"
                      width="200"
                      height="100"
@@ -175,7 +179,8 @@
             </div>
             <!-- badges -->
             <div class="bg-white dark:bg-gray-800 shadow-md rounded-lg p-4 hover:scale-105 transition-transform w-full sm:w-[300px] md:w-[320px] lg:w-[350px] flex flex-col h-full">
-                <img src="{% static 'img/features/badges.webp' %}"
+                <img loading="lazy"
+                     src="{% static 'img/features/badges.webp' %}"
                      alt="badges"
                      width="200"
                      height="100"
@@ -194,7 +199,8 @@
             </div>
             <!-- Bid on Issues -->
             <div class="bg-white dark:bg-gray-800 shadow-md rounded-lg p-4 hover:scale-105 transition-transform w-full sm:w-[300px] md:w-[320px] lg:w-[350px] flex flex-col h-full">
-                <img src="{% static 'img/features/bid.webp' %}"
+                <img loading="lazy"
+                     src="{% static 'img/features/bid.webp' %}"
                      alt="bid"
                      width="200"
                      height="100"
@@ -213,7 +219,8 @@
             </div>
             <!-- Blt extesnion   -->
             <div class="bg-white dark:bg-gray-800 shadow-md rounded-lg p-4 hover:scale-105 transition-transform w-full sm:w-[300px] md:w-[320px] lg:w-[350px] flex flex-col h-full">
-                <img src="{% static 'img/features/blt-extension.webp' %}"
+                <img loading="lazy"
+                     src="{% static 'img/features/blt-extension.webp' %}"
                      alt="blt_extension"
                      width="200"
                      height="100"
@@ -232,7 +239,8 @@
             </div>
             <!-- BLT slack bot  -->
             <div class="bg-white dark:bg-gray-800 shadow-md rounded-lg p-4 hover:scale-105 transition-transform w-full sm:w-[300px] md:w-[320px] lg:w-[350px] flex flex-col h-full">
-                <img src="{% static 'img/features/slack-bot.webp' %}"
+                <img loading="lazy"
+                     src="{% static 'img/features/slack-bot.webp' %}"
                      alt="slack-bot"
                      width="200"
                      height="100"
@@ -251,7 +259,8 @@
             </div>
             <!-- Education -->
             <div class="bg-white dark:bg-gray-800 shadow-md rounded-lg p-4 hover:scale-105 transition-transform w-full sm:w-[300px] md:w-[320px] lg:w-[350px] flex flex-col h-full">
-                <img src="{% static 'img/features/bltv.webp' %}"
+                <img loading="lazy"
+                     src="{% static 'img/features/bltv.webp' %}"
                      alt="Education"
                      width="200"
                      height="100"
@@ -270,7 +279,8 @@
             </div>
             <!-- Bug Bounties -->
             <div class="bg-white dark:bg-gray-800 shadow-md rounded-lg p-4 hover:scale-105 transition-transform w-full sm:w-[300px] md:w-[320px] lg:w-[350px] flex flex-col h-full">
-                <img src="{% static 'img/features/bug-bounty.webp' %}"
+                <img loading="lazy"
+                     src="{% static 'img/features/bug-bounty.webp' %}"
                      alt="bug Bounties"
                      height="100"
                      width="200"
@@ -289,7 +299,8 @@
             </div>
             <!-- Contributors -->
             <div class="bg-white dark:bg-gray-800 shadow-md rounded-lg p-4 hover:scale-105 transition-transform w-full sm:w-[300px] md:w-[320px] lg:w-[350px] flex flex-col h-full">
-                <img src="{% static 'img/features/contributors.webp' %}"
+                <img loading="lazy"
+                     src="{% static 'img/features/contributors.webp' %}"
                      alt="contributors"
                      height="100"
                      width="200"
@@ -308,7 +319,8 @@
             </div>
             <!-- Developer Api  -->
             <div class="bg-white dark:bg-gray-800 shadow-md rounded-lg p-4 hover:scale-105 transition-transform w-full sm:w-[300px] md:w-[320px] lg:w-[350px] flex flex-col h-full">
-                <img src="{% static 'img/features/swagger-api.webp' %}"
+                <img loading="lazy"
+                     src="{% static 'img/features/swagger-api.webp' %}"
                      alt="developer_api"
                      width="200"
                      height="100"
@@ -327,7 +339,8 @@
             </div>
             <!-- Discussion Rooms -->
             <div class="bg-white dark:bg-gray-800 shadow-md rounded-lg p-4 hover:scale-105 transition-transform w-full sm:w-[300px] md:w-[320px] lg:w-[350px] flex flex-col h-full">
-                <img src="{% static 'img/features/rooms.webp' %}"
+                <img loading="lazy"
+                     src="{% static 'img/features/rooms.webp' %}"
                      alt="rooms"
                      width="200"
                      height="100"
@@ -346,7 +359,8 @@
             </div>
             <!-- Donations -->
             <div class="bg-white dark:bg-gray-800 shadow-md rounded-lg p-4 hover:scale-105 transition-transform w-full sm:w-[300px] md:w-[320px] lg:w-[350px] flex flex-col h-full">
-                <img src="{% static 'img/features/donate.webp' %}"
+                <img loading="lazy"
+                     src="{% static 'img/features/donate.webp' %}"
                      alt="donate"
                      width="200"
                      height="100"
@@ -365,7 +379,8 @@
             </div>
             <!-- flutter app  -->
             <div class="bg-white dark:bg-gray-800 shadow-md rounded-lg p-4 hover:scale-105 transition-transform w-full sm:w-[300px] md:w-[320px] lg:w-[350px] flex flex-col h-full">
-                <img src="{% static 'img/features/app.webp' %}"
+                <img loading="lazy"
+                     src="{% static 'img/features/app.webp' %}"
                      alt="flutter_app"
                      width="200"
                      height="100"
@@ -384,7 +399,8 @@
             </div>
             <!-- github action   -->
             <div class="bg-white dark:bg-gray-800 shadow-md rounded-lg p-4 hover:scale-105 transition-transform w-full sm:w-[300px] md:w-[320px] lg:w-[350px] flex flex-col h-full">
-                <img src="{% static 'img/features/github-action.webp' %}"
+                <img loading="lazy"
+                     src="{% static 'img/features/github-action.webp' %}"
                      alt="github_action"
                      width="200"
                      height="100"
@@ -403,7 +419,8 @@
             </div>
             <!-- Gsoc  -->
             <div class="bg-white dark:bg-gray-800 shadow-md rounded-lg p-4 hover:scale-105 transition-transform w-full sm:w-[300px] md:w-[320px] lg:w-[350px] flex flex-col h-full">
-                <img src="{% static 'images/gsoc.png' %}"
+                <img loading="lazy"
+                     src="{% static 'images/gsoc.png' %}"
                      alt="gsoc"
                      width="200"
                      height="100"
@@ -422,7 +439,8 @@
             </div>
             <!-- invite referrals  -->
             <div class="bg-white dark:bg-gray-800 shadow-md rounded-lg p-4 hover:scale-105 transition-transform w-full sm:w-[300px] md:w-[320px] lg:w-[350px] flex flex-col h-full">
-                <img src="{% static 'img/features/referral.webp' %}"
+                <img loading="lazy"
+                     src="{% static 'img/features/referral.webp' %}"
                      alt="referral"
                      width="200"
                      height="100"
@@ -441,7 +459,8 @@
             </div>
             <!-- Issues (Bugs) -->
             <div class="bg-white dark:bg-gray-800 shadow-md rounded-lg p-4 hover:scale-105 transition-transform w-full sm:w-[300px] md:w-[320px] lg:w-[350px] flex flex-col h-full">
-                <img src="{% static 'img/features/report-bug.webp' %}"
+                <img loading="lazy"
+                     src="{% static 'img/features/report-bug.webp' %}"
                      alt="issues"
                      height="100"
                      width="200"
@@ -460,7 +479,8 @@
             </div>
             <!-- Leaderboard -->
             <div class="bg-white dark:bg-gray-800 shadow-md rounded-lg p-4 hover:scale-105 transition-transform w-full sm:w-[300px] md:w-[320px] lg:w-[350px] flex flex-col h-full">
-                <img src="{% static 'img/features/leaderboard.webp' %}"
+                <img loading="lazy"
+                     src="{% static 'img/features/leaderboard.webp' %}"
                      alt="leaderboard_global"
                      height="100"
                      width="200"
@@ -479,7 +499,8 @@
             </div>
             <!-- oraganisatiions  -->
             <div class="bg-white dark:bg-gray-800 shadow-md rounded-lg p-4 hover:scale-105 transition-transform w-full sm:w-[300px] md:w-[320px] lg:w-[350px] flex flex-col h-full">
-                <img src="{% static 'img/features/org.webp' %}"
+                <img loading="lazy"
+                     src="{% static 'img/features/org.webp' %}"
                      alt="Organisations"
                      width="200"
                      height="100"
@@ -498,7 +519,8 @@
             </div>
             <!-- oraganisations Dashboard  -->
             <div class="bg-white dark:bg-gray-800 shadow-md rounded-lg p-4 hover:scale-105 transition-transform w-full sm:w-[300px] md:w-[320px] lg:w-[350px] flex flex-col h-full">
-                <img src="{% static 'img/features/org-dashboard.webp' %}"
+                <img loading="lazy"
+                     src="{% static 'img/features/org-dashboard.webp' %}"
                      alt="org_dashboard"
                      width="200"
                      height="100"
@@ -517,7 +539,8 @@
             </div>
             <!-- projects   -->
             <div class="bg-white dark:bg-gray-800 shadow-md rounded-lg p-4 hover:scale-105 transition-transform w-full sm:w-[300px] md:w-[320px] lg:w-[350px] flex flex-col h-full">
-                <img src="{% static 'img/features/project.webp' %}"
+                <img loading="lazy"
+                     src="{% static 'img/features/project.webp' %}"
                      alt="project"
                      width="200"
                      height="100"
@@ -536,7 +559,8 @@
             </div>
             <!-- Report Ip  -->
             <div class="bg-white dark:bg-gray-800 shadow-md rounded-lg p-4 hover:scale-105 transition-transform w-full sm:w-[300px] md:w-[320px] lg:w-[350px] flex flex-col h-full">
-                <img src="{% static 'img/features/report-ip.webp' %}"
+                <img loading="lazy"
+                     src="{% static 'img/features/report-ip.webp' %}"
                      alt="report_ip"
                      width="200"
                      height="100"
@@ -555,7 +579,8 @@
             </div>
             <!-- repo  -->
             <div class="bg-white dark:bg-gray-800 shadow-md rounded-lg p-4 hover:scale-105 transition-transform w-full sm:w-[300px] md:w-[320px] lg:w-[350px] flex flex-col h-full">
-                <img src="{% static 'img/features/repo.webp' %}"
+                <img loading="lazy"
+                     src="{% static 'img/features/repo.webp' %}"
                      alt="repo"
                      width="200"
                      height="100"
@@ -574,7 +599,8 @@
             </div>
             <!-- Scoreboard -->
             <div class="bg-white dark:bg-gray-800 shadow-md rounded-lg p-4 hover:scale-105 transition-transform w-full sm:w-[300px] md:w-[320px] lg:w-[350px] flex flex-col h-full">
-                <img src="{% static 'img/features/scoreboard.webp' %}"
+                <img loading="lazy"
+                     src="{% static 'img/features/scoreboard.webp' %}"
                      alt="scoreboard"
                      height="100"
                      width="200"
@@ -593,7 +619,8 @@
             </div>
             <!-- Sitemap  -->
             <div class="bg-white dark:bg-gray-800 shadow-md rounded-lg p-4 hover:scale-105 transition-transform w-full sm:w-[300px] md:w-[320px] lg:w-[350px] flex flex-col h-full">
-                <img src="{% static 'img/features/sitemap.webp' %}"
+                <img loading="lazy"
+                     src="{% static 'img/features/sitemap.webp' %}"
                      alt="sitemap"
                      width="200"
                      height="100"
@@ -612,7 +639,8 @@
             </div>
             <!-- Sizzle (Time Tracking) -->
             <div class="bg-white dark:bg-gray-800 shadow-md rounded-lg p-4 hover:scale-105 transition-transform w-full sm:w-[300px] md:w-[320px] lg:w-[350px] flex flex-col h-full">
-                <img src="{% static 'img/features/sizzle.webp' %}"
+                <img loading="lazy"
+                     src="{% static 'img/features/sizzle.webp' %}"
                      alt="sizzle"
                      width="200"
                      height="100"
@@ -631,7 +659,8 @@
             </div>
             <!-- Sponsorships -->
             <div class="bg-white dark:bg-gray-800 shadow-md rounded-lg p-4 hover:scale-105 transition-transform w-full sm:w-[300px] md:w-[320px] lg:w-[350px] flex flex-col h-full">
-                <img src="{% static 'img/features/sponsor.webp' %}"
+                <img loading="lazy"
+                     src="{% static 'img/features/sponsor.webp' %}"
                      alt="sponsor "
                      width="200"
                      height="100"
@@ -650,7 +679,8 @@
             </div>
             <!-- Stats -->
             <div class="bg-white dark:bg-gray-800 shadow-md rounded-lg p-4 hover:scale-105 transition-transform w-full sm:w-[300px] md:w-[320px] lg:w-[350px] flex flex-col h-full">
-                <img src="{% static 'img/features/blt-stat.webp' %}"
+                <img loading="lazy"
+                     src="{% static 'img/features/blt-stat.webp' %}"
                      alt="blt-stat"
                      width="200"
                      height="100"
@@ -669,7 +699,8 @@
             </div>
             <!-- Stats Dashboard  -->
             <div class="bg-white dark:bg-gray-800 shadow-md rounded-lg p-4 hover:scale-105 transition-transform w-full sm:w-[300px] md:w-[320px] lg:w-[350px] flex flex-col h-full">
-                <img src="{% static 'img/features/stats-dashboard.webp' %}"
+                <img loading="lazy"
+                     src="{% static 'img/features/stats-dashboard.webp' %}"
                      alt="stat_dashboard"
                      width="200"
                      height="100"
@@ -688,7 +719,8 @@
             </div>
             <!-- steak based point system  -->
             <div class="bg-white dark:bg-gray-800 shadow-md rounded-lg p-4 hover:scale-105 transition-transform w-full sm:w-[300px] md:w-[320px] lg:w-[350px] flex flex-col h-full">
-                <img src="{% static 'img/features/steak.webp' %}"
+                <img loading="lazy"
+                     src="{% static 'img/features/steak.webp' %}"
                      alt="steak"
                      width="200"
                      height="100"
@@ -707,7 +739,8 @@
             </div>
             <!-- Teams  -->
             <div class="bg-white dark:bg-gray-800 shadow-md rounded-lg p-4 hover:scale-105 transition-transform w-full sm:w-[300px] md:w-[320px] lg:w-[350px] flex flex-col h-full">
-                <img src="{% static 'img/features/teams.webp' %}"
+                <img loading="lazy"
+                     src="{% static 'img/features/teams.webp' %}"
                      alt="teams"
                      width="200"
                      height="100"
@@ -726,7 +759,8 @@
             </div>
             <!-- Template List  -->
             <div class="bg-white dark:bg-gray-800 shadow-md rounded-lg p-4 hover:scale-105 transition-transform w-full sm:w-[300px] md:w-[320px] lg:w-[350px] flex flex-col h-full">
-                <img src="{% static 'img/features/template-list.webp' %}"
+                <img loading="lazy"
+                     src="{% static 'img/features/template-list.webp' %}"
                      alt="template_list"
                      width="200"
                      height="100"
@@ -745,7 +779,8 @@
             </div>
             <!-- Tomato (Funding) -->
             <div class="bg-white dark:bg-gray-800 shadow-md rounded-lg p-4 hover:scale-105 transition-transform w-full sm:w-[300px] md:w-[320px] lg:w-[350px] flex flex-col h-full">
-                <img src="{% static 'img/features/funding.webp' %}"
+                <img loading="lazy"
+                     src="{% static 'img/features/funding.webp' %}"
                      alt="funding"
                      width="200"
                      height="100"
@@ -764,7 +799,8 @@
             </div>
             <!-- Trademark Search -->
             <div class="bg-white dark:bg-gray-800 shadow-md rounded-lg p-4 hover:scale-105 transition-transform w-full sm:w-[300px] md:w-[320px] lg:w-[350px] flex flex-col h-full">
-                <img src="{% static 'img/features/trademark.webp' %}"
+                <img loading="lazy"
+                     src="{% static 'img/features/trademark.webp' %}"
                      alt="trademarks"
                      height="100"
                      width="200"
@@ -783,7 +819,8 @@
             </div>
             <!-- user-Profile  -->
             <div class="bg-white dark:bg-gray-800 shadow-md rounded-lg p-4 hover:scale-105 transition-transform w-full sm:w-[300px] md:w-[320px] lg:w-[350px] flex flex-col h-full">
-                <img src="{% static 'img/features/user-profile.webp' %}"
+                <img loading="lazy"
+                     src="{% static 'img/features/user-profile.webp' %}"
                      alt="user_profile"
                      width="200"
                      height="100"
@@ -802,7 +839,8 @@
             </div>
             <!-- website Stat  -->
             <div class="bg-white dark:bg-gray-800 shadow-md rounded-lg p-4 hover:scale-105 transition-transform w-full sm:w-[300px] md:w-[320px] lg:w-[350px] flex flex-col h-full">
-                <img src="{% static 'img/features/web-stats.webp' %}"
+                <img loading="lazy"
+                     src="{% static 'img/features/web-stats.webp' %}"
                      alt="web_Stats"
                      width="200"
                      height="100"
@@ -832,7 +870,8 @@
         <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
             <!--  AI-Assisted Coder for Automated Issue-to-PR Workflow   -->
             <div class="bg-white dark:bg-gray-800 shadow-md rounded-lg p-4 hover:scale-105 transition-transform w-full sm:w-[300px] md:w-[320px] lg:w-[350px] flex flex-col h-full">
-                <img src="{% static 'img/features/coming-soon.webp' %}"
+                <img loading="lazy"
+                     src="{% static 'img/features/coming-soon.webp' %}"
                      alt="assisted_coder"
                      height="100"
                      width="200"
@@ -854,7 +893,8 @@
             </div>
             <!-- AI-Powered GitHub Sportscaster Live Stream   -->
             <div class="bg-white dark:bg-gray-800 shadow-md rounded-lg p-4 hover:scale-105 transition-transform w-full sm:w-[300px] md:w-[320px] lg:w-[350px] flex flex-col h-full">
-                <img src="{% static 'img/features/coming-soon.webp' %}"
+                <img loading="lazy"
+                     src="{% static 'img/features/coming-soon.webp' %}"
                      alt="Sportscaster"
                      height="100"
                      width="200"
@@ -876,7 +916,8 @@
             </div>
             <!-- 3.Open Source Sorting Hat-->
             <div class="bg-white dark:bg-gray-800 shadow-md rounded-lg p-4 hover:scale-105 transition-transform w-full sm:w-[300px] md:w-[320px] lg:w-[350px] flex flex-col h-full">
-                <img src="{% static 'img/features/coming-soon.webp' %}"
+                <img loading="lazy"
+                     src="{% static 'img/features/coming-soon.webp' %}"
                      alt="ossh"
                      height="100"
                      width="200"
@@ -899,7 +940,8 @@
             </div>
             <!-- 4.project Stats   -->
             <div class="bg-white dark:bg-gray-800 shadow-md rounded-lg p-4 hover:scale-105 transition-transform w-full sm:w-[300px] md:w-[320px] lg:w-[350px] flex flex-col h-full">
-                <img src="{% static 'img/features/coming-soon.webp' %}"
+                <img loading="lazy"
+                     src="{% static 'img/features/coming-soon.webp' %}"
                      alt="feed"
                      height="100"
                      width="200"

--- a/website/templates/github_issue_detail.html
+++ b/website/templates/github_issue_detail.html
@@ -52,7 +52,8 @@
                     <a href="{{ issue.user_profile.github_url }}"
                        target="_blank"
                        class="flex items-center hover:text-[#e74c3c]">
-                        <img src="{{ issue.user_profile.github_url }}.png"
+                        <img loading="lazy"
+                             src="{{ issue.user_profile.github_url }}.png"
                              alt="{{ issue.user.login }}"
                              class="w-6 h-6 rounded-full mr-2"
                              width="24"
@@ -63,13 +64,15 @@
                     <a href="{% url 'profile' issue.user_profile.user.username %}"
                        class="flex items-center hover:text-[#e74c3c]">
                         {% if issue.user_profile.user_avatar %}
-                            <img src="{{ issue.user_profile.user_avatar.url }}"
+                            <img loading="lazy"
+                                 src="{{ issue.user_profile.user_avatar.url }}"
                                  alt="{{ issue.user.login }}"
                                  class="w-6 h-6 rounded-full mr-2"
                                  width="24"
                                  height="24">
                         {% else %}
-                            <img src="{% gravatar_url issue.user_profile.user.email 24 %}"
+                            <img loading="lazy"
+                                 src="{% gravatar_url issue.user_profile.user.email 24 %}"
                                  alt="{{ issue.user.login }}"
                                  class="w-6 h-6 rounded-full mr-2"
                                  width="24"
@@ -81,7 +84,8 @@
                     <a href="{{ issue.user.html_url }}"
                        target="_blank"
                        class="flex items-center hover:text-[#e74c3c]">
-                        <img src="{{ issue.user.avatar_url }}"
+                        <img loading="lazy"
+                             src="{{ issue.user.avatar_url }}"
                              alt="{{ issue.user.login }}"
                              class="w-6 h-6 rounded-full mr-2"
                              width="24"
@@ -129,7 +133,8 @@
                     <h3 class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Assignees</h3>
                     <div class="flex -space-x-2">
                         {% for assignee in issue.assignees %}
-                            <img src="{{ assignee.avatar_url }}"
+                            <img loading="lazy"
+                                 src="{{ assignee.avatar_url }}"
                                  alt="{{ assignee.login }}"
                                  title="{{ assignee.login }}"
                                  class="w-8 h-8 rounded-full border-2 border-white"
@@ -148,7 +153,8 @@
                     {% for comment in issue.comment_list %}
                         <div class="border-b border-gray-200 dark:border-gray-700 pb-6 last:border-0 last:pb-0">
                             <div class="flex items-center mb-4">
-                                <img src="{{ comment.user.avatar_url }}"
+                                <img loading="lazy"
+                                     src="{{ comment.user.avatar_url }}"
                                      alt="{{ comment.user.login }}"
                                      class="w-8 h-8 rounded-full mr-3"
                                      width="32"

--- a/website/templates/gsoc.html
+++ b/website/templates/gsoc.html
@@ -18,22 +18,22 @@
 {% endblock og_description %}
 {% block extra_head %}
     <style>
-.mentor-description-container {
-    max-height: 8rem;
-    overflow-y: auto;
-    scrollbar-width: none;
-    -ms-overflow-style: none;
-}
-.mentor-description-container::-webkit-scrollbar {
-    display: none;
-}
-.mentor-description-text {
-    scrollbar-width: none;
-    -ms-overflow-style: none;
-}
-.mentor-description-text::-webkit-scrollbar {
-    display: none;
-}
+    .mentor-description-container {
+        max-height: 8rem;
+        overflow-y: auto;
+        scrollbar-width: none;
+        -ms-overflow-style: none;
+    }
+    .mentor-description-container::-webkit-scrollbar {
+        display: none;
+    }
+    .mentor-description-text {
+        scrollbar-width: none;
+        -ms-overflow-style: none;
+    }
+    .mentor-description-text::-webkit-scrollbar {
+        display: none;
+    }
     </style>
 {% endblock extra_head %}
 {% block content %}
@@ -45,7 +45,8 @@
                 <div class="md:w-1/3 flex justify-center">
                     <div class="relative">
                         <div class="absolute -inset-4 bg-[#e74c3c] rounded-full blur-md opacity-30 animate-pulse"></div>
-                        <img src="{% static 'images/gsoc.png' %}"
+                        <img loading="lazy"
+                             src="{% static 'images/gsoc.png' %}"
                              alt="Google Summer of Code Logo"
                              class="w-[160px] h-auto object-contain relative"
                              width="200"

--- a/website/templates/hackathons/detail.html
+++ b/website/templates/hackathons/detail.html
@@ -113,7 +113,8 @@
             <!-- Hackathon Header -->
             <div class="relative rounded-lg overflow-hidden mb-8">
                 {% if hackathon.banner_image %}
-                    <img src="{{ hackathon.banner_image.url }}"
+                    <img loading="lazy"
+                         src="{{ hackathon.banner_image.url }}"
                          alt="{{ hackathon.name }}"
                          width="1200"
                          height="256"
@@ -385,7 +386,8 @@
                                             <div class="w-8 h-8 mr-3">
                                                 {% if entry.is_contributor %}
                                                     {% if entry.contributor.avatar_url %}
-                                                        <img src="{{ entry.contributor.avatar_url }}"
+                                                        <img loading="lazy"
+                                                             src="{{ entry.contributor.avatar_url }}"
                                                              alt="{{ entry.user.username }}"
                                                              class="w-8 h-8 rounded-full object-cover"
                                                              width="32"
@@ -397,7 +399,8 @@
                                                     {% endif %}
                                                 {% else %}
                                                     {% if entry.user.userprofile.user_avatar %}
-                                                        <img src="{{ entry.user.userprofile.user_avatar.url }}"
+                                                        <img loading="lazy"
+                                                             src="{{ entry.user.userprofile.user_avatar.url }}"
                                                              alt="{{ entry.user.username }}"
                                                              class="w-8 h-8 rounded-full object-cover"
                                                              width="32"
@@ -464,7 +467,8 @@
                                             <div class="w-8 h-8 mr-3">
                                                 {% if entry.is_contributor %}
                                                     {% if entry.contributor.avatar_url %}
-                                                        <img src="{{ entry.contributor.avatar_url }}"
+                                                        <img loading="lazy"
+                                                             src="{{ entry.contributor.avatar_url }}"
                                                              alt="Avatar for {{ entry.user.username }}"
                                                              class="w-8 h-8 rounded-full object-cover"
                                                              width="32"
@@ -477,7 +481,8 @@
                                                     {% endif %}
                                                 {% else %}
                                                     {% if entry.user.userprofile.user_avatar %}
-                                                        <img src="{{ entry.user.userprofile.user_avatar.url }}"
+                                                        <img loading="lazy"
+                                                             src="{{ entry.user.userprofile.user_avatar.url }}"
                                                              alt="Avatar for {{ entry.user.username }}"
                                                              class="w-8 h-8 rounded-full object-cover"
                                                              width="32"
@@ -554,7 +559,8 @@
                                                rel="noopener noreferrer"
                                                class="flex flex-col items-center p-3 border rounded-lg hover:bg-gray-50 transition">
                                                 {% if sponsor.logo %}
-                                                    <img src="{{ sponsor.logo.url }}"
+                                                    <img loading="lazy"
+                                                         src="{{ sponsor.logo.url }}"
                                                          alt="{{ sponsor.organization.name }}"
                                                          width="48"
                                                          height="48"
@@ -604,11 +610,11 @@
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script>
 document.addEventListener('DOMContentLoaded', function() {
-    // Initialize the sparkline chart
-    const ctx = document.getElementById('viewsSparkline').getContext('2d');
+        // Initialize the sparkline chart
+        const ctx = document.getElementById('viewsSparkline').getContext('2d');
     const dates = {{ view_dates|safe }};
     const counts = {{ view_counts|safe }};
-    
+
     new Chart(ctx, {
         type: 'bar',
         data: {
@@ -650,13 +656,13 @@ document.addEventListener('DOMContentLoaded', function() {
             }
         }
     });
-    
+
     // Initialize the PR activity chart
     const prCtx = document.getElementById('prActivityChart').getContext('2d');
     const prDates = {{ pr_dates|safe }};
     const prCounts = {{ pr_counts|safe }};
     const mergedPrCounts = {{ merged_pr_counts|safe }};
-    
+
     new Chart(prCtx, {
         type: 'bar',
         data: {
@@ -710,17 +716,17 @@ document.addEventListener('DOMContentLoaded', function() {
             }
         }
     });
-    
+
     // Share button functionality
     const shareButton = document.getElementById('shareButton');
     const shareDropdown = document.getElementById('shareDropdown');
-    
+
     // Toggle dropdown on button click
     shareButton.addEventListener('click', function(e) {
         e.stopPropagation();
         shareDropdown.classList.toggle('hidden');
     });
-    
+
     // Close dropdown when clicking outside
     document.addEventListener('click', function(e) {
         if (!shareButton.contains(e.target) && !shareDropdown.contains(e.target)) {
@@ -729,119 +735,119 @@ document.addEventListener('DOMContentLoaded', function() {
     });
 });
 
-// Helper function to show success toast
-function showCopySuccessToast() {
-    const toast = document.createElement('div');
-    toast.className = 'fixed bottom-24 left-4 bg-gray-800 text-white px-6 py-3 rounded-lg shadow-lg transform transition-all duration-500 ease-in-out z-50';
-    
-    const container = document.createElement('div');
-    container.className = 'flex items-center';
-    
-    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
-    svg.setAttribute('class', 'w-5 h-5 text-green-400 mr-2');
-    svg.setAttribute('fill', 'none');
-    svg.setAttribute('stroke', 'currentColor');
-    svg.setAttribute('viewBox', '0 0 24 24');
-    const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
-    path.setAttribute('stroke-linecap', 'round');
-    path.setAttribute('stroke-linejoin', 'round');
-    path.setAttribute('stroke-width', '2');
-    path.setAttribute('d', 'M5 13l4 4L19 7');
-    svg.appendChild(path);
-    
-    const text = document.createTextNode(' Link copied to clipboard!');
-    
-    container.appendChild(svg);
-    container.appendChild(text);
-    toast.appendChild(container);
-    document.body.appendChild(toast);
-    
-    setTimeout(() => {
-        toast.classList.add('opacity-0');
-        setTimeout(() => {
-            toast.remove();
-        }, 500);
-    }, 3000);
-}
+    // Helper function to show success toast
+    function showCopySuccessToast() {
+        const toast = document.createElement('div');
+        toast.className = 'fixed bottom-24 left-4 bg-gray-800 text-white px-6 py-3 rounded-lg shadow-lg transform transition-all duration-500 ease-in-out z-50';
 
-// Helper function to show error toast
-function showCopyErrorToast(message) {
-    const errorToast = document.createElement('div');
-    errorToast.className = 'fixed bottom-24 left-4 bg-red-600 text-white px-6 py-3 rounded-lg shadow-lg transform transition-all duration-500 ease-in-out z-50';
-    
-    const errorContainer = document.createElement('div');
-    errorContainer.className = 'flex items-center';
-    
-    const errorSvg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
-    errorSvg.setAttribute('class', 'w-5 h-5 mr-2');
-    errorSvg.setAttribute('fill', 'none');
-    errorSvg.setAttribute('stroke', 'currentColor');
-    errorSvg.setAttribute('viewBox', '0 0 24 24');
-    const errorPath = document.createElementNS('http://www.w3.org/2000/svg', 'path');
-    errorPath.setAttribute('stroke-linecap', 'round');
-    errorPath.setAttribute('stroke-linejoin', 'round');
-    errorPath.setAttribute('stroke-width', '2');
-    errorPath.setAttribute('d', 'M6 18L18 6M6 6l12 12');
-    errorSvg.appendChild(errorPath);
-    
-    const errorText = document.createTextNode(' ' + message);
-    
-    errorContainer.appendChild(errorSvg);
-    errorContainer.appendChild(errorText);
-    errorToast.appendChild(errorContainer);
-    document.body.appendChild(errorToast);
-    
-    setTimeout(() => {
-        errorToast.classList.add('opacity-0');
-        setTimeout(() => {
-            errorToast.remove();
-        }, 500);
-    }, 3000);
-}
+        const container = document.createElement('div');
+        container.className = 'flex items-center';
 
-// Copy to clipboard function with fallback for insecure contexts
-function copyToClipboard() {
-    const url = window.location.href;
-    
-    // Check if clipboard API is available and we're in a secure context
-    if (navigator.clipboard && window.isSecureContext) {
-        navigator.clipboard.writeText(url).then(function() {
-            showCopySuccessToast();
-            document.getElementById('shareDropdown').classList.add('hidden');
-        }).catch(function(err) {
-            console.error('Failed to copy: ', err);
-            showCopyErrorToast('Failed to copy link. Please try again.');
-            document.getElementById('shareDropdown').classList.add('hidden');
-        });
-    } else {
-        // Fallback for insecure context or unsupported Clipboard API
-        const textArea = document.createElement('textarea');
-        textArea.value = url;
-        // Avoid scrolling to bottom
-        textArea.style.position = 'fixed';
-        textArea.style.top = '0';
-        textArea.style.left = '0';
-        textArea.style.width = '2em';
-        textArea.style.height = '2em';
-        textArea.style.padding = '0';
-        textArea.style.border = 'none';
-        textArea.style.outline = 'none';
-        textArea.style.boxShadow = 'none';
-        textArea.style.background = 'transparent';
-        document.body.appendChild(textArea);
-        textArea.select();
-        try {
-            // Using deprecated execCommand as fallback for older browsers and HTTP contexts
-            document.execCommand('copy');
-            showCopySuccessToast();
-            document.getElementById('shareDropdown').classList.add('hidden');
-        } catch (err) {
-            console.error('Fallback: Unable to copy', err);
-            showCopyErrorToast('Failed to copy link. Please try again.');
-            document.getElementById('shareDropdown').classList.add('hidden');
-        }
-        document.body.removeChild(textArea);
+        const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+        svg.setAttribute('class', 'w-5 h-5 text-green-400 mr-2');
+        svg.setAttribute('fill', 'none');
+        svg.setAttribute('stroke', 'currentColor');
+        svg.setAttribute('viewBox', '0 0 24 24');
+        const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+        path.setAttribute('stroke-linecap', 'round');
+        path.setAttribute('stroke-linejoin', 'round');
+        path.setAttribute('stroke-width', '2');
+        path.setAttribute('d', 'M5 13l4 4L19 7');
+        svg.appendChild(path);
+
+        const text = document.createTextNode(' Link copied to clipboard!');
+
+        container.appendChild(svg);
+        container.appendChild(text);
+        toast.appendChild(container);
+        document.body.appendChild(toast);
+
+        setTimeout(() => {
+            toast.classList.add('opacity-0');
+            setTimeout(() => {
+                toast.remove();
+            }, 500);
+        }, 3000);
     }
-}
+
+    // Helper function to show error toast
+    function showCopyErrorToast(message) {
+        const errorToast = document.createElement('div');
+        errorToast.className = 'fixed bottom-24 left-4 bg-red-600 text-white px-6 py-3 rounded-lg shadow-lg transform transition-all duration-500 ease-in-out z-50';
+
+        const errorContainer = document.createElement('div');
+        errorContainer.className = 'flex items-center';
+
+        const errorSvg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+        errorSvg.setAttribute('class', 'w-5 h-5 mr-2');
+        errorSvg.setAttribute('fill', 'none');
+        errorSvg.setAttribute('stroke', 'currentColor');
+        errorSvg.setAttribute('viewBox', '0 0 24 24');
+        const errorPath = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+        errorPath.setAttribute('stroke-linecap', 'round');
+        errorPath.setAttribute('stroke-linejoin', 'round');
+        errorPath.setAttribute('stroke-width', '2');
+        errorPath.setAttribute('d', 'M6 18L18 6M6 6l12 12');
+        errorSvg.appendChild(errorPath);
+
+        const errorText = document.createTextNode(' ' + message);
+
+        errorContainer.appendChild(errorSvg);
+        errorContainer.appendChild(errorText);
+        errorToast.appendChild(errorContainer);
+        document.body.appendChild(errorToast);
+
+        setTimeout(() => {
+            errorToast.classList.add('opacity-0');
+            setTimeout(() => {
+                errorToast.remove();
+            }, 500);
+        }, 3000);
+    }
+
+    // Copy to clipboard function with fallback for insecure contexts
+    function copyToClipboard() {
+        const url = window.location.href;
+
+        // Check if clipboard API is available and we're in a secure context
+        if (navigator.clipboard && window.isSecureContext) {
+        navigator.clipboard.writeText(url).then(function() {
+                showCopySuccessToast();
+                document.getElementById('shareDropdown').classList.add('hidden');
+        }).catch(function(err) {
+                console.error('Failed to copy: ', err);
+                showCopyErrorToast('Failed to copy link. Please try again.');
+                document.getElementById('shareDropdown').classList.add('hidden');
+            });
+        } else {
+            // Fallback for insecure context or unsupported Clipboard API
+            const textArea = document.createElement('textarea');
+            textArea.value = url;
+            // Avoid scrolling to bottom
+            textArea.style.position = 'fixed';
+            textArea.style.top = '0';
+            textArea.style.left = '0';
+            textArea.style.width = '2em';
+            textArea.style.height = '2em';
+            textArea.style.padding = '0';
+            textArea.style.border = 'none';
+            textArea.style.outline = 'none';
+            textArea.style.boxShadow = 'none';
+            textArea.style.background = 'transparent';
+            document.body.appendChild(textArea);
+            textArea.select();
+            try {
+                // Using deprecated execCommand as fallback for older browsers and HTTP contexts
+                document.execCommand('copy');
+                showCopySuccessToast();
+                document.getElementById('shareDropdown').classList.add('hidden');
+            } catch (err) {
+                console.error('Fallback: Unable to copy', err);
+                showCopyErrorToast('Failed to copy link. Please try again.');
+                document.getElementById('shareDropdown').classList.add('hidden');
+            }
+            document.body.removeChild(textArea);
+        }
+    }
     </script>
 {% endblock scripts %}

--- a/website/templates/home.html
+++ b/website/templates/home.html
@@ -332,19 +332,22 @@
                                         <div class="flex items-center gap-3">
                                             <span class="text-[#e74c3c] font-bold">{{ forloop.counter }}</span>
                                             {% if profile.avatar %}
-                                                <img src="{{ profile.avatar }}"
+                                                <img loading="lazy"
+                                                     src="{{ profile.avatar }}"
                                                      class="w-8 h-8 rounded-full"
                                                      alt="{{ profile.user.username }}'s avatar"
                                                      width="32"
                                                      height="32">
                                             {% elif profile.user.socialaccount_set.all.0.get_avatar_url %}
-                                                <img src="{{ profile.user.socialaccount_set.all.0.get_avatar_url }}"
+                                                <img loading="lazy"
+                                                     src="{{ profile.user.socialaccount_set.all.0.get_avatar_url }}"
                                                      class="w-8 h-8 rounded-full"
                                                      alt="{{ profile.user.username }}'s avatar"
                                                      width="32"
                                                      height="32">
                                             {% else %}
-                                                <img src="{% gravatar_url profile.user.email 50 %}"
+                                                <img loading="lazy"
+                                                     src="{% gravatar_url profile.user.email 50 %}"
                                                      class="w-8 h-8 rounded-full"
                                                      alt="{{ profile.user.username }}'s avatar"
                                                      width="32"
@@ -380,19 +383,22 @@
                                             <a href="{% url 'profile' user.username %}"
                                                class="text-sm hover:text-[#e74c3c] font-medium flex items-center gap-2">
                                                 {% if user.userprofile.avatar %}
-                                                    <img src="{{ user.userprofile.avatar }}"
+                                                    <img loading="lazy"
+                                                         src="{{ user.userprofile.avatar }}"
                                                          alt="{{ user.username }}'s avatar"
                                                          width="24"
                                                          height="24"
                                                          class="w-6 h-6 rounded-full">
                                                 {% elif user.socialaccount_set.all.0.get_avatar_url %}
-                                                    <img src="{{ user.socialaccount_set.all.0.get_avatar_url }}"
+                                                    <img loading="lazy"
+                                                         src="{{ user.socialaccount_set.all.0.get_avatar_url }}"
                                                          alt="{{ user.username }}'s avatar"
                                                          width="24"
                                                          height="24"
                                                          class="w-6 h-6 rounded-full">
                                                 {% else %}
-                                                    <img src="{% gravatar_url user.email 50 %}"
+                                                    <img loading="lazy"
+                                                         src="{% gravatar_url user.email 50 %}"
                                                          alt="{{ user.username }}'s avatar"
                                                          width="24"
                                                          height="24"
@@ -429,14 +435,16 @@
                                                target="_blank"
                                                class="text-sm hover:text-[#e74c3c] font-medium flex items-center gap-2">
                                                 {% if user.contributor__avatar_url %}
-                                                    <img src="{{ user.contributor__avatar_url }}"
+                                                    <img loading="lazy"
+                                                         src="{{ user.contributor__avatar_url }}"
                                                          alt="{{ user.contributor__name }}'s avatar"
                                                          width="24"
                                                          height="24"
                                                          class="w-6 h-6 rounded-full"
                                                          onerror="this.src='{% static 'images/dummy-user.webp' %}';">
                                                 {% else %}
-                                                    <img src="{% static 'images/dummy-user.webp' %}"
+                                                    <img loading="lazy"
+                                                         src="{% static 'images/dummy-user.webp' %}"
                                                          alt="{{ user.contributor__name }}'s avatar"
                                                          width="24"
                                                          height="24"
@@ -475,19 +483,22 @@
                                         <div class="flex items-center gap-3">
                                             <span class="text-[#e74c3c] font-bold">{{ forloop.counter }}</span>
                                             {% if invite.sender.userprofile.avatar %}
-                                                <img src="{{ invite.sender.userprofile.avatar }}"
+                                                <img loading="lazy"
+                                                     src="{{ invite.sender.userprofile.avatar }}"
                                                      class="w-8 h-8 rounded-full"
                                                      alt="{{ invite.sender.username }}'s avatar"
                                                      width="32"
                                                      height="32">
                                             {% elif invite.sender.socialaccount_set.all.0.get_avatar_url %}
-                                                <img src="{{ invite.sender.socialaccount_set.all.0.get_avatar_url }}"
+                                                <img loading="lazy"
+                                                     src="{{ invite.sender.socialaccount_set.all.0.get_avatar_url }}"
                                                      class="w-8 h-8 rounded-full"
                                                      alt="{{ invite.sender.username }}'s avatar"
                                                      width="32"
                                                      height="32">
                                             {% else %}
-                                                <img src="{% gravatar_url invite.sender.email 50 %}"
+                                                <img loading="lazy"
+                                                     src="{% gravatar_url invite.sender.email 50 %}"
                                                      class="w-8 h-8 rounded-full"
                                                      alt="{{ invite.sender.username }}'s avatar"
                                                      width="32"
@@ -899,7 +910,8 @@
                                 </div>
                                 {% if bug.screenshots.all.0 %}
                                     <div class="mb-4 rounded-lg overflow-hidden">
-                                        <img src="{{ bug.screenshots.all.0.image.url }}"
+                                        <img loading="lazy"
+                                             src="{{ bug.screenshots.all.0.image.url }}"
                                              alt="Screenshot"
                                              class="w-full h-32 object-cover"
                                              width="400"
@@ -910,13 +922,15 @@
                                     <div class="flex items-center">
                                         {% if bug.user %}
                                             {% if bug.user.userprofile.avatar %}
-                                                <img src="{{ bug.user.userprofile.avatar }}"
+                                                <img loading="lazy"
+                                                     src="{{ bug.user.userprofile.avatar }}"
                                                      alt="{{ bug.user.username }}"
                                                      class="w-6 h-6 rounded-full mr-2"
                                                      width="24"
                                                      height="24">
                                             {% else %}
-                                                <img src="{% gravatar_url bug.user.email 30 %}"
+                                                <img loading="lazy"
+                                                     src="{% gravatar_url bug.user.email 30 %}"
                                                      alt="{{ bug.user.username }}"
                                                      class="w-6 h-6 rounded-full mr-2"
                                                      width="24"
@@ -966,7 +980,8 @@
                             <div class="bg-white dark:bg-gray-800 rounded-lg shadow-lg border-2 border-[#e74c3c] overflow-hidden">
                                 {% if post.image %}
                                     <div class="w-full h-48 overflow-hidden">
-                                        <img src="{{ post.image.url }}"
+                                        <img loading="lazy"
+                                             src="{{ post.image.url }}"
                                              alt="{{ post.title }}"
                                              width="800"
                                              height="400"
@@ -1184,12 +1199,14 @@
                     <div class="flex flex-col items-center text-center">
                         <a href="{% url 'organization_detail' slug='owasp' %}"
                            class="w-32 h-32 flex items-center justify-center mb-4 hover:opacity-80 transition-opacity">
-                            <img src="{% static 'images/OWASP_black_logo.svg' %}"
+                            <img loading="lazy"
+                                 src="{% static 'images/OWASP_black_logo.svg' %}"
                                  alt="OWASP Logo"
                                  width="128"
                                  height="128"
                                  class="block dark:hidden max-w-full max-h-full">
-                            <img src="{% static 'images/OWASP_white_logo.svg' %}"
+                            <img loading="lazy"
+                                 src="{% static 'images/OWASP_white_logo.svg' %}"
                                  alt="OWASP Logo"
                                  width="128"
                                  height="128"
@@ -1203,12 +1220,14 @@
                     <div class="flex flex-col items-center text-center">
                         <a href="{% url 'organization_detail' slug='sentry' %}"
                            class="w-32 h-32 flex items-center justify-center mb-4 hover:opacity-80 transition-opacity">
-                            <img src="{% static 'images/sentry-logo.svg' %}"
+                            <img loading="lazy"
+                                 src="{% static 'images/sentry-logo.svg' %}"
                                  alt="Sentry Logo"
                                  width="128"
                                  height="128"
                                  class="block dark:hidden max-w-full max-h-full">
-                            <img src="{% static 'images/sentry-white.png' %}"
+                            <img loading="lazy"
+                                 src="{% static 'images/sentry-white.png' %}"
                                  alt="Sentry Logo"
                                  width="128"
                                  height="128"
@@ -1222,7 +1241,8 @@
                     <div class="flex flex-col items-center text-center">
                         <a href="{% url 'organization_detail' slug='google' %}"
                            class="w-32 h-32 flex items-center justify-center mb-4 hover:opacity-80 transition-opacity">
-                            <img src="{% static 'images/googlelogo_color_272x92dp.webp' %}"
+                            <img loading="lazy"
+                                 src="{% static 'images/googlelogo_color_272x92dp.webp' %}"
                                  alt="Google Logo"
                                  width="272"
                                  height="92"
@@ -1298,7 +1318,7 @@
         copyText.select();
         copyText.setSelectionRange(0, 99999);
         document.execCommand("copy");
-        
+
         // Show feedback
         var button = event.target.closest('button');
         var originalText = button.innerHTML;

--- a/website/templates/includes/_leaderboard_widget.html
+++ b/website/templates/includes/_leaderboard_widget.html
@@ -32,19 +32,22 @@
                 <div class="relative">
                     <a href="{% url 'profile' slug=leader.username %}" class="block">
                         {% if leader.userprofile.avatar %}
-                            <img src="{{ leader.userprofile.avatar }}"
+                            <img loading="lazy"
+                                 src="{{ leader.userprofile.avatar }}"
                                  class="w-12 h-12 rounded-full object-cover ring-2 ring-[#e74c3c] ring-offset-2"
                                  alt="{{ leader.username }}"
                                  width="48"
                                  height="48">
                         {% elif user.socialaccount_set.all.0.get_avatar_url %}
-                            <img src="{{ leader.socialaccount_set.all.0.get_avatar_url }}"
+                            <img loading="lazy"
+                                 src="{{ leader.socialaccount_set.all.0.get_avatar_url }}"
                                  class="w-12 h-12 rounded-full object-cover ring-2 ring-[#e74c3c] ring-offset-2"
                                  alt="{{ leader.username }}"
                                  width="48"
                                  height="48">
                         {% else %}
-                            <img src="{% gravatar_url leader.email 50 %}"
+                            <img loading="lazy"
+                                 src="{% gravatar_url leader.email 50 %}"
                                  class="w-12 h-12 rounded-full object-cover ring-2 ring-[#e74c3c] ring-offset-2"
                                  alt="{{ leader.username }}"
                                  width="48"

--- a/website/templates/includes/_like_dislike_share.html
+++ b/website/templates/includes/_like_dislike_share.html
@@ -26,13 +26,15 @@
                                             {% for usr in flagers %}
                                                 <div class="flex items-center p-3 rounded-lg shadow-sm hover:shadow-md transition-shadow duration-200">
                                                     {% if usr.user.socialaccount_set.all.0.get_avatar_url %}
-                                                        <img src="{{ usr.user.socialaccount_set.all.0.get_avatar_url }}"
+                                                        <img loading="lazy"
+                                                             src="{{ usr.user.socialaccount_set.all.0.get_avatar_url }}"
                                                              class="h-10 w-10 rounded-full object-cover"
                                                              alt="{{ usr.user.username }}"
                                                              height="40"
                                                              width="40">
                                                     {% else %}
-                                                        <img src="{% gravatar_url usr.user.email 50 %}"
+                                                        <img loading="lazy"
+                                                             src="{% gravatar_url usr.user.email 50 %}"
                                                              class="h-10 w-10 rounded-full object-cover"
                                                              alt="{{ usr.user.username }}"
                                                              height="40"
@@ -80,13 +82,15 @@
                                             {% for usr in likers %}
                                                 <div class="flex items-center p-3 rounded-lg shadow-sm hover:shadow-md transition-shadow duration-200">
                                                     {% if usr.user.socialaccount_set.all.0.get_avatar_url %}
-                                                        <img src="{{ usr.user.socialaccount_set.all.0.get_avatar_url }}"
+                                                        <img loading="lazy"
+                                                             src="{{ usr.user.socialaccount_set.all.0.get_avatar_url }}"
                                                              class="h-10 w-10 rounded-full object-cover"
                                                              alt="{{ usr.user.username }}"
                                                              height="40"
                                                              width="40">
                                                     {% else %}
-                                                        <img src="{% gravatar_url usr.user.email 50 %}"
+                                                        <img loading="lazy"
+                                                             src="{% gravatar_url usr.user.email 50 %}"
                                                              class="h-10 w-10 rounded-full object-cover"
                                                              alt="{{ usr.user.username }}"
                                                              height="40"
@@ -118,9 +122,9 @@
 <script>
     function copyClipboard() {
         var textToCopy = "Bug Found on @{{ object.domain_title|escapejs }} - {{ object.description|escapejs }} Report: https://{% env 'FQDN' %}/issue/{{ object.id }}";
-        
+
         navigator.clipboard.writeText(textToCopy);
-      
+
         $.notify("Bug details copied to clipboard!", {
             style: "custom",
             className: "success"
@@ -199,14 +203,14 @@
     async function resolveIssue(){
         var id = {{object.pk}};
 
-        const request = await fetch(`/resolve/${id}/`)
-        window.location.reload();
+    const request = await fetch(`/resolve/${id}/`) 
+    window.location.reload();
         if (request.status == 403){
-            $.notify("Permission Denied", {
-                style: "custom",
-                className: "danger"
-            });
-        }
+        $.notify("Permission Denied", {
+            style: "custom",
+            className: "danger"
+        });
+    }
     }
 </script>
 <script>
@@ -322,19 +326,19 @@
             }
         })
     }
-    
+
     function likeOpenn() {
         document.getElementById('like-modal').classList.remove('hidden');
     }
-    
+
     function flagOpenn() {
         document.getElementById('flag-modal').classList.remove('hidden');
     }
-    
+
     document.getElementById('close-like').addEventListener('click', function() {
         document.getElementById('like-modal').classList.add('hidden');
     });
-    
+
     document.getElementById('close-flag').addEventListener('click', function() {
         document.getElementById('flag-modal').classList.add('hidden');
     });

--- a/website/templates/index3.html
+++ b/website/templates/index3.html
@@ -76,7 +76,8 @@
                             Tailwind CSS.
                         </p>
                         <figure>
-                            <img src="https://flowbite.s3.amazonaws.com/typography-plugin/typography-image-1.png"
+                            <img loading="lazy"
+                                 src="https://flowbite.s3.amazonaws.com/typography-plugin/typography-image-1.png"
                                  alt="Digital art by Anonymous"
                                  width="100%"
                                  height="auto">
@@ -166,7 +167,8 @@
                             <li>Diagonal stress in the strokes</li>
                             <li>Slanted serifs on lower-case ascenders</li>
                         </ul>
-                        <img src="https://flowbite.s3.amazonaws.com/typography-plugin/typography-image-2.png"
+                        <img loading="lazy"
+                             src="https://flowbite.s3.amazonaws.com/typography-plugin/typography-image-2.png"
                              alt="Digital art by Anonymous"
                              width="100%"
                              height="auto">
@@ -305,7 +307,8 @@
                             <div class="w-full">
                                 <div class="w-full flex items-center">
                                     <div class="w-[90px] h-[90px] rounded-full object-fill flex flex-col overflow-hidden">
-                                        <img class="w-full h-full object-cover"
+                                        <img loading="lazy"
+                                             class="w-full h-full object-cover"
                                              src="https://blt.owasp.org/static/img/browser-logos/firefox/firefox_64x64.png"
                                              alt="Firefox Logo"
                                              width="auto"
@@ -327,7 +330,8 @@
                             <div class="w-full mt-10">
                                 <div class="w-full flex items-center">
                                     <div class="w-[90px] h-[90px] rounded-full object-fill border-black border-[1px] flex flex-col overflow-hidden">
-                                        <img class="w-full h-full object-cover"
+                                        <img loading="lazy"
+                                             class="w-full h-full object-cover"
                                              src="https://storage.googleapis.com/bhfiles/logos/basij.ir.jpg"
                                              alt="Basij.ir Logo"
                                              width="auto"
@@ -347,7 +351,8 @@
                             <div class="w-full">
                                 <div class="w-full flex items-center">
                                     <div class="w-[90px] h-[90px] rounded-full object-fill border-black border-[1px] flex flex-col overflow-hidden">
-                                        <img class="w-full h-full object-cover"
+                                        <img loading="lazy"
+                                             class="w-full h-full object-cover"
                                              src="https://secure.gravatar.com/avatar/54e1af8b11945e8712b0b550a6ce0a11.jpg?s=100&d=mm&r=g"
                                              alt="Swapnil Shinde"
                                              width="auto"
@@ -389,7 +394,8 @@
                         <footer class="flex justify-between items-center mb-2">
                             <div class="flex items-center">
                                 <p class="inline-flex items-center mr-3 text-sm text-gray-900 dark:text-gray-100">
-                                    <img class="mr-2 w-6 h-6 rounded-full"
+                                    <img loading="lazy"
+                                         class="mr-2 w-6 h-6 rounded-full"
                                          src="https://flowbite.com/docs/images/people/profile-picture-2.jpg"
                                          alt="Michael Gough"
                                          width="32px"
@@ -455,7 +461,8 @@
                         <footer class="flex justify-between items-center mb-2">
                             <div class="flex items-center">
                                 <p class="inline-flex items-center mr-3 text-sm text-gray-900 dark:text-gray-100">
-                                    <img class="mr-2 w-6 h-6 rounded-full"
+                                    <img loading="lazy"
+                                         class="mr-2 w-6 h-6 rounded-full"
                                          src="https://flowbite.com/docs/images/people/profile-picture-5.jpg"
                                          alt="Jese Leos"
                                          width="32px"
@@ -517,7 +524,8 @@
                         <footer class="flex justify-between items-center mb-2">
                             <div class="flex items-center">
                                 <p class="inline-flex items-center mr-3 text-sm text-gray-900 dark:text-gray-100">
-                                    <img class="mr-2 w-6 h-6 rounded-full"
+                                    <img loading="lazy"
+                                         class="mr-2 w-6 h-6 rounded-full"
                                          src="https://flowbite.com/docs/images/people/profile-picture-3.jpg"
                                          alt="Bonnie Green"
                                          width="32px"
@@ -581,7 +589,8 @@
                         <footer class="flex justify-between items-center mb-2">
                             <div class="flex items-center">
                                 <p class="inline-flex items-center mr-3 text-sm text-gray-900 dark:text-gray-100">
-                                    <img class="mr-2 w-6 h-6 rounded-full"
+                                    <img loading="lazy"
+                                         class="mr-2 w-6 h-6 rounded-full"
                                          src="https://flowbite.com/docs/images/people/profile-picture-4.jpg"
                                          alt="Helene Engels"
                                          width="32px"
@@ -651,7 +660,8 @@
             <div class="grid gap-12 sm:grid-cols-2 lg:grid-cols-4">
                 <article class="max-w-xs">
                     <a href="#">
-                        <img src="https://flowbite.s3.amazonaws.com/blocks/marketing-ui/article/blog-1.png"
+                        <img loading="lazy"
+                             src="https://flowbite.s3.amazonaws.com/blocks/marketing-ui/article/blog-1.png"
                              class="mb-5 rounded-lg"
                              alt="Image 1"
                              width="100%"
@@ -670,7 +680,8 @@
                 </article>
                 <article class="max-w-xs">
                     <a href="#">
-                        <img src="https://flowbite.s3.amazonaws.com/blocks/marketing-ui/article/blog-2.png"
+                        <img loading="lazy"
+                             src="https://flowbite.s3.amazonaws.com/blocks/marketing-ui/article/blog-2.png"
                              class="mb-5 rounded-lg"
                              alt="Image 2"
                              width="100%"
@@ -689,7 +700,8 @@
                 </article>
                 <article class="max-w-xs">
                     <a href="#">
-                        <img src="https://flowbite.s3.amazonaws.com/blocks/marketing-ui/article/blog-3.png"
+                        <img loading="lazy"
+                             src="https://flowbite.s3.amazonaws.com/blocks/marketing-ui/article/blog-3.png"
                              class="mb-5 rounded-lg"
                              alt="Image 3"
                              width="100%"
@@ -708,7 +720,8 @@
                 </article>
                 <article class="max-w-xs">
                     <a href="#">
-                        <img src="https://flowbite.s3.amazonaws.com/blocks/marketing-ui/article/blog-4.png"
+                        <img loading="lazy"
+                             src="https://flowbite.s3.amazonaws.com/blocks/marketing-ui/article/blog-4.png"
                              class="mb-5 rounded-lg"
                              alt="Image 4"
                              width="100%"

--- a/website/templates/leaderboard_eachmonth.html
+++ b/website/templates/leaderboard_eachmonth.html
@@ -68,19 +68,22 @@
                                         <!-- User Avatar -->
                                         <div class="mb-4 relative">
                                             {% if month.user.userprofile.avatar %}
-                                                <img src="{{ month.user.userprofile.avatar }}"
+                                                <img loading="lazy"
+                                                     src="{{ month.user.userprofile.avatar }}"
                                                      class="w-20 h-20 rounded-full object-cover ring-2 ring-[#e74c3c] ring-offset-2"
                                                      alt="{{ month.user.username }}"
                                                      width="80"
                                                      height="80">
                                             {% elif user.socialaccount_set.all.0.get_avatar_url %}
-                                                <img src="{{ month.user.socialaccount_set.all.0.get_avatar_url }}"
+                                                <img loading="lazy"
+                                                     src="{{ month.user.socialaccount_set.all.0.get_avatar_url }}"
                                                      class="w-20 h-20 rounded-full object-cover ring-2 ring-[#e74c3c] ring-offset-2"
                                                      alt="{{ month.user.username }}"
                                                      width="80"
                                                      height="80">
                                             {% else %}
-                                                <img src="{% gravatar_url month.user.email 50 %}"
+                                                <img loading="lazy"
+                                                     src="{% gravatar_url month.user.email 50 %}"
                                                      class="w-20 h-20 rounded-full object-cover ring-2 ring-[#e74c3c] ring-offset-2"
                                                      alt="{{ month.user.username }}"
                                                      width="80"

--- a/website/templates/leaderboard_global.html
+++ b/website/templates/leaderboard_global.html
@@ -36,19 +36,22 @@
                                 <div class="flex justify-between items-center">
                                     <div class="flex gap-2 items-center truncate">
                                         {% if leader.userprofile.avatar %}
-                                            <img src="{{ leader.userprofile.avatar }}"
+                                            <img loading="lazy"
+                                                 src="{{ leader.userprofile.avatar }}"
                                                  class="size-11 select-none border border-gray-200 dark:border-gray-700 rounded-full"
                                                  alt="{{ leader.username }}"
                                                  width="50px"
                                                  height="50px">
                                         {% elif leader.socialaccount_set.all.0.get_avatar_url %}
-                                            <img src="{{ leader.socialaccount_set.all.0.get_avatar_url }}"
+                                            <img loading="lazy"
+                                                 src="{{ leader.socialaccount_set.all.0.get_avatar_url }}"
                                                  class="size-11 select-none border border-gray-200 dark:border-gray-700 rounded-full"
                                                  alt="username"
                                                  width="50px"
                                                  height="50px">
                                         {% else %}
-                                            <img src="{% gravatar_url leader.email 50 %}"
+                                            <img loading="lazy"
+                                                 src="{% gravatar_url leader.email 50 %}"
                                                  class="size-11 select-none border border-gray-200 dark:border-gray-700 rounded-full"
                                                  alt="username"
                                                  width="50px"
@@ -89,13 +92,15 @@
                                 <div class="flex justify-between items-center">
                                     <div class="flex gap-2 items-center truncate">
                                         {% if leader.contributor__avatar_url %}
-                                            <img src="{{ leader.contributor__avatar_url }}"
+                                            <img loading="lazy"
+                                                 src="{{ leader.contributor__avatar_url }}"
                                                  class="size-11 select-none border border-gray-200 dark:border-gray-700 rounded-full"
                                                  alt="{{ leader.contributor__name }}"
                                                  width="50px"
                                                  height="50px">
                                         {% else %}
-                                            <img src="{% gravatar_url 'default@example.com' 50 %}"
+                                            <img loading="lazy"
+                                                 src="{% gravatar_url 'default@example.com' 50 %}"
                                                  class="size-11 select-none border border-gray-200 dark:border-gray-700 rounded-full"
                                                  alt="{{ leader.contributor__name|default:'Unknown User' }}"
                                                  width="50px"
@@ -137,13 +142,15 @@
                                 <div class="flex justify-between items-center">
                                     <div class="flex gap-2 items-center truncate">
                                         {% if leader.reviewer_contributor__avatar_url %}
-                                            <img src="{{ leader.reviewer_contributor__avatar_url }}"
+                                            <img loading="lazy"
+                                                 src="{{ leader.reviewer_contributor__avatar_url }}"
                                                  class="size-11 select-none border border-gray-200 dark:border-gray-700 rounded-full"
                                                  alt="{{ leader.reviewer_contributor__name }}"
                                                  width="50px"
                                                  height="50px">
                                         {% else %}
-                                            <img src="{% gravatar_url 'default@example.com' 50 %}"
+                                            <img loading="lazy"
+                                                 src="{% gravatar_url 'default@example.com' 50 %}"
                                                  class="size-11 select-none border border-gray-200 dark:border-gray-700 rounded-full"
                                                  alt="{{ leader.reviewer_contributor__name|default:'Unknown User' }}"
                                                  width="50px"
@@ -186,13 +193,15 @@
                                 <div class="flex justify-between items-center">
                                     <div class="flex gap-2 items-center truncate">
                                         {% if profile.avatar %}
-                                            <img src="{{ profile.avatar }}"
+                                            <img loading="lazy"
+                                                 src="{{ profile.avatar }}"
                                                  class="size-11 select-none border border-gray-200 dark:border-gray-700 rounded-full rounded-full"
                                                  alt="{{ profile.user.username }}"
                                                  width="50px"
                                                  height="50px">
                                         {% else %}
-                                            <img src="{% gravatar_url profile.user.email 50 %}"
+                                            <img loading="lazy"
+                                                 src="{% gravatar_url profile.user.email 50 %}"
                                                  class="size-11 select-none border border-gray-200 dark:border-gray-700 rounded-full"
                                                  alt="{{ profile.user.username }}"
                                                  width="50px"

--- a/website/templates/leaderboard_specific_month.html
+++ b/website/templates/leaderboard_specific_month.html
@@ -90,19 +90,22 @@
                                     <!-- User Info -->
                                     <div class="flex-shrink-0">
                                         {% if leader.userprofile.avatar %}
-                                            <img src="{{ leader.userprofile.avatar }}"
+                                            <img loading="lazy"
+                                                 src="{{ leader.userprofile.avatar }}"
                                                  class="w-12 h-12 rounded-full object-cover ring-2 ring-[#e74c3c] ring-offset-2"
                                                  alt="{{ leader.username }}"
                                                  width="48"
                                                  height="48">
                                         {% elif leader.socialaccount_set.all.0.get_avatar_url %}
-                                            <img src="{{ leader.socialaccount_set.all.0.get_avatar_url }}"
+                                            <img loading="lazy"
+                                                 src="{{ leader.socialaccount_set.all.0.get_avatar_url }}"
                                                  class="w-12 h-12 rounded-full object-cover ring-2 ring-[#e74c3c] ring-offset-2"
                                                  alt="{{ leader.username }}"
                                                  width="48"
                                                  height="48">
                                         {% else %}
-                                            <img src="{% gravatar_url leader.email 50 %}"
+                                            <img loading="lazy"
+                                                 src="{% gravatar_url leader.email 50 %}"
                                                  class="w-12 h-12 rounded-full object-cover ring-2 ring-[#e74c3c] ring-offset-2"
                                                  alt="{{ leader.username }}"
                                                  width="48"
@@ -140,125 +143,125 @@
     </div>
     <!-- Month Picker Script -->
     <script>
-        function padToTwo(number) {
-            if (number <= 9999) {
-                number = ("0" + number).slice(-2);
-            }
-            return number;
+    function padToTwo(number) {
+        if (number <= 9999) {
+            number = ("0" + number).slice(-2);
         }
+        return number;
+    }
 
         (function($) {
             $.fn.monthly = function(options) {
-                var months = options.months || [
-                    "January", "February", "March", "April", "May", "June",
-                    "July", "August", "September", "October", "November", "December"
-                ];
+            var months = options.months || [
+                "January", "February", "March", "April", "May", "June",
+                "July", "August", "September", "October", "November", "December"
+            ];
 
                 var Monthly = function(el) {
-                    this._el = $(el);
-                    this._init();
-                    this._render();
-                    this._renderYears();
-                    this._renderMonths();
-                    this._bind();
-                };
+                this._el = $(el);
+                this._init();
+                this._render();
+                this._renderYears();
+                this._renderMonths();
+                this._bind();
+            };
 
-                Monthly.prototype = {
+            Monthly.prototype = {
                     _init: function() {
-                        this._el.text(months[0] + " " + options.years[0]);
-                    },
+                    this._el.text(months[0] + " " + options.years[0]);
+                },
 
                     _render: function() {
-                        var linkPosition = this._el.offset();
-                        this._container = $('<div class="bg-white dark:bg-gray-800 rounded-lg shadow-lg border border-gray-200 dark:border-gray-700 p-4 z-50">')
-                            .css({
-                                display: "none",
-                                position: "absolute",
-                                top: linkPosition.top + this._el.height() + (options.topOffset || 0),
-                                left: linkPosition.left
-                            })
-                            .appendTo($("body"));
-                    },
+                    var linkPosition = this._el.offset();
+                    this._container = $('<div class="bg-white dark:bg-gray-800 rounded-lg shadow-lg border border-gray-200 dark:border-gray-700 p-4 z-50">')
+                        .css({
+                            display: "none",
+                            position: "absolute",
+                            top: linkPosition.top + this._el.height() + (options.topOffset || 0),
+                            left: linkPosition.left
+                        })
+                        .appendTo($("body"));
+                },
 
                     _bind: function() {
-                        var self = this;
-                        this._el.on("click", $.proxy(this._show, this));
-                        $(document).on("click", $.proxy(this._hide, this));
+                    var self = this;
+                    this._el.on("click", $.proxy(this._show, this));
+                    $(document).on("click", $.proxy(this._hide, this));
                         this._yearsSelect.on("click", function(e) {
-                            e.stopPropagation();
-                        });
-                        this._container.on("click", "button", $.proxy(this._selectMonth, this));
-                    },
+                        e.stopPropagation();
+                    });
+                    this._container.on("click", "button", $.proxy(this._selectMonth, this));
+                },
 
                     _show: function(e) {
-                        e.preventDefault();
-                        e.stopPropagation();
-                        this._container.css("display", "inline-block");
-                    },
+                    e.preventDefault();
+                    e.stopPropagation();
+                    this._container.css("display", "inline-block");
+                },
 
                     _hide: function() {
-                        this._container.css("display", "none");
-                    },
+                    this._container.css("display", "none");
+                },
 
                     _selectMonth: function(e) {
-                        var monthIndex = $(e.target).data("value"),
-                            month = $("<div>").text(months[monthIndex]).html(),
-                            year = $("<div>").text(this._yearsSelect.val()).html();
-                        this._el.text(month + " " + year);
-                        if (options.onMonthSelect) {
-                            options.onMonthSelect(monthIndex + 1, month, year);
-                        }
-                    },
+                    var monthIndex = $(e.target).data("value"),
+                        month = $("<div>").text(months[monthIndex]).html(),
+                        year = $("<div>").text(this._yearsSelect.val()).html();
+                    this._el.text(month + " " + year);
+                    if (options.onMonthSelect) {
+                        options.onMonthSelect(monthIndex + 1, month, year);
+                    }
+                },
 
                     _renderYears: function() {
                         var markup = $.map(options.years, function(year) {
-                            return $("<option>").text(year)[0].outerHTML;
-                        });
-                        var yearsWrap = $('<div class="mb-4">').appendTo(this._container);
-                        this._yearsSelect = $('<select class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:ring-[#e74c3c] focus:border-[#e74c3c] font-inherit text-inherit">')
-                            .html(markup.join(""))
-                            .appendTo(yearsWrap);
-                    },
+                        return $("<option>").text(year)[0].outerHTML;
+                    });
+                    var yearsWrap = $('<div class="mb-4">').appendTo(this._container);
+                    this._yearsSelect = $('<select class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:ring-[#e74c3c] focus:border-[#e74c3c] font-inherit text-inherit">')
+                        .html(markup.join(""))
+                        .appendTo(yearsWrap);
+                },
 
                     _renderMonths: function() {
-                        var self = this;
-                        var container = $('<div class="grid grid-cols-3 gap-2">');
-                        
+                    var self = this;
+                    var container = $('<div class="grid grid-cols-3 gap-2">');
+
                         $.each(months, function(i, month) {
-                            $('<button>')
-                                .attr('data-value', i)
-                                .addClass('px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[#e74c3c] cursor-pointer')
-                                .text(month)
-                                .appendTo(container);
-                        });
-                        
-                        this._container.append(container);
-                    }
-                };
+                        $('<button>')
+                            .attr('data-value', i)
+                            .addClass('px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[#e74c3c] cursor-pointer')
+                            .text(month)
+                            .appendTo(container);
+                    });
+
+                    this._container.append(container);
+                }
+            };
 
                 return this.each(function() {
-                    return new Monthly(this);
-                });
-            };
-        })(jQuery);
+                return new Monthly(this);
+            });
+        };
+    })(jQuery);
 
         $(function() {
-            let current_year = new Date().getFullYear();
-            let years = [];
-            for (let year = current_year; year >= 2000; year -= 1) {
-                years.push(year);
-            }
+        let current_year = new Date().getFullYear();
+        let years = [];
+        for (let year = current_year; year >= 2000; year -= 1) {
+            years.push(year);
+        }
 
-            $("#selection").monthly({
-                years: years,
-                topOffset: 8,
+        $("#selection").monthly({
+            years: years,
+            topOffset: 8,
                 onMonthSelect: function(mi, m, y) {
-                    mi = padToTwo(mi);
-                    $("#selection").val(m + " " + y);
-                    $("#monthly").val(y + "-" + mi);
-                    window.location = `?month=${mi}&year=${y}`;
-                }
-            });
+                mi = padToTwo(mi);
+                $("#selection").val(m + " " + y);
+                $("#monthly").val(y + "-" + mi);
+                window.location = `?month=${mi}&year=${y}`;
+            }
         });
+    });
     </script>
 {% endblock content %}

--- a/website/templates/organization/bughunt/edit_bughunt.html
+++ b/website/templates/organization/bughunt/edit_bughunt.html
@@ -161,7 +161,8 @@
                                                 <div id="previewLogoDiv"
                                                      class="relative h-32 w-32 overflow-hidden rounded-2xl border-2 border-dashed border-gray-300 dark:border-gray-600 hover:border-[#e74c3c] transition-colors duration-200">
                                                     {% if hunt.logo %}
-                                                        <img id="logoPreview"
+                                                        <img loading="lazy"
+                                                             id="logoPreview"
                                                              src="{{ MEDIA_URL }}/{{ hunt.logo }}"
                                                              height="128"
                                                              width="128"
@@ -170,7 +171,8 @@
                                                         <div id="defaultLogoIcon"
                                                              class="absolute inset-0 items-center justify-center text-[#e74c3c] hidden">
                                                         {% else %}
-                                                            <img id="logoPreview"
+                                                            <img loading="lazy"
+                                                                 id="logoPreview"
                                                                  height="128"
                                                                  width="128"
                                                                  class="absolute inset-0 h-full w-full object-cover hidden rounded-2xl"
@@ -248,7 +250,8 @@
                                             <div class="flex items-start gap-x-4">
                                                 <div class="relative">
                                                     {% if hunt.banner %}
-                                                        <img id="bannerPreview"
+                                                        <img loading="lazy"
+                                                             id="bannerPreview"
                                                              height="128"
                                                              width="128"
                                                              src="{{ MEDIA_URL }}/{{ hunt.banner }}"
@@ -257,7 +260,8 @@
                                                         <div id="defaultBannerIcon"
                                                              class="hidden items-center justify-center w-64 h-32 bg-gray-50 dark:bg-gray-900 border-2 border-dashed border-gray-300 dark:border-gray-600 rounded-lg text-gray-400 dark:text-gray-600">
                                                         {% else %}
-                                                            <img id="bannerPreview"
+                                                            <img loading="lazy"
+                                                                 id="bannerPreview"
                                                                  width="128"
                                                                  height="128"
                                                                  class="hidden max-w-md max-h-48 object-cover rounded-lg border-2 border-gray-200 dark:border-gray-700"
@@ -499,51 +503,51 @@
     <!-- Hunt Controller Script -->
     <script src="{% static 'organization/js/hunt_controller.js' %}?v=2.9"></script>
     <script>
-        // Set organization ID for JavaScript access
-        window.organizationId = {{ organization.id }};
-        
-        // Date inputs are now plain text with MM/DD/YYYY format
-        // Add date validation and formatting
-        function validateDateFormat(input) {
-            const datePattern = /^(0[1-9]|1[0-2])\/(0[1-9]|[12][0-9]|3[01])\/\d{4}$/;
-            const value = input.value.trim();
-            
-            if (value && !datePattern.test(value)) {
-                input.style.borderColor = '#e74c3c';
-                // Show error message if error div exists
-                const errorDiv = document.getElementById(input.id + '_error');
-                if (!errorDiv) {
-                    const error = document.createElement('div');
-                    error.id = input.id + '_error';
-                    error.className = 'text-xs text-[#e74c3c] mt-1';
-                    error.textContent = 'Please enter date in MM/DD/YYYY format';
-                    input.parentNode.insertBefore(error, input.nextSibling);
-                }
-            } else {
-                input.style.borderColor = '';
-                const errorDiv = document.getElementById(input.id + '_error');
-                if (errorDiv) {
-                    errorDiv.remove();
-                }
+    // Set organization ID for JavaScript access
+    window.organizationId = {{ organization.id }};
+
+    // Date inputs are now plain text with MM/DD/YYYY format
+    // Add date validation and formatting
+    function validateDateFormat(input) {
+        const datePattern = /^(0[1-9]|1[0-2])\/(0[1-9]|[12][0-9]|3[01])\/\d{4}$/;
+        const value = input.value.trim();
+
+        if (value && !datePattern.test(value)) {
+            input.style.borderColor = '#e74c3c';
+            // Show error message if error div exists
+            const errorDiv = document.getElementById(input.id + '_error');
+            if (!errorDiv) {
+                const error = document.createElement('div');
+                error.id = input.id + '_error';
+                error.className = 'text-xs text-[#e74c3c] mt-1';
+                error.textContent = 'Please enter date in MM/DD/YYYY format';
+                input.parentNode.insertBefore(error, input.nextSibling);
+            }
+        } else {
+            input.style.borderColor = '';
+            const errorDiv = document.getElementById(input.id + '_error');
+            if (errorDiv) {
+                errorDiv.remove();
             }
         }
-        
-        // Add event listeners for date validation
+    }
+
+    // Add event listeners for date validation
         document.addEventListener('DOMContentLoaded', function() {
-            const startDate = document.getElementById('start_date');
-            const endDate = document.getElementById('end_date');
-            
-            if (startDate) {
+        const startDate = document.getElementById('start_date');
+        const endDate = document.getElementById('end_date');
+
+        if (startDate) {
                 startDate.addEventListener('blur', function() {
-                    validateDateFormat(this);
-                });
-            }
-            
-            if (endDate) {
+                validateDateFormat(this);
+            });
+        }
+
+        if (endDate) {
                 endDate.addEventListener('blur', function() {
-                    validateDateFormat(this);
-                });
-            }
-        });
+                validateDateFormat(this);
+            });
+        }
+    });
     </script>
 {% endblock scripts %}

--- a/website/templates/organization/bughunt/view_bughunt.html
+++ b/website/templates/organization/bughunt/view_bughunt.html
@@ -33,92 +33,92 @@
 {% endblock head %}
 {% block style %}
     <style>
-        .cursive {
-            font-family: 'Nanum Pen Script', cursive;
-        }
+    .cursive {
+        font-family: 'Nanum Pen Script', cursive;
+    }
         [x-cloak] { display: none; }
 
-        .CodeMirror-focused {   
-            border-radius: .375rem;
-            outline: 2px solid transparent;
-            outline-offset: 2px;
-            --tw-ring-opacity: 0.5;
-            --tw-ring-color: rgba(199, 210, 254, var(--tw-ring-opacity));
-            --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
-            --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(3px + var(--tw-ring-offset-width)) var(--tw-ring-color);
-            box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
-        }
-        .CodeMirror {
-            padding: 0.75rem;
-            font-family: inherit;
-            font-size: inherit;
-            border-bottom-left-radius: .375rem;
-            border-bottom-right-radius: .375rem;
-            --tw-border-opacity: 1;
-            border: 1px solid rgba(209, 213, 219, var(--tw-border-opacity));
-        }
-        .CodeMirror.CodeMirror-focused {
-            --tw-border-opacity: 1;
-            border-color: rgba(165, 180, 252, var(--tw-border-opacity));
-        }
+    .CodeMirror-focused {
+        border-radius: .375rem;
+        outline: 2px solid transparent;
+        outline-offset: 2px;
+        --tw-ring-opacity: 0.5;
+        --tw-ring-color: rgba(199, 210, 254, var(--tw-ring-opacity));
+        --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+        --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(3px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+        box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+    }
+    .CodeMirror {
+        padding: 0.75rem;
+        font-family: inherit;
+        font-size: inherit;
+        border-bottom-left-radius: .375rem;
+        border-bottom-right-radius: .375rem;
+        --tw-border-opacity: 1;
+        border: 1px solid rgba(209, 213, 219, var(--tw-border-opacity));
+    }
+    .CodeMirror.CodeMirror-focused {
+        --tw-border-opacity: 1;
+        border-color: rgba(165, 180, 252, var(--tw-border-opacity));
+    }
 
-        .cm-s-default .cm-header,
-        .cm-s-default .cm-variable-2 {
-            color: rgb(31, 41, 55);
-        }
+    .cm-s-default .cm-header,
+    .cm-s-default .cm-variable-2 {
+        color: rgb(31, 41, 55);
+    }
 
-        .dropdown {
-            min-width: 160px;
-            z-index: 1000;
-        }
+    .dropdown {
+        min-width: 160px;
+        z-index: 1000;
+    }
 
-        .pagination-button:disabled {
+    .pagination-button:disabled {
             background-color: #d1d5db; /* Gray background */
             color: #6b7280; /* Gray text */
             cursor: not-allowed; /* Change cursor to indicate disabled */
             box-shadow: none; /* Remove shadow for disabled state */
-        }
+    }
 
-        .crypto-address {
+    .crypto-address {
         text-align: center;
-        }
+    }
 
-        .dialog {
-            /* position: relative; */
-        }
+    .dialog {
+        /* position: relative; */
+    }
 
-        .crypto-name {
-            text-align: center;
-            width: 100%;
-            font-size: 20px;
-            color: white;
-            background-color: #ff4444;
-            display: inline-block;
+    .crypto-name {
+        text-align: center;
+        width: 100%;
+        font-size: 20px;
+        color: white;
+        background-color: #ff4444;
+        display: inline-block;
             margin: 0 auto; /* Center the element horizontally */
-        }
+    }
 
-        .navigation {
-            position: absolute;
-            top: 0;
-            left: 50%;
-            transform: translateX(-50%);
-            display: flex;
-            justify-content: center;
-        }
+    .navigation {
+        position: absolute;
+        top: 0;
+        left: 50%;
+        transform: translateX(-50%);
+        display: flex;
+        justify-content: center;
+    }
 
-        .nav-btn {
-            cursor: pointer;
+    .nav-btn {
+        cursor: pointer;
             transition: 0.4s;;
-        }
-        .nav-btn.active {
+    }
+    .nav-btn.active {
             background: red; /* Change to whatever red color you prefer */
             color: white; /* Change text color to contrast with the red background */
-        }
+    }
 
-        input[name="r"] {
-            position: absolute;
-            visibility: hidden;
-        }
+    input[name="r"] {
+        position: absolute;
+        visibility: hidden;
+    }
 
     </style>
 {% endblock style %}
@@ -127,14 +127,16 @@
     <div class="h-full bg-gray-200 dark:bg-gray-700 p-8">
         <div class="bg-white dark:bg-gray-800 rounded-lg shadow-xl pb-8">
             <div class="w-full h-[250px]">
-                <img src="{% if banner_src %} {{ MEDIA_URL }}{{ banner_src }} {% else %}https://versohydraulic.com/bitrix/templates/aspro-allcorp/images/background.png {% endif %}"
+                <img loading="lazy"
+                     src="{% if banner_src %} {{ MEDIA_URL }}{{ banner_src }} {% else %}https://versohydraulic.com/bitrix/templates/aspro-allcorp/images/background.png {% endif %}"
                      class="w-full h-full rounded-tl-lg rounded-tr-lg object-cover"
                      width="100%"
                      height="100%"
                      alt="banner">
             </div>
             <div class="flex flex-col items-center -mt-20">
-                <img src="{% if hunt_obj.logo %} {{ MEDIA_URL }}{{ hunt_obj.logo }} {% else %} https://via.placeholder.com/160?text=No+Logo {% endif %}"
+                <img loading="lazy"
+                     src="{% if hunt_obj.logo %} {{ MEDIA_URL }}{{ hunt_obj.logo }} {% else %} https://via.placeholder.com/160?text=No+Logo {% endif %}"
                      class="w-40 h-40 border-4 rounded-full"
                      width="100"
                      height="100"
@@ -349,7 +351,8 @@
                                     <tr class="winner-row bg-white dark:bg-gray-800 border-b">
                                         <td scope="row"
                                             class="flex items-center px-6 py-4 text-gray-900 dark:text-gray-100 whitespace-nowrap">
-                                            <img class="rounded-full"
+                                            <img loading="lazy"
+                                                 class="rounded-full"
                                                  src="{% if winner.winner.userprofile.user_avatar %} {{ MEDIA_URL }}{{ winner.winner.userprofile.user_avatar }} {% else %} https://via.placeholder.com/100?text=No+Avatar {% endif %}"
                                                  alt="avatar"
                                                  width="40"
@@ -388,7 +391,8 @@
                                                     id="btc-btn-{{ winner.winner.id }}">Bitcoin</button>
                                         </div>
                                         <div id="slideshow-{{ winner.winner.id }}" class="slideshow mt-[50px]">
-                                            <img id="qr-image-{{ winner.winner.id }}"
+                                            <img loading="lazy"
+                                                 id="qr-image-{{ winner.winner.id }}"
                                                  alt="QR Code"
                                                  height="300"
                                                  width="400">
@@ -502,7 +506,8 @@
                     {% for issue in latest_issues %}
                         <div class="w-full h-[200px] flex px-5 my-2 py-6 bg-white dark:bg-gray-800 rounded-lg shadow-md hover:shadow-xl transition-all">
                             <div class="w-[10%] mr-5 h-full flex items-center">
-                                <img src="{% if issue.first_screenshot %} {{ MEDIA_URL }}{{ issue.first_screenshot }} {% else %} https://via.placeholder.com/100?text=No+Screenshot {% endif %}"
+                                <img loading="lazy"
+                                     src="{% if issue.first_screenshot %} {{ MEDIA_URL }}{{ issue.first_screenshot }} {% else %} https://via.placeholder.com/100?text=No+Screenshot {% endif %}"
                                      alt=""
                                      width="100%"
                                      height="100%">
@@ -553,7 +558,8 @@
                                     <div>
                                         <a class="flex items-center"
                                            href="{% url 'profile' issue.user__username %}">
-                                            <img class="mr-3 w-10 h-10 object-cover rounded-full hidden sm:block"
+                                            <img loading="lazy"
+                                                 class="mr-3 w-10 h-10 object-cover rounded-full hidden sm:block"
                                                  src="{% if issue.user__userprofile__user_avatar %} {{ MEDIA_URL }}{{ issue.user__userprofile__user_avatar }} {% else %} https://via.placeholder.com/40?text=No+Avatar {% endif %}"
                                                  alt="avatar"
                                                  width="40px"
@@ -583,7 +589,8 @@
                            class="flex flex-col items-center m-5 justify-center text-gray-800 dark:text-gray-200 hover:text-red-600"
                            title="View Profile">
                             <div class="w-[100px] h-[100px] rounded-full border-[1px] border-gray-500 dark:border-gray-400 overflow-hidden flex items-center justify-center">
-                                <img src="{% if tester.user__userprofile__user_avatar %} {{ MEDIA_URL }}{{ tester.user__userprofile__user_avatar }} {% else %} https://via.placeholder.com/100?text=No+Avatar {% endif %}"
+                                <img loading="lazy"
+                                     src="{% if tester.user__userprofile__user_avatar %} {{ MEDIA_URL }}{{ tester.user__userprofile__user_avatar }} {% else %} https://via.placeholder.com/100?text=No+Avatar {% endif %}"
                                      class="object-cover"
                                      width="100%"
                                      height="100%"
@@ -730,7 +737,7 @@
             { name: 'Ethereum', address: eth },
             { name: 'Bitcoin', address: btc }
         ];
-        
+
         let currentIndex = 0;
 
         const updateSlide = () => {
@@ -749,7 +756,7 @@
 
         updateSlide();
 
-        
+
         // Set up the navigation buttons
         const bchBtn = document.getElementById('bch-btn-' + userId);
         const ethBtn = document.getElementById('eth-btn-' + userId);

--- a/website/templates/organization/dashboard/organization_team_overview.html
+++ b/website/templates/organization/dashboard/organization_team_overview.html
@@ -17,12 +17,12 @@
 {% endblock og_description %}
 {% block body %}
     {% comment %} <div class="fixed bottom-6 right-6 z-50 flex gap-3">
-        <a href="https://github.com/OWASP-BLT/BLT/blob/main/website/templates/organization/organization_manage_bugs.html" class="bg-gray-800 dark:bg-gray-100 hover:bg-gray-900 text-white p-3 rounded-full shadow-lg transition-all duration-200 hover:scale-110">
-            <i class="fab fa-github text-xl"></i>
-        </a>
-        <a href="https://www.figma.com/file/s0xuxeU6O2guoWEfA9OElZ/Design?node-id=3%3A76&t=pqxWpF3hcYxjEDrs-1" class="bg-[#e74c3c] hover:bg-[#c0392b] text-white p-3 rounded-full shadow-lg transition-all duration-200 hover:scale-110">
-            <i class="fab fa-figma text-xl"></i>
-        </a>
+    <a href="https://github.com/OWASP-BLT/BLT/blob/main/website/templates/organization/organization_manage_bugs.html" class="bg-gray-800 dark:bg-gray-100 hover:bg-gray-900 text-white p-3 rounded-full shadow-lg transition-all duration-200 hover:scale-110">
+        <i class="fab fa-github text-xl"></i>
+    </a>
+    <a href="https://www.figma.com/file/s0xuxeU6O2guoWEfA9OElZ/Design?node-id=3%3A76&t=pqxWpF3hcYxjEDrs-1" class="bg-[#e74c3c] hover:bg-[#c0392b] text-white p-3 rounded-full shadow-lg transition-all duration-200 hover:scale-110">
+        <i class="fab fa-figma text-xl"></i>
+    </a>
     </div> {% endcomment %}
     <div class="min-h-screen bg-gradient-to-br from-gray-50 to-gray-100 dark:from-gray-900 dark:to-gray-800">
         <!-- Header Section -->
@@ -78,13 +78,15 @@
                                         <td class="px-6 py-4 whitespace-nowrap">
                                             <div class="flex items-center">
                                                 {% if member.user_avatar %}
-                                                    <img src="{{ member.user_avatar.url }}"
+                                                    <img loading="lazy"
+                                                         src="{{ member.user_avatar.url }}"
                                                          alt="{{ member.user.username }}"
                                                          width="40"
                                                          height="40"
                                                          class="w-10 h-10 rounded-full mr-3 border-2 border-[#e74c3c]/20 object-cover">
                                                 {% else %}
-                                                    <img src="{% static 'images/dummy-user.webp' %}"
+                                                    <img loading="lazy"
+                                                         src="{% static 'images/dummy-user.webp' %}"
                                                          alt="{{ member.user.username }}"
                                                          width="40"
                                                          height="40"
@@ -154,8 +156,8 @@
             </div>
             <!-- Daily Status Reports Section -->
             {% comment %}
-            DEBUG: Team Members: {{ team_members|length }}
-            DEBUG: Daily Reports: {{ daily_status_reports|length }}
+        DEBUG: Team Members: {{ team_members|length }}
+        DEBUG: Daily Reports: {{ daily_status_reports|length }}
             {% endcomment %}
             <div class="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 overflow-hidden">
                 <div class="px-6 py-4 border-b border-gray-200 dark:border-gray-700 flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
@@ -250,13 +252,15 @@
                                             <div class="flex items-center">
                                                 {% with user_profile=report.user.userprofile %}
                                                     {% if user_profile.user_avatar %}
-                                                        <img src="{{ user_profile.user_avatar.url }}"
+                                                        <img loading="lazy"
+                                                             src="{{ user_profile.user_avatar.url }}"
                                                              alt="{{ report.user.username }}"
                                                              width="32"
                                                              height="32"
                                                              class="w-8 h-8 rounded-full mr-3 object-cover">
                                                     {% else %}
-                                                        <img src="{% static 'images/dummy-user.webp' %}"
+                                                        <img loading="lazy"
+                                                             src="{% static 'images/dummy-user.webp' %}"
                                                              alt="{{ report.user.username }}"
                                                              width="32"
                                                              height="32"

--- a/website/templates/organization/dashboard/view_domain.html
+++ b/website/templates/organization/dashboard/view_domain.html
@@ -22,14 +22,16 @@
         <div class="h-full bg-gray-200 dark:bg-gray-700 p-8">
             <div class="bg-white dark:bg-gray-800 rounded-lg shadow-xl pb-8">
                 <div class="w-full h-[250px]">
-                    <img src="{% if webshot %} {{ MEDIA_URL }}{{ webshot }} {% else %} https://versohydraulic.com/bitrix/templates/aspro-allcorp/images/background.png {% endif %} "
+                    <img loading="lazy"
+                         src="{% if webshot %} {{ MEDIA_URL }}{{ webshot }} {% else %} https://versohydraulic.com/bitrix/templates/aspro-allcorp/images/background.png {% endif %} "
                          class="w-full h-full rounded-tl-lg rounded-tr-lg object-cover"
                          alt="domain image"
                          width="100%"
                          height="100%">
                 </div>
                 <div class="flex flex-col items-center -mt-20">
-                    <img src="{% if logo %} {{ MEDIA_URL }}{{ logo }} {% else %} https://via.placeholder.com/160?text=No+Logo {% endif %}"
+                    <img loading="lazy"
+                         src="{% if logo %} {{ MEDIA_URL }}{{ logo }} {% else %} https://via.placeholder.com/160?text=No+Logo {% endif %}"
                          class="w-40 h-40 border-4 rounded-full"
                          width="160px"
                          height="160px"
@@ -290,7 +292,7 @@
                         {% for hunt in ongoing_bughunts %}
                             <div class="flex w-full md:w-[48%] lg:w-[30%] h-[180px] border-2 border-gray-300 dark:border-gray-600 p-2 cursor-pointer shadow-sm hover:scale-105 hover:shadow-lg transition-all m-2 sm:mt-5 rounded-lg">
                                 <div class="flex justify-center items-center w-[40%]">
-                                    <img class="w-32 h-32 rounded-lg" {{ hunt.logo }} src="{% if hunt.logo %} {{ MEDIA_URL }}{{ hunt.logo }} {% else %} https://via.placeholder.com/128?text=No+Logo {% endif %}" alt="bugbounty logo" width="128px" height="128px">
+                                    <img loading="lazy" class="w-32 h-32 rounded-lg" {{ hunt.logo }} src="{% if hunt.logo %} {{ MEDIA_URL }}{{ hunt.logo }} {% else %} https://via.placeholder.com/128?text=No+Logo {% endif %}" alt="bugbounty logo" width="128px" height="128px">
                                 </div>
                                 <div class="flex flex-col ml-5 w-[60%]">
                                     <p class="text-lg font-extrabold mt-6">{{ hunt.name }}</p>
@@ -329,7 +331,8 @@
                         {% for issue in latest_issues %}
                             <div class="w-full h-[200px] flex px-5 my-2 py-6 bg-white dark:bg-gray-800 rounded-lg shadow-md hover:shadow-xl transition-all">
                                 <div class="w-[10%] mr-5 h-full flex items-center">
-                                    <img src="{% if issue.first_screenshot %} {{ MEDIA_URL }}{{ issue.first_screenshot }} {% else %} https://via.placeholder.com/100?text=No+Screenshot {% endif %}"
+                                    <img loading="lazy"
+                                         src="{% if issue.first_screenshot %} {{ MEDIA_URL }}{{ issue.first_screenshot }} {% else %} https://via.placeholder.com/100?text=No+Screenshot {% endif %}"
                                          alt="bug"
                                          width="100%"
                                          height="100%">
@@ -354,7 +357,8 @@
                                         <div>
                                             <a class="flex items-center"
                                                href="{% url 'profile' issue.user__username %}">
-                                                <img class="mr-3 w-10 h-10 object-cover rounded-full hidden sm:block"
+                                                <img loading="lazy"
+                                                     class="mr-3 w-10 h-10 object-cover rounded-full hidden sm:block"
                                                      src="{% if issue.user__userprofile__user_avatar %} {{ MEDIA_URL }}{{ issue.user__userprofile__user_avatar }} {% else %} https://via.placeholder.com/40?text=No+Avatar {% endif %}"
                                                      alt="avatar"
                                                      width="40px"
@@ -383,7 +387,8 @@
                             <a href="{% url 'profile' tester.user__username %}"
                                class="flex flex-col items-center m-5 justify-center text-gray-800 dark:text-gray-200 hover:text-red-600"
                                title="View Profile">
-                                <img src="{% if tester.user__userprofile__user_avatar %} {{ MEDIA_URL }}{{ tester.user__userprofile__user_avatar }} {% else %} https://via.placeholder.com/100?text=No+Avatar {% endif %}"
+                                <img loading="lazy"
+                                     src="{% if tester.user__userprofile__user_avatar %} {{ MEDIA_URL }}{{ tester.user__userprofile__user_avatar }} {% else %} https://via.placeholder.com/100?text=No+Avatar {% endif %}"
                                      class="w-[100px] rounded-full"
                                      alt="tester avatar"
                                      width="100px"
@@ -400,44 +405,44 @@
     {% block script %}
         <script>
         document.addEventListener('DOMContentLoaded', function() {
-            // Monthly Activity Chart
-            const DATA_SET_VERTICAL_BAR_CHART_1 = JSON.parse('{{ monthly_activity_chart|escapejs | safe }}');
+        // Monthly Activity Chart
+        const DATA_SET_VERTICAL_BAR_CHART_1 = JSON.parse('{{ monthly_activity_chart|escapejs | safe }}');
 
-            const labels_vertical_bar_chart = ['January', 'February', 'Mart', 'April', 'May', 'Jun', 'July', 'August', 'September', 'October', 'November', 'December'];
+        const labels_vertical_bar_chart = ['January', 'February', 'Mart', 'April', 'May', 'Jun', 'July', 'August', 'September', 'October', 'November', 'December'];
 
             const dataVerticalBarChart= {
-                labels: labels_vertical_bar_chart,
-                datasets: [
-                    {
-                        label: 'Bugs Reported',
-                        data: DATA_SET_VERTICAL_BAR_CHART_1,
-                        borderColor: 'rgb(54, 162, 235)',
-                        backgroundColor: 'rgba(54, 162, 235, 0.5)',
+            labels: labels_vertical_bar_chart,
+            datasets: [
+                {
+                    label: 'Bugs Reported',
+                    data: DATA_SET_VERTICAL_BAR_CHART_1,
+                    borderColor: 'rgb(54, 162, 235)',
+                    backgroundColor: 'rgba(54, 162, 235, 0.5)',
+                }
+            ]
+        };
+        const configVerticalBarChart = {
+            type: 'bar',
+            data: dataVerticalBarChart,
+            options: {
+                responsive: true,
+                plugins: {
+                    legend: {
+                        position: 'top',
+                    },
+                    title: {
+                        display: true,
+                        text: 'Monthly Activity'
                     }
-                ]
-            };
-            const configVerticalBarChart = {
-                type: 'bar',
-                data: dataVerticalBarChart,
-                options: {
-                    responsive: true,
-                    plugins: {
-                        legend: {
-                            position: 'top',
-                        },
-                        title: {
-                            display: true,
-                            text: 'Monthly Activity'
-                        }
-                    }
-                },
-            };
+                }
+            },
+        };
 
-            var verticalBarChart = new Chart(
-                document.getElementById('verticalBarChart'),
-                configVerticalBarChart
-            );
-        });
+        var verticalBarChart = new Chart(
+            document.getElementById('verticalBarChart'),
+            configVerticalBarChart
+        );
+    });
         </script>
     {% endblock script %}
 {% endblock content %}

--- a/website/templates/organization/organization_detail.html
+++ b/website/templates/organization/organization_detail.html
@@ -40,7 +40,8 @@
                     <div class="flex items-center space-x-4">
                         {% if organization.logo %}
                             <div class="w-24 h-24 bg-white dark:bg-gray-800 rounded-lg shadow-md p-2 flex items-center justify-center">
-                                <img src="{{ MEDIA_URL }}{{ organization.logo }}"
+                                <img loading="lazy"
+                                     src="{{ MEDIA_URL }}{{ organization.logo }}"
                                      alt="{{ organization.name }} logo"
                                      width="96"
                                      height="96"
@@ -418,7 +419,8 @@
                             <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4 hover:shadow-md transition-shadow duration-200">
                                 <h3 class="font-semibold text-gray-900 dark:text-gray-100 mb-2">Administrator</h3>
                                 <div class="flex items-center space-x-3">
-                                    <img src="{% gravatar_url organization.admin.email 40 %}"
+                                    <img loading="lazy"
+                                         src="{% gravatar_url organization.admin.email 40 %}"
                                          alt="{{ organization.admin.username }}"
                                          width="40"
                                          height="40"
@@ -438,7 +440,8 @@
                                 <div class="space-y-3">
                                     {% for manager in organization.managers.all %}
                                         <div class="flex items-center space-x-3">
-                                            <img src="{% gravatar_url manager.email 32 %}"
+                                            <img loading="lazy"
+                                                 src="{% gravatar_url manager.email 32 %}"
                                                  alt="{{ manager.username }}"
                                                  width="32"
                                                  height="32"
@@ -474,7 +477,8 @@
                                         <div class="flex-1">
                                             <div class="flex items-center space-x-3">
                                                 {% if project_data.project.logo %}
-                                                    <img src="{{ project_data.project.logo.url }}"
+                                                    <img loading="lazy"
+                                                         src="{{ project_data.project.logo.url }}"
                                                          alt="{{ project_data.project.name }} logo"
                                                          width="32"
                                                          height="32"
@@ -519,7 +523,8 @@
                                 <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4 hover:shadow-md transition-shadow duration-200">
                                     <div class="flex items-center space-x-3">
                                         {% if contributor.avatar_url %}
-                                            <img src="{{ contributor.avatar_url }}"
+                                            <img loading="lazy"
+                                                 src="{{ contributor.avatar_url }}"
                                                  alt="{{ contributor.username }}"
                                                  width="40"
                                                  height="40"
@@ -619,7 +624,8 @@
                                                 <td class="px-6 py-4 whitespace-nowrap">
                                                     <div class="flex items-center">
                                                         {% if item.avatar_url %}
-                                                            <img src="{{ item.avatar_url }}"
+                                                            <img loading="lazy"
+                                                                 src="{{ item.avatar_url }}"
                                                                  alt="{{ item.username }}"
                                                                  width="40"
                                                                  height="40"
@@ -718,137 +724,137 @@
 {% endblock %}
 {% block after_js %}
     <script>
-function syncGithubProjects() {
-    const button = event.target.closest('button');
-    const originalContent = button.innerHTML;
-    button.disabled = true;
-    button.innerHTML = '<i class="fas fa-spinner fa-spin mr-2"></i>Syncing...';
+    function syncGithubProjects() {
+        const button = event.target.closest('button');
+        const originalContent = button.innerHTML;
+        button.disabled = true;
+        button.innerHTML = '<i class="fas fa-spinner fa-spin mr-2"></i>Syncing...';
 
-    fetch('/stats/sync-github-projects/', {
-        method: 'POST',
-        headers: {
-            'X-CSRFToken': '{{ csrf_token }}'
-        }
-    })
-    .then(response => response.json())
-    .then(data => {
-        if (data.success) {
-            location.reload();
-        } else {
-            alert('Failed to sync projects. Please try again.');
-            button.disabled = false;
-            button.innerHTML = originalContent;
-        }
-    })
-    .catch(error => {
-        console.error('Error:', error);
-        alert('An error occurred while syncing projects.');
-        button.disabled = false;
-        button.innerHTML = originalContent;
-    });
-}
-
-function updateGithubRepos(slug) {
-    const button = document.getElementById('updateReposBtn');
-    const statusArea = document.getElementById('repoUpdateStatus');
-    const statusMessages = document.getElementById('statusMessages');
-    
-    // Disable button and show status area
-    button.disabled = true;
-    button.innerHTML = '<i class="fas fa-spinner fa-spin mr-2"></i>Updating...';
-    statusArea.classList.remove('hidden');
-    statusMessages.innerHTML = '';
-    
-    // Style the status area to look like a terminal
-    statusMessages.className = 'text-sm font-mono bg-gray-900 text-green-400 p-3 rounded max-h-96 overflow-y-auto';
-    
-    // Connect to the server-sent events endpoint
-    let eventSource;
-    try {
-        eventSource = new EventSource(`/organization/${slug}/update-repos/`);
-    } catch (err) {
-        console.error('Error creating EventSource:', err);
-        statusMessages.innerHTML = `<div class="text-red-500">Error: ${err.message}</div>`;
-        button.disabled = false;
-        button.innerHTML = '<i class="fas fa-sync-alt mr-2"></i>Update GitHub Repositories';
-        return;
+        fetch('/stats/sync-github-projects/', {
+            method: 'POST',
+            headers: {
+                'X-CSRFToken': '{{ csrf_token }}'
+            }
+        })
+            .then(response => response.json())
+            .then(data => {
+                if (data.success) {
+                    location.reload();
+                } else {
+                    alert('Failed to sync projects. Please try again.');
+                    button.disabled = false;
+                    button.innerHTML = originalContent;
+                }
+            })
+            .catch(error => {
+                console.error('Error:', error);
+                alert('An error occurred while syncing projects.');
+                button.disabled = false;
+                button.innerHTML = originalContent;
+            });
     }
-    
-    // Set a timeout to detect connection issues
-    const connectionTimeout = setTimeout(() => {
-        if (eventSource.readyState !== EventSource.OPEN) {
-            statusMessages.innerHTML += '<div class="text-red-500">Error: Connection timeout</div>';
-            eventSource.close();
+
+    function updateGithubRepos(slug) {
+        const button = document.getElementById('updateReposBtn');
+        const statusArea = document.getElementById('repoUpdateStatus');
+        const statusMessages = document.getElementById('statusMessages');
+
+        // Disable button and show status area
+        button.disabled = true;
+        button.innerHTML = '<i class="fas fa-spinner fa-spin mr-2"></i>Updating...';
+        statusArea.classList.remove('hidden');
+        statusMessages.innerHTML = '';
+
+        // Style the status area to look like a terminal
+        statusMessages.className = 'text-sm font-mono bg-gray-900 text-green-400 p-3 rounded max-h-96 overflow-y-auto';
+
+        // Connect to the server-sent events endpoint
+        let eventSource;
+        try {
+            eventSource = new EventSource(`/organization/${slug}/update-repos/`);
+        } catch (err) {
+            console.error('Error creating EventSource:', err);
+            statusMessages.innerHTML = `<div class="text-red-500">Error: ${err.message}</div>`;
             button.disabled = false;
             button.innerHTML = '<i class="fas fa-sync-alt mr-2"></i>Update GitHub Repositories';
-        }
-    }, 10000); // 10 second timeout
-    
-    // Handle connection open
-    eventSource.onopen = function() {
-        clearTimeout(connectionTimeout);
-    };
-    
-    // Handle incoming messages
-    eventSource.onmessage = function(event) {
-        const message = event.data;
-        
-        // Check if the update is complete
-        if (message.includes('DONE')) {
-            clearTimeout(connectionTimeout);
-            eventSource.close();
-            button.disabled = false;
-            button.innerHTML = '<i class="fas fa-sync-alt mr-2"></i>Update GitHub Repositories';
-            
-            // Add a refresh button
-            const refreshBtn = document.createElement('button');
-            refreshBtn.className = 'mt-2 inline-flex items-center px-3 py-2 text-sm font-medium text-white bg-[#e74c3c] rounded-md hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[#e74c3c] transition-colors duration-200';
-            refreshBtn.innerHTML = '<i class="fas fa-redo mr-2"></i>Refresh Page';
-            refreshBtn.onclick = function() { location.reload(); };
-            statusArea.appendChild(refreshBtn);
-            
             return;
         }
-        
-        // Add the message to the terminal
-        const line = document.createElement('div');
-        
-        // Style based on message content
-        if (message.includes('Error:') || message.includes('[error]')) {
-            line.className = 'text-red-500';
-        } else if (message.includes('[created]')) {
-            line.className = 'text-blue-400';
-        } else if (message.includes('[updated]')) {
-            line.className = 'text-yellow-400';
-        }
-        
-        line.textContent = message;
-        statusMessages.appendChild(line);
-        
-        // Auto-scroll to the bottom
-        statusMessages.scrollTop = statusMessages.scrollHeight;
-    };
-    
-    // Handle errors
+
+        // Set a timeout to detect connection issues
+        const connectionTimeout = setTimeout(() => {
+            if (eventSource.readyState !== EventSource.OPEN) {
+                statusMessages.innerHTML += '<div class="text-red-500">Error: Connection timeout</div>';
+                eventSource.close();
+                button.disabled = false;
+                button.innerHTML = '<i class="fas fa-sync-alt mr-2"></i>Update GitHub Repositories';
+            }
+        }, 10000); // 10 second timeout
+
+        // Handle connection open
+    eventSource.onopen = function() {
+            clearTimeout(connectionTimeout);
+        };
+
+        // Handle incoming messages
+    eventSource.onmessage = function(event) {
+            const message = event.data;
+
+            // Check if the update is complete
+            if (message.includes('DONE')) {
+                clearTimeout(connectionTimeout);
+                eventSource.close();
+                button.disabled = false;
+                button.innerHTML = '<i class="fas fa-sync-alt mr-2"></i>Update GitHub Repositories';
+
+                // Add a refresh button
+                const refreshBtn = document.createElement('button');
+                refreshBtn.className = 'mt-2 inline-flex items-center px-3 py-2 text-sm font-medium text-white bg-[#e74c3c] rounded-md hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[#e74c3c] transition-colors duration-200';
+                refreshBtn.innerHTML = '<i class="fas fa-redo mr-2"></i>Refresh Page';
+            refreshBtn.onclick = function() { location.reload(); };
+                statusArea.appendChild(refreshBtn);
+
+                return;
+            }
+
+            // Add the message to the terminal
+            const line = document.createElement('div');
+
+            // Style based on message content
+            if (message.includes('Error:') || message.includes('[error]')) {
+                line.className = 'text-red-500';
+            } else if (message.includes('[created]')) {
+                line.className = 'text-blue-400';
+            } else if (message.includes('[updated]')) {
+                line.className = 'text-yellow-400';
+            }
+
+            line.textContent = message;
+            statusMessages.appendChild(line);
+
+            // Auto-scroll to the bottom
+            statusMessages.scrollTop = statusMessages.scrollHeight;
+        };
+
+        // Handle errors
     eventSource.onerror = function(error) {
-        clearTimeout(connectionTimeout);
-        console.error('EventSource error:', error);
-        
-        eventSource.close();
-        
-        statusMessages.innerHTML += '<div class="text-red-500">Error: Connection to the server was lost</div>';
-        
-        // Add a retry button
-        const retryBtn = document.createElement('button');
-        retryBtn.className = 'mt-2 inline-flex items-center px-3 py-2 text-sm font-medium text-white bg-[#e74c3c] rounded-md hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[#e74c3c] transition-colors duration-200';
-        retryBtn.innerHTML = '<i class="fas fa-redo mr-2"></i>Retry';
+            clearTimeout(connectionTimeout);
+            console.error('EventSource error:', error);
+
+            eventSource.close();
+
+            statusMessages.innerHTML += '<div class="text-red-500">Error: Connection to the server was lost</div>';
+
+            // Add a retry button
+            const retryBtn = document.createElement('button');
+            retryBtn.className = 'mt-2 inline-flex items-center px-3 py-2 text-sm font-medium text-white bg-[#e74c3c] rounded-md hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[#e74c3c] transition-colors duration-200';
+            retryBtn.innerHTML = '<i class="fas fa-redo mr-2"></i>Retry';
         retryBtn.onclick = function() { updateGithubRepos(slug); };
-        statusArea.appendChild(retryBtn);
-        
-        button.disabled = false;
-        button.innerHTML = '<i class="fas fa-sync-alt mr-2"></i>Update GitHub Repositories';
-    };
-}
+            statusArea.appendChild(retryBtn);
+
+            button.disabled = false;
+            button.innerHTML = '<i class="fas fa-sync-alt mr-2"></i>Update GitHub Repositories';
+        };
+    }
     </script>
     <!-- Add Leaflet JavaScript -->
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
@@ -856,22 +862,22 @@ function updateGithubRepos(slug) {
             crossorigin=""></script>
     {% if organization.latitude and organization.longitude %}
         <script>
-            // Initialize the map
+    // Initialize the map
             const map = L.map('org-map').setView([{{ organization.latitude }}, {{ organization.longitude }}], 13);
-            
-            // Add OpenStreetMap tiles
-            L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-                maxZoom: 19,
-                attribution: '© OpenStreetMap contributors'
-            }).addTo(map);
-            
-            // Add a marker for the organization's location
+
+    // Add OpenStreetMap tiles
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+        maxZoom: 19,
+        attribution: '© OpenStreetMap contributors'
+    }).addTo(map);
+
+    // Add a marker for the organization's location
             const marker = L.marker([{{ organization.latitude }}, {{ organization.longitude }}])
                 .addTo(map)
-                .bindPopup("{{ organization.name }}");
-            
-            // Open the popup by default
-            marker.openPopup();
+        .bindPopup("{{ organization.name }}");
+
+    // Open the popup by default
+    marker.openPopup();
         </script>
     {% endif %}
 {% endblock %}

--- a/website/templates/projects/project_detail.html
+++ b/website/templates/projects/project_detail.html
@@ -42,7 +42,8 @@
                     <div class="relative flex items-center h-full px-8">
                         <div class="flex items-center gap-6">
                             {% if project.organization.logo %}
-                                <img src="{{ project.organization.logo.url }}"
+                                <img loading="lazy"
+                                     src="{{ project.organization.logo.url }}"
                                      width="50"
                                      height="50"
                                      alt="{{ project.organization.name }}"
@@ -78,7 +79,8 @@
             <div class="bg-gradient-to-r from-red-500 to-red-600 p-6">
                 <div class="flex items-start gap-6">
                     {% if project.logo %}
-                        <img src="{{ project.logo.url }}"
+                        <img loading="lazy"
+                             src="{{ project.logo.url }}"
                              width="60"
                              height="60"
                              alt="{{ project.name }}"
@@ -403,7 +405,7 @@
     <script>
     function copyToClipboard(elementId) {
         const element = document.getElementById(elementId);
-        
+
         // Select the text
         element.select();
         element.setSelectionRange(0, 99999); // For mobile devices
@@ -414,12 +416,12 @@
                 // Get the button
                 const button = element.nextElementSibling;
                 const originalText = button.textContent;
-                
+
                 // Change button style to show success
                 button.textContent = 'Copied!';
                 button.classList.remove('bg-red-500', 'hover:bg-red-600');
                 button.classList.add('bg-green-500', 'hover:bg-green-600');
-                
+
                 // Reset button after 2 seconds
                 setTimeout(() => {
                     button.textContent = originalText;

--- a/website/templates/projects/repo_detail.html
+++ b/website/templates/projects/repo_detail.html
@@ -52,7 +52,8 @@
                 <div class="flex-1">
                     <div class="flex items-center gap-4 mb-4">
                         {% if repo.logo_url %}
-                            <img src="{{ repo.logo_url }}"
+                            <img loading="lazy"
+                                 src="{{ repo.logo_url }}"
                                  width="40"
                                  height="40"
                                  alt="{{ repo.name }} logo"
@@ -539,7 +540,8 @@
                             <div class="grid grid-cols-1 md:grid-cols-2 gap-4 contributors-grid">
                                 {% for contributor in top_contributors %}
                                     <div class="flex items-center gap-4 p-3 bg-gray-50 dark:bg-gray-900 rounded-lg hover:bg-gray-100 transition-colors group">
-                                        <img src="{{ contributor.avatar_url }}"
+                                        <img loading="lazy"
+                                             src="{{ contributor.avatar_url }}"
                                              width="30"
                                              height="30"
                                              alt="{{ contributor.name }}"
@@ -1318,7 +1320,8 @@
                 <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
                     {% for stargazer in stargazers %}
                         <div class="flex items-center space-x-3 p-3 bg-gray-50 dark:bg-gray-900 rounded-lg hover:bg-gray-100 transition-colors">
-                            <img src="{{ stargazer.avatar_url }}"
+                            <img loading="lazy"
+                                 src="{{ stargazer.avatar_url }}"
                                  alt="{{ stargazer.login }}'s avatar"
                                  class="w-10 h-10 rounded-full"
                                  height="40"
@@ -1376,34 +1379,34 @@
     {{ block.super }}
     <script>
         document.addEventListener('DOMContentLoaded', function() {
-            const refreshButton = document.getElementById('refresh-github-data');
-            const loadingOverlay = document.getElementById('loadingOverlay');
-            
-            if (refreshButton) {
+        const refreshButton = document.getElementById('refresh-github-data');
+        const loadingOverlay = document.getElementById('loadingOverlay');
+
+        if (refreshButton) {
                 refreshButton.addEventListener('click', function() {
-                    const repoId = this.getAttribute('data-repo-id');
-                    
-                    // Show loading overlay
-                    if (loadingOverlay) {
-                        loadingOverlay.classList.remove('hidden');
-                    }
-                    
-                    // Disable the button to prevent multiple clicks
-                    refreshButton.disabled = true;
-                    refreshButton.classList.add('opacity-50', 'cursor-not-allowed');
-                    
-                    // Get CSRF token
-                    const csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
-                    
-                    // Make the AJAX request to refresh the data
-                    fetch(`/repository/${repoId}/refresh/`, {
-                        method: 'POST',
-                        headers: {
-                            'X-CSRFToken': csrfToken,
-                            'Content-Type': 'application/json'
-                        },
-                        credentials: 'same-origin'
-                    })
+                const repoId = this.getAttribute('data-repo-id');
+
+                // Show loading overlay
+                if (loadingOverlay) {
+                    loadingOverlay.classList.remove('hidden');
+                }
+
+                // Disable the button to prevent multiple clicks
+                refreshButton.disabled = true;
+                refreshButton.classList.add('opacity-50', 'cursor-not-allowed');
+
+                // Get CSRF token
+                const csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
+
+                // Make the AJAX request to refresh the data
+                fetch(`/repository/${repoId}/refresh/`, {
+                    method: 'POST',
+                    headers: {
+                        'X-CSRFToken': csrfToken,
+                        'Content-Type': 'application/json'
+                    },
+                    credentials: 'same-origin'
+                })
                     .then(response => {
                         if (!response.ok) {
                             throw new Error(`Network response was not ok: ${response.status}`);
@@ -1415,21 +1418,21 @@
                         const issuesCount = document.getElementById('issues-count');
                         const prsCount = document.getElementById('prs-count');
                         const dollarTagCount = document.getElementById('dollar-tag-count');
-                        
+
                         if (issuesCount) issuesCount.textContent = data.data.issues_count;
                         if (prsCount) prsCount.textContent = data.data.prs_count;
                         if (dollarTagCount) dollarTagCount.textContent = data.data.dollar_tag_count;
-                        
+
                         // Update the last updated text
                         const lastUpdatedText = document.getElementById('last-updated-text');
                         if (lastUpdatedText && data.data.last_updated) {
                             const lastUpdated = new Date(data.data.last_updated);
                             lastUpdatedText.textContent = `Last updated: ${lastUpdated.toLocaleString()}`;
                         }
-                        
+
                         // Show success message
                         alert('Repository data refreshed successfully! Reload the page to see the updated issues and PRs.');
-                        
+
                         // Optional: Reload the page to show updated data
                         // window.location.reload();
                     })
@@ -1442,14 +1445,14 @@
                         if (loadingOverlay) {
                             loadingOverlay.classList.add('hidden');
                         }
-                        
+
                         // Re-enable the button
                         refreshButton.disabled = false;
                         refreshButton.classList.remove('opacity-50', 'cursor-not-allowed');
                     });
-                });
-            }
-        });
+            });
+        }
+    });
     </script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script src="{% static 'js/repo_detail.js' %}"></script>

--- a/website/templates/queue/list.html
+++ b/website/templates/queue/list.html
@@ -131,7 +131,8 @@
                                 <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Image</label>
                                 <div class="relative">
                                     <div id="viewImageContainer" class="hidden">
-                                        <img id="viewImage"
+                                        <img loading="lazy"
+                                             id="viewImage"
                                              src=""
                                              alt="Queue image"
                                              width="600"
@@ -226,7 +227,8 @@
                                     </div>
                                 </div>
                                 <div id="createImagePreview" class="mt-4 hidden">
-                                    <img id="createPreviewImg"
+                                    <img loading="lazy"
+                                         id="createPreviewImg"
                                          src=""
                                          alt="Image preview"
                                          width="128"
@@ -290,7 +292,8 @@
                                 </label>
                                 <div id="currentImageContainer" class="mb-4 hidden">
                                     <p class="text-sm text-gray-600 dark:text-gray-400 mb-2">Current Image:</p>
-                                    <img id="currentImage"
+                                    <img loading="lazy"
+                                         id="currentImage"
                                          src=""
                                          alt="Current image"
                                          width="128"
@@ -323,7 +326,8 @@
                                 </div>
                                 <div id="editImagePreview" class="mt-4 hidden">
                                     <p class="text-sm text-gray-600 dark:text-gray-400 mb-2">New Image Preview:</p>
-                                    <img id="editPreviewImg"
+                                    <img loading="lazy"
+                                         id="editPreviewImg"
                                          src=""
                                          alt="Image preview"
                                          width="128"
@@ -453,7 +457,8 @@
                                                 </td>
                                                 <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-500">
                                                     {% if item.image %}
-                                                        <img src="{{ item.image.url }}"
+                                                        <img loading="lazy"
+                                                             src="{{ item.image.url }}"
                                                              alt="Queue image"
                                                              width="40"
                                                              height="40"
@@ -549,7 +554,8 @@
                                                 </td>
                                                 <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-500">
                                                     {% if item.image %}
-                                                        <img src="{{ item.image.url }}"
+                                                        <img loading="lazy"
+                                                             src="{{ item.image.url }}"
                                                              alt="Queue image"
                                                              width="144"
                                                              height="144"
@@ -689,7 +695,8 @@
                                     </td>
                                     <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-500">
                                         {% if item.image %}
-                                            <img src="{{ item.image.url }}"
+                                            <img loading="lazy"
+                                                 src="{{ item.image.url }}"
                                                  alt="Queue image"
                                                  width="40"
                                                  height="40"
@@ -858,238 +865,238 @@
         </div>
     </div>
     <script>
-        function isSafeImageUrl(url) {
-    try {
-        const parsed = new URL(url, window.location.origin);
-        return parsed.protocol === 'http:' || parsed.protocol === 'https:';
-    } catch {
-        return false;
+    function isSafeImageUrl(url) {
+        try {
+            const parsed = new URL(url, window.location.origin);
+            return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+        } catch {
+            return false;
+        }
     }
-}
 
 document.addEventListener('DOMContentLoaded', function() {
-    // Launch Control functionality
-    const showLaunchControlBtn = document.getElementById('showLaunchControlBtn');
-    const closeLaunchControlBtn = document.getElementById('closeLaunchControlBtn');
-    const launchControlContainer = document.getElementById('launchControlContainer');
+        // Launch Control functionality
+        const showLaunchControlBtn = document.getElementById('showLaunchControlBtn');
+        const closeLaunchControlBtn = document.getElementById('closeLaunchControlBtn');
+        const launchControlContainer = document.getElementById('launchControlContainer');
 
-    if (showLaunchControlBtn && launchControlContainer) {
+        if (showLaunchControlBtn && launchControlContainer) {
         showLaunchControlBtn.addEventListener('click', function() {
-            launchControlContainer.classList.remove('hidden');
-            launchControlContainer.scrollIntoView({ behavior: 'smooth' });
-        });
-    }
+                launchControlContainer.classList.remove('hidden');
+                launchControlContainer.scrollIntoView({ behavior: 'smooth' });
+            });
+        }
 
-    if (closeLaunchControlBtn && launchControlContainer) {
+        if (closeLaunchControlBtn && launchControlContainer) {
         closeLaunchControlBtn.addEventListener('click', function() {
-            launchControlContainer.classList.add('hidden');
-        });
-    }
+                launchControlContainer.classList.add('hidden');
+            });
+        }
 
-    // Modal functionality
-    function showModal(modalId) {
-        const modal = document.getElementById(modalId);
-        modal.classList.remove('hidden');
-        modal.classList.add('flex');
-        document.body.style.overflow = 'hidden';
-    }
+        // Modal functionality
+        function showModal(modalId) {
+            const modal = document.getElementById(modalId);
+            modal.classList.remove('hidden');
+            modal.classList.add('flex');
+            document.body.style.overflow = 'hidden';
+        }
 
-    function hideModal(modalId) {
-        const modal = document.getElementById(modalId);
-        modal.classList.remove('flex');
-        modal.classList.add('hidden');
-        document.body.style.overflow = 'auto';
-    }
+        function hideModal(modalId) {
+            const modal = document.getElementById(modalId);
+            modal.classList.remove('flex');
+            modal.classList.add('hidden');
+            document.body.style.overflow = 'auto';
+        }
 
-    // Create form functionality
-    const showCreateFormBtn = document.getElementById('showCreateFormBtn');
-    const closeCreateFormBtn = document.getElementById('closeCreateFormBtn');
-    const createFormContainer = document.getElementById('createFormContainer');
-    const createMessage = document.getElementById('createMessage');
-    const createCharCount = document.getElementById('createCharCount');
-    const createImage = document.getElementById('createImage');
-    const createImagePreview = document.getElementById('createImagePreview');
-    const createPreviewImg = document.getElementById('createPreviewImg');
+        // Create form functionality
+        const showCreateFormBtn = document.getElementById('showCreateFormBtn');
+        const closeCreateFormBtn = document.getElementById('closeCreateFormBtn');
+        const createFormContainer = document.getElementById('createFormContainer');
+        const createMessage = document.getElementById('createMessage');
+        const createCharCount = document.getElementById('createCharCount');
+        const createImage = document.getElementById('createImage');
+        const createImagePreview = document.getElementById('createImagePreview');
+        const createPreviewImg = document.getElementById('createPreviewImg');
 
-    if (showCreateFormBtn) {
-        showCreateFormBtn.addEventListener('click', () => showModal('createFormContainer'));
-    }
+        if (showCreateFormBtn) {
+            showCreateFormBtn.addEventListener('click', () => showModal('createFormContainer'));
+        }
 
-    if (closeCreateFormBtn) {
-        closeCreateFormBtn.addEventListener('click', () => hideModal('createFormContainer'));
-    }
+        if (closeCreateFormBtn) {
+            closeCreateFormBtn.addEventListener('click', () => hideModal('createFormContainer'));
+        }
 
-    if (createMessage) {
+        if (createMessage) {
         createMessage.addEventListener('input', function() {
-            createCharCount.textContent = this.value.length;
-        });
-    }
+                createCharCount.textContent = this.value.length;
+            });
+        }
 
-    if (createImage) {
+        if (createImage) {
         createImage.addEventListener('change', function() {
-            if (this.files && this.files[0]) {
-                const reader = new FileReader();
+                if (this.files && this.files[0]) {
+                    const reader = new FileReader();
                 reader.onload = function(e) {
-                    createPreviewImg.src = e.target.result;
-                    createImagePreview.classList.remove('hidden');
-                };
-                reader.readAsDataURL(this.files[0]);
-            } else {
-                createImagePreview.classList.add('hidden');
-            }
-        });
-    }
+                        createPreviewImg.src = e.target.result;
+                        createImagePreview.classList.remove('hidden');
+                    };
+                    reader.readAsDataURL(this.files[0]);
+                } else {
+                    createImagePreview.classList.add('hidden');
+                }
+            });
+        }
 
-    // Edit form functionality
-    const editBtns = document.querySelectorAll('.edit-btn');
-    const closeEditFormBtn = document.getElementById('closeEditFormBtn');
-    const editFormContainer = document.getElementById('editFormContainer');
-    const editQueueId = document.getElementById('editQueueId');
-    const editMessage = document.getElementById('editMessage');
-    const editCharCount = document.getElementById('editCharCount');
-    const editImage = document.getElementById('editImage');
-    const currentImageContainer = document.getElementById('currentImageContainer');
-    const currentImage = document.getElementById('currentImage');
-    const editImagePreview = document.getElementById('editImagePreview');
-    const editPreviewImg = document.getElementById('editPreviewImg');
+        // Edit form functionality
+        const editBtns = document.querySelectorAll('.edit-btn');
+        const closeEditFormBtn = document.getElementById('closeEditFormBtn');
+        const editFormContainer = document.getElementById('editFormContainer');
+        const editQueueId = document.getElementById('editQueueId');
+        const editMessage = document.getElementById('editMessage');
+        const editCharCount = document.getElementById('editCharCount');
+        const editImage = document.getElementById('editImage');
+        const currentImageContainer = document.getElementById('currentImageContainer');
+        const currentImage = document.getElementById('currentImage');
+        const editImagePreview = document.getElementById('editImagePreview');
+        const editPreviewImg = document.getElementById('editPreviewImg');
 
     editBtns.forEach(function(btn) {
         btn.addEventListener('click', function() {
-            const id = this.getAttribute('data-id');
-            const message = this.getAttribute('data-message');
-            const imageUrl = this.getAttribute('data-image');
-            
-            editQueueId.value = id;
-            editMessage.value = message;
-            editCharCount.textContent = message.length;
-        
-            if (imageUrl && isSafeImageUrl(imageUrl)) {
-                currentImage.src = imageUrl;
-                currentImageContainer.classList.remove('hidden');
-            } else {
-                currentImage.removeAttribute('src');
-                currentImageContainer.classList.add('hidden');
-            }
-            
-            editImagePreview.classList.add('hidden');
-            showModal('editFormContainer');
-        });
-    });
+                const id = this.getAttribute('data-id');
+                const message = this.getAttribute('data-message');
+                const imageUrl = this.getAttribute('data-image');
 
-    if (closeEditFormBtn) {
-        closeEditFormBtn.addEventListener('click', () => hideModal('editFormContainer'));
-    }
+                editQueueId.value = id;
+                editMessage.value = message;
+                editCharCount.textContent = message.length;
 
-    if (editMessage) {
-        editMessage.addEventListener('input', function() {
-            editCharCount.textContent = this.value.length;
-        });
-    }
+                if (imageUrl && isSafeImageUrl(imageUrl)) {
+                    currentImage.src = imageUrl;
+                    currentImageContainer.classList.remove('hidden');
+                } else {
+                    currentImage.removeAttribute('src');
+                    currentImageContainer.classList.add('hidden');
+                }
 
-    if (editImage) {
-        editImage.addEventListener('change', function() {
-            if (this.files && this.files[0]) {
-                const reader = new FileReader();
-                reader.onload = function(e) {
-                    editPreviewImg.src = e.target.result;
-                    editImagePreview.classList.remove('hidden');
-                };
-                reader.readAsDataURL(this.files[0]);
-            } else {
                 editImagePreview.classList.add('hidden');
-            }
+                showModal('editFormContainer');
+            });
         });
-    }
 
-    // Delete confirmation functionality
-    const deleteBtns = document.querySelectorAll('.delete-btn');
-    const closeDeleteConfirmBtn = document.getElementById('closeDeleteConfirmBtn');
-    const cancelDeleteBtn = document.getElementById('cancelDeleteBtn');
-    const deleteConfirmContainer = document.getElementById('deleteConfirmContainer');
-    const deleteQueueId = document.getElementById('deleteQueueId');
-    const deleteItemId = document.getElementById('deleteItemId');
-    const deleteItemMessage = document.getElementById('deleteItemMessage');
+        if (closeEditFormBtn) {
+            closeEditFormBtn.addEventListener('click', () => hideModal('editFormContainer'));
+        }
+
+        if (editMessage) {
+        editMessage.addEventListener('input', function() {
+                editCharCount.textContent = this.value.length;
+            });
+        }
+
+        if (editImage) {
+        editImage.addEventListener('change', function() {
+                if (this.files && this.files[0]) {
+                    const reader = new FileReader();
+                reader.onload = function(e) {
+                        editPreviewImg.src = e.target.result;
+                        editImagePreview.classList.remove('hidden');
+                    };
+                    reader.readAsDataURL(this.files[0]);
+                } else {
+                    editImagePreview.classList.add('hidden');
+                }
+            });
+        }
+
+        // Delete confirmation functionality
+        const deleteBtns = document.querySelectorAll('.delete-btn');
+        const closeDeleteConfirmBtn = document.getElementById('closeDeleteConfirmBtn');
+        const cancelDeleteBtn = document.getElementById('cancelDeleteBtn');
+        const deleteConfirmContainer = document.getElementById('deleteConfirmContainer');
+        const deleteQueueId = document.getElementById('deleteQueueId');
+        const deleteItemId = document.getElementById('deleteItemId');
+        const deleteItemMessage = document.getElementById('deleteItemMessage');
 
     deleteBtns.forEach(function(btn) {
         btn.addEventListener('click', function() {
-            const id = this.getAttribute('data-id');
-            const message = this.getAttribute('data-message');
-            
-            deleteQueueId.value = id;
-            deleteItemId.textContent = id;
-            deleteItemMessage.textContent = message;
-            
-            showModal('deleteConfirmContainer');
+                const id = this.getAttribute('data-id');
+                const message = this.getAttribute('data-message');
+
+                deleteQueueId.value = id;
+                deleteItemId.textContent = id;
+                deleteItemMessage.textContent = message;
+
+                showModal('deleteConfirmContainer');
+            });
         });
-    });
 
-    if (closeDeleteConfirmBtn) {
-        closeDeleteConfirmBtn.addEventListener('click', () => hideModal('deleteConfirmContainer'));
-    }
+        if (closeDeleteConfirmBtn) {
+            closeDeleteConfirmBtn.addEventListener('click', () => hideModal('deleteConfirmContainer'));
+        }
 
-    if (cancelDeleteBtn) {
-        cancelDeleteBtn.addEventListener('click', () => hideModal('deleteConfirmContainer'));
-    }
+        if (cancelDeleteBtn) {
+            cancelDeleteBtn.addEventListener('click', () => hideModal('deleteConfirmContainer'));
+        }
 
-    // View modal functionality
-    const viewBtns = document.querySelectorAll('.view-btn');
-    const closeViewModalBtn = document.getElementById('closeViewModalBtn');
-    const viewModalContainer = document.getElementById('viewModalContainer');
-    const viewMessage = document.getElementById('viewMessage');
-    const viewImageContainer = document.getElementById('viewImageContainer');
-    const viewImage = document.getElementById('viewImage');
-    const noImageText = document.getElementById('noImageText');
-    const copyMessageBtn = document.getElementById('copyMessageBtn');
-    const copySuccessMessage = document.getElementById('copySuccessMessage');
+        // View modal functionality
+        const viewBtns = document.querySelectorAll('.view-btn');
+        const closeViewModalBtn = document.getElementById('closeViewModalBtn');
+        const viewModalContainer = document.getElementById('viewModalContainer');
+        const viewMessage = document.getElementById('viewMessage');
+        const viewImageContainer = document.getElementById('viewImageContainer');
+        const viewImage = document.getElementById('viewImage');
+        const noImageText = document.getElementById('noImageText');
+        const copyMessageBtn = document.getElementById('copyMessageBtn');
+        const copySuccessMessage = document.getElementById('copySuccessMessage');
 
-    function showCopySuccess() {
-        copySuccessMessage.classList.remove('hidden');
-        setTimeout(() => {
-            copySuccessMessage.classList.add('hidden');
-        }, 2000);
-    }
+        function showCopySuccess() {
+            copySuccessMessage.classList.remove('hidden');
+            setTimeout(() => {
+                copySuccessMessage.classList.add('hidden');
+            }, 2000);
+        }
 
     viewBtns.forEach(function(btn) {
         btn.addEventListener('click', function() {
-            const message = this.getAttribute('data-message');
-            const imageUrl = this.getAttribute('data-image');
-            
-            viewMessage.value = message;
-            
-            if (imageUrl && isSafeImageUrl(imageUrl)) {
-                viewImage.src = imageUrl;
-                viewImageContainer.classList.remove('hidden');
-                noImageText.classList.add('hidden');
-            } else {
-                viewImage.removeAttribute('src');
-                viewImageContainer.classList.add('hidden');
-                noImageText.classList.remove('hidden');
-            }
-            
-            showModal('viewModalContainer');
+                const message = this.getAttribute('data-message');
+                const imageUrl = this.getAttribute('data-image');
+
+                viewMessage.value = message;
+
+                if (imageUrl && isSafeImageUrl(imageUrl)) {
+                    viewImage.src = imageUrl;
+                    viewImageContainer.classList.remove('hidden');
+                    noImageText.classList.add('hidden');
+                } else {
+                    viewImage.removeAttribute('src');
+                    viewImageContainer.classList.add('hidden');
+                    noImageText.classList.remove('hidden');
+                }
+
+                showModal('viewModalContainer');
+            });
         });
-    });
 
-    if (closeViewModalBtn) {
-        closeViewModalBtn.addEventListener('click', () => hideModal('viewModalContainer'));
-    }
+        if (closeViewModalBtn) {
+            closeViewModalBtn.addEventListener('click', () => hideModal('viewModalContainer'));
+        }
 
-    if (copyMessageBtn) {
+        if (copyMessageBtn) {
         copyMessageBtn.addEventListener('click', function() {
-            viewMessage.select();
-            document.execCommand('copy');
-            showCopySuccess();
-        });
-    }
+                viewMessage.select();
+                document.execCommand('copy');
+                showCopySuccess();
+            });
+        }
 
-    // Close modals when clicking outside
-    document.querySelectorAll('[id$="Container"]').forEach(modal => {
+        // Close modals when clicking outside
+        document.querySelectorAll('[id$="Container"]').forEach(modal => {
         modal.addEventListener('click', function(e) {
-            if (e.target === this) {
-                hideModal(this.id);
-            }
+                if (e.target === this) {
+                    hideModal(this.id);
+                }
+            });
         });
     });
-});
     </script>
 {% endblock content %}

--- a/website/templates/search.html
+++ b/website/templates/search.html
@@ -160,7 +160,8 @@
                                                     <div class="bg-white dark:bg-gray-800 shadow-lg rounded-lg p-6 hover:shadow-2xl transition-shadow duration-300">
                                                         <div class="flex items-center mb-4 space-x-4">
                                                             {% if domain.logo %}
-                                                                <img class="h-16 w-16 object-cover rounded-lg border border-gray-300 dark:border-gray-600"
+                                                                <img loading="lazy"
+                                                                     class="h-16 w-16 object-cover rounded-lg border border-gray-300 dark:border-gray-600"
                                                                      src="{{ domain.logo.url }}"
                                                                      alt="{{ domain.name }} Logo"
                                                                      height="64"
@@ -182,7 +183,8 @@
                                                         <div class="flex items-center mb-4">
                                                             {% if domain.webshot %}
                                                                 <a href="{{ domain.webshot.url }}" target="_blank" class="ml-auto">
-                                                                    <img src="{{ domain.webshot.url }}"
+                                                                    <img loading="lazy"
+                                                                         src="{{ domain.webshot.url }}"
                                                                          alt="{{ domain.name }} Webshot"
                                                                          class="h-10 w-10 rounded-lg"
                                                                          height="40"
@@ -279,19 +281,22 @@
                                         {% for user in users %}
                                             <div class="bg-white dark:bg-gray-800 shadow-lg rounded-xl p-6 hover:shadow-2xl transition-shadow duration-300 flex items-center">
                                                 {% if user.userprofile.user_avatar %}
-                                                    <img src="{{ user.userprofile.user_avatar.url }}"
+                                                    <img loading="lazy"
+                                                         src="{{ user.userprofile.user_avatar.url }}"
                                                          class="h-24 w-24 object-cover rounded-md border border-indigo-200 mr-6"
                                                          alt="{{ user.username }}"
                                                          height="96"
                                                          width="96">
                                                 {% elif user.socialaccount_set.all.0.get_avatar_url %}
-                                                    <img src="{{ user.socialaccount_set.all.0.get_avatar_url }}"
+                                                    <img loading="lazy"
+                                                         src="{{ user.socialaccount_set.all.0.get_avatar_url }}"
                                                          class="h-24 w-24 object-cover rounded-full border border-indigo-200 mr-6"
                                                          alt="user image"
                                                          height="96"
                                                          width="96">
                                                 {% else %}
-                                                    <img src="{% static 'images/dummy-user.webp' %}"
+                                                    <img loading="lazy"
+                                                         src="{% static 'images/dummy-user.webp' %}"
                                                          class="h-24 w-24 object-cover rounded-full border border-indigo-200 mr-6"
                                                          alt="user image"
                                                          height="96"
@@ -370,7 +375,8 @@
                                                     <div class="flex flex-wrap gap-4 mt-4">
                                                         {% for badge in user.badges %}
                                                             <div class="flex items-center space-x-2 bg-gray-200 dark:bg-gray-700 rounded-md p-3">
-                                                                <img src="{{ badge.badge.icon.url }}"
+                                                                <img loading="lazy"
+                                                                     src="{{ badge.badge.icon.url }}"
                                                                      alt="{{ badge.badge.title }}"
                                                                      class="w-12 h-12 object-contain"
                                                                      title="{{ badge.badge.title }}"
@@ -403,7 +409,8 @@
                                             <div class="bg-white dark:bg-gray-800 shadow-lg rounded-xl p-6 hover:shadow-2xl transition-shadow duration-300">
                                                 <div class="flex items-center">
                                                     {% if organization.logo %}
-                                                        <img class="h-24 w-24 object-cover rounded-lg border border-indigo-200 mr-6"
+                                                        <img loading="lazy"
+                                                             class="h-24 w-24 object-cover rounded-lg border border-indigo-200 mr-6"
                                                              src="{{ organization.logo.url }}"
                                                              alt="{{ organization.name }} Logo"
                                                              height="96"
@@ -495,7 +502,8 @@
                                             <div class="bg-white dark:bg-gray-800 shadow-lg rounded-xl p-6 hover:shadow-2xl transition-shadow duration-300">
                                                 <div class="flex items-center">
                                                     {% if project.logo %}
-                                                        <img class="h-24 w-24 object-cover rounded-lg border border-indigo-200 mr-6"
+                                                        <img loading="lazy"
+                                                             class="h-24 w-24 object-cover rounded-lg border border-indigo-200 mr-6"
                                                              src="{{ project.logo.url }}"
                                                              alt="{{ project.name }} Logo"
                                                              height="96"
@@ -541,7 +549,8 @@
                                                 <div class="mt-4 flex items-center space-x-3">
                                                     {% if project.organization %}
                                                         {% if project.organization.logo %}
-                                                            <img class="h-24 w-24 object-cover rounded-lg border border-indigo-200 mr-6"
+                                                            <img loading="lazy"
+                                                                 class="h-24 w-24 object-cover rounded-lg border border-indigo-200 mr-6"
                                                                  src="{{ project.organization.logo.url }}"
                                                                  alt="{{ project.organization.name }} Logo"
                                                                  height="96"
@@ -609,7 +618,8 @@
                                                 {% for org in matching_organizations %}
                                                     <div class="bg-blue-100 text-blue-800 px-4 py-2 rounded-md shadow-md hover:shadow-lg transition-shadow flex items-center gap-3">
                                                         {% if org.logo %}
-                                                            <img src="{{ org.logo.url }}"
+                                                            <img loading="lazy"
+                                                                 src="{{ org.logo.url }}"
                                                                  alt="{{ org.name }} logo"
                                                                  class="rounded-md"
                                                                  height="32"
@@ -630,7 +640,8 @@
                                                 {% for domain in matching_domains %}
                                                     <div class="bg-green-100 text-green-800 px-4 py-2 rounded-md shadow-md hover:shadow-lg transition-shadow flex items-center gap-3">
                                                         {% if domain.logo %}
-                                                            <img src="{{ domain.logo.url }}"
+                                                            <img loading="lazy"
+                                                                 src="{{ domain.logo.url }}"
                                                                  alt="{{ domain.name }} logo"
                                                                  class="rounded-md"
                                                                  height="32"
@@ -652,7 +663,8 @@
                                                 {% for issue in matching_issues %}
                                                     <div class="bg-red-100 text-red-800 px-4 py-2 rounded-md shadow-md hover:shadow-lg transition-shadow flex items-center gap-3">
                                                         {% if issue.logo %}
-                                                            <img src="{{ issue.logo.url }}"
+                                                            <img loading="lazy"
+                                                                 src="{{ issue.logo.url }}"
                                                                  alt="{{ issue.description }} logo"
                                                                  class="rounded-md"
                                                                  height="32"
@@ -674,13 +686,15 @@
                                                 {% for profile in matching_user_profiles %}
                                                     <div class="bg-yellow-100 text-yellow-800 px-4 py-2 rounded-md shadow-md hover:shadow-lg transition-shadow flex items-center gap-3">
                                                         {% if profile.user_avatar %}
-                                                            <img src="{{ profile.user_avatar.url }}"
+                                                            <img loading="lazy"
+                                                                 src="{{ profile.user_avatar.url }}"
                                                                  alt="{{ profile.user.username }}"
                                                                  class="rounded-md"
                                                                  height="32"
                                                                  width="32">
                                                         {% else %}
-                                                            <img src="{% gravatar_url profile.user.email 200 %}"
+                                                            <img loading="lazy"
+                                                                 src="{% gravatar_url profile.user.email 200 %}"
                                                                  class="rounded-md"
                                                                  alt="avatar"
                                                                  width="32"
@@ -719,7 +733,8 @@
                                             <div class="bg-white dark:bg-gray-800 shadow-lg rounded-xl p-6 hover:shadow-2xl transition-shadow duration-300">
                                                 <div class="flex items-center">
                                                     {% if repo.logo_url %}
-                                                        <img class="h-24 w-24 object-cover rounded-lg border border-indigo-200 mr-6"
+                                                        <img loading="lazy"
+                                                             class="h-24 w-24 object-cover rounded-lg border border-indigo-200 mr-6"
                                                              src="{{ repo.logo_url }}"
                                                              alt="{{ repo.name }} Logo"
                                                              height="96"
@@ -806,54 +821,54 @@
     function scrollToSection(sectionId) {
         const section = document.getElementById(sectionId);
         if (section) {
-            section.scrollIntoView({ 
+            section.scrollIntoView({
                 behavior: 'smooth',
                 block: 'start'
             });
         }
     }
-document.addEventListener("DOMContentLoaded", function () {
-    const messageButtons = document.querySelectorAll(".start-chat");
-    messageButtons.forEach(button => {
-        button.addEventListener("click", function () {
-            const userId = this.getAttribute("data-user-id");
+    document.addEventListener("DOMContentLoaded", function () {
+        const messageButtons = document.querySelectorAll(".start-chat");
+        messageButtons.forEach(button => {
+            button.addEventListener("click", function () {
+                const userId = this.getAttribute("data-user-id");
 
-            fetch(`/messaging/start-thread/${userId}/`, {
-                method: "POST",
-                headers: {
-                    "Content-Type": "application/json",
-                    "X-CSRFToken": getCookie("csrftoken")
-                },
-                body: JSON.stringify({})
-            })
-            .then(response => response.json())
-            .then(data => {
-                if (data.success) {
-                    window.location.href = `/messaging/?thread=${data.thread_id}`;
-                } else {
-                    alert("Error starting chat.");
-                }
-            })
-            .catch(error => console.error("Error:", error));
+                fetch(`/messaging/start-thread/${userId}/`, {
+                    method: "POST",
+                    headers: {
+                        "Content-Type": "application/json",
+                        "X-CSRFToken": getCookie("csrftoken")
+                    },
+                    body: JSON.stringify({})
+                })
+                    .then(response => response.json())
+                    .then(data => {
+                        if (data.success) {
+                            window.location.href = `/messaging/?thread=${data.thread_id}`;
+                        } else {
+                            alert("Error starting chat.");
+                        }
+                    })
+                    .catch(error => console.error("Error:", error));
+            });
         });
-    });
 
-    function getCookie(name) {
-        let cookieValue = null;
-        if (document.cookie && document.cookie !== '') {
-            const cookies = document.cookie.split(';');
-            for (let i = 0; i < cookies.length; i++) {
-                const cookie = cookies[i].trim();
-                if (cookie.startsWith(name + '=')) {
-                    cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
-                    break;
+        function getCookie(name) {
+            let cookieValue = null;
+            if (document.cookie && document.cookie !== '') {
+                const cookies = document.cookie.split(';');
+                for (let i = 0; i < cookies.length; i++) {
+                    const cookie = cookies[i].trim();
+                    if (cookie.startsWith(name + '=')) {
+                        cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
+                        break;
+                    }
                 }
             }
+            return cookieValue;
         }
-        return cookieValue;
-    }
 
-});
+    });
         </script>
     {% endif %}
 {% endblock content %}

--- a/website/templates/sizzle/sizzle_docs.html
+++ b/website/templates/sizzle/sizzle_docs.html
@@ -47,7 +47,8 @@
                             Locate the most recent successful build and click on it to proceed with the download.
                         </p>
                     </div>
-                    <img src="{% static 'img/sizzle/app_finding_1.jpg' %}"
+                    <img loading="lazy"
+                         src="{% static 'img/sizzle/app_finding_1.jpg' %}"
                          alt="Finding the App on GitHub Actions"
                          height="200"
                          width="200"
@@ -62,7 +63,8 @@
                             Select the appropriate version of the app for your device and download it.
                         </p>
                     </div>
-                    <img src="{% static 'img/sizzle/app_finding_2.jpg' %}"
+                    <img loading="lazy"
+                         src="{% static 'img/sizzle/app_finding_2.jpg' %}"
                          alt="Choosing Device Version to Download"
                          height="200"
                          width="200"
@@ -75,7 +77,8 @@
                         <div class="text-xl font-semibold text-gray-800 dark:text-gray-200 mb-4">Open the App and Login</div>
                         <p class="text-gray-600 dark:text-gray-400">Once downloaded, open the app and login using your credentials.</p>
                     </div>
-                    <img src="{% static 'img/sizzle/running_sizzle_1.jpg' %}"
+                    <img loading="lazy"
+                         src="{% static 'img/sizzle/running_sizzle_1.jpg' %}"
                          alt="Logging into the App"
                          height="200"
                          width="200"
@@ -88,7 +91,8 @@
                         <div class="text-xl font-semibold text-gray-800 dark:text-gray-200 mb-4">Access the Side Menu and Click "Sizzle"</div>
                         <p class="text-gray-600 dark:text-gray-400">Open the side menu and tap on the "Sizzle" button to continue.</p>
                     </div>
-                    <img src="{% static 'img/sizzle/running_sizzle_2.jpg' %}"
+                    <img loading="lazy"
+                         src="{% static 'img/sizzle/running_sizzle_2.jpg' %}"
                          alt="Accessing Side Menu"
                          height="200"
                          width="200"
@@ -103,7 +107,8 @@
                             Enter your GitHub username in the provided field and click "Add Username".
                         </p>
                     </div>
-                    <img src="{% static 'img/sizzle/running_sizzle_3.jpg' %}"
+                    <img loading="lazy"
+                         src="{% static 'img/sizzle/running_sizzle_3.jpg' %}"
                          alt="Entering GitHub Username"
                          height="200"
                          width="200"
@@ -116,7 +121,8 @@
                         <div class="text-xl font-semibold text-gray-800 dark:text-gray-200 mb-4">Start Time Tracking</div>
                         <p class="text-gray-600 dark:text-gray-400">Click on the "Start Work" button to begin tracking your work time.</p>
                     </div>
-                    <img src="{% static 'img/sizzle/running_sizzle_4.jpg' %}"
+                    <img loading="lazy"
+                         src="{% static 'img/sizzle/running_sizzle_4.jpg' %}"
                          alt="Starting Time Tracking"
                          height="200"
                          width="200"
@@ -131,7 +137,8 @@
                             All assigned issues will be displayed here. Select any task to begin working and click on the "Run" button to start tracking time for that task.
                         </p>
                     </div>
-                    <img src="{% static 'img/sizzle/running_sizzle_5.jpg' %}"
+                    <img loading="lazy"
+                         src="{% static 'img/sizzle/running_sizzle_5.jpg' %}"
                          alt="Viewing and Selecting Tasks"
                          height="200"
                          width="200"
@@ -146,7 +153,8 @@
                             Congratulations! You are now tracking time for the selected task. Click on the "Stop" button to stop tracking once completed.
                         </p>
                     </div>
-                    <img src="{% static 'img/sizzle/running_sizzle_6.jpg' %}"
+                    <img loading="lazy"
+                         src="{% static 'img/sizzle/running_sizzle_6.jpg' %}"
                          alt="Tracking Time for Selected Task"
                          height="200"
                          width="200"
@@ -171,7 +179,8 @@
         <div class="relative">
             <button class="absolute top-4 right-4 bg-white dark:bg-gray-800 rounded-full p-2 text-gray-800 dark:text-gray-200 hover:bg-gray-200 transition duration-300"
                     id="closeModal">×</button>
-            <img src=""
+            <img loading="lazy"
+                 src=""
                  alt="Expanded Image"
                  id="modalImage"
                  height="600"
@@ -180,23 +189,23 @@
         </div>
     </div>
     <script>
-        const images = document.querySelectorAll('img');
-        const modal = document.getElementById('imageModal');
-        const modalImage = document.getElementById('modalImage');
-        const closeModal = document.getElementById('closeModal');
-        images.forEach(image => {
-            image.addEventListener('click', () => {
-                modal.classList.remove('hidden');
-                modalImage.src = image.src;
-            });
+    const images = document.querySelectorAll('img');
+    const modal = document.getElementById('imageModal');
+    const modalImage = document.getElementById('modalImage');
+    const closeModal = document.getElementById('closeModal');
+    images.forEach(image => {
+        image.addEventListener('click', () => {
+            modal.classList.remove('hidden');
+            modalImage.src = image.src;
         });
-        closeModal.addEventListener('click', () => {
+    });
+    closeModal.addEventListener('click', () => {
+        modal.classList.add('hidden');
+    });
+    window.addEventListener('click', (e) => {
+        if (e.target === modal) {
             modal.classList.add('hidden');
-        });
-        window.addEventListener('click', (e) => {
-            if (e.target === modal) {
-                modal.classList.add('hidden');
-            }
-        });
+        }
+    });
     </script>
 {% endblock content %}


### PR DESCRIPTION
### Summary
Implemented loading="lazy" for image tags across the major high-impact templates.
This covers the high-priority and medium-priority files identified in the analysis (features, home, contribute, search, index3, and others with multiple images).

### Improvements

- Reduces initial page load time
- Defers off-screen images

### Follow-up
Remaining low-priority templates can be handled later if needed.
closes: #5251 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced GitHub project synchronization UI with real-time status updates, retry functionality, and improved error feedback
  * Improved image viewer with enhanced modal interactions including close button and outside-click handling

* **Performance**
  * Implemented lazy loading for images across all pages to reduce initial page load time and improve overall performance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->