### PR TITLE
chore: Removed Available mentors

### DIFF
--- a/website/templates/gsoc.html
+++ b/website/templates/gsoc.html
@@ -1031,46 +1031,6 @@
                         </div>
                     </div>
                 </div>
-                <!-- Available Mentors Section -->
-                <div class="mt-16 bg-gray-50 dark:bg-gray-900 rounded-xl p-8 border border-gray-200 dark:border-gray-700">
-                    <h3 class="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-6 text-center">
-                        Available Mentors for Future Students
-                    </h3>
-                    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-                        <!-- Manikandan Chandran -->
-                        <div class="bg-white dark:bg-gray-800 rounded-lg p-6 border border-gray-200 dark:border-gray-700">
-                            <div class="flex items-center gap-3 mb-3">
-                                <div class="w-12 h-12 bg-red-100 rounded-full flex items-center justify-center">
-                                    <i class="fas fa-chalkboard-teacher text-[#e74c3c] text-lg"></i>
-                                </div>
-                                <div>
-                                    <h4 class="text-lg font-bold text-gray-900 dark:text-gray-100">Manikandan Chandran</h4>
-                                    <p class="text-sm text-gray-600 dark:text-gray-400">React/OAuth/REST API</p>
-                                </div>
-                            </div>
-                            <p class="text-gray-600 dark:text-gray-400 text-sm">
-                                Mentors teams on building secure React apps with real-world OAuth
-                                flows and robust REST APIs.
-                            </p>
-                        </div>
-                        <!-- Ahmed ElSheikh -->
-                        <div class="bg-white dark:bg-gray-800 rounded-lg p-6 border border-gray-200 dark:border-gray-700">
-                            <div class="flex items-center gap-3 mb-3">
-                                <div class="w-12 h-12 bg-red-100 rounded-full flex items-center justify-center">
-                                    <i class="fas fa-chalkboard-teacher text-[#e74c3c] text-lg"></i>
-                                </div>
-                                <div>
-                                    <h4 class="text-lg font-bold text-gray-900 dark:text-gray-100">Ahmed ElSheikh</h4>
-                                    <p class="text-sm text-gray-600 dark:text-gray-400">React/OAuth/REST API</p>
-                                </div>
-                            </div>
-                            <p class="text-gray-600 dark:text-gray-400 text-sm">
-                                Cybersecurity analyst and AI security engineer specializing in
-                                secure system design.
-                            </p>
-                        </div>
-                    </div>
-                </div>
             </div>
             <!-- Past Mentors Section -->
             <div class="bg-white dark:bg-gray-800 rounded-xl shadow-lg transition-all duration-300 p-8 mb-20 border border-gray-100 dark:border-gray-800">

--- a/website/templates/gsoc.html
+++ b/website/templates/gsoc.html
@@ -1031,6 +1031,12 @@
                         </div>
                     </div>
                 </div>
+                <!-- Available Mentors Section -->
+                <div class="mt-16 bg-gray-50 dark:bg-gray-900 rounded-xl p-8 border border-gray-200 dark:border-gray-700">
+                    <h3 class="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-6 text-center">
+                        Available Mentors for Future Students
+                    </h3>
+                </div>
             </div>
             <!-- Past Mentors Section -->
             <div class="bg-white dark:bg-gray-800 rounded-xl shadow-lg transition-all duration-300 p-8 mb-20 border border-gray-100 dark:border-gray-800">


### PR DESCRIPTION
Removed the "Available Mentors" since each mentor already has one mentee, and Donnie mentioned that only one mentee is allowed per mentor.

Screenshots-
<img width="1915" height="906" alt="image" src="https://github.com/user-attachments/assets/add5812c-3e96-434f-80b0-f9c9b766ab15" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed the "Available Mentors for Future Students" section from the GSOC page, including the mentor cards and their descriptions.
  * Page now flows directly into the Past Mentors section with no other structural changes.
  * Change is small and low review effort.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->