### PR TITLE
Fix data loss in pending_transactions_view and restore auth on batch_send_bacon_tokens_view

### DIFF
--- a/website/views/bitcoin.py
+++ b/website/views/bitcoin.py
@@ -40,7 +40,7 @@ def slack_escape(text):
     )
 
 
-# @login_required
+@login_required
 def batch_send_bacon_tokens_view(request):
     # Get all users with non-zero tokens_earned
     users_with_tokens = BaconEarning.objects.filter(tokens_earned__gt=0)
@@ -100,7 +100,7 @@ def pending_transactions_view(request):
     for transaction in pending_transactions:
         user = transaction.user
         btc_address = getattr(user.userprofile, "btc_address", None)
-        transactions_data = [{"user": user.username, "address": btc_address, "tokens": transaction.tokens_earned}]
+        transactions_data.append({"user": user.username, "address": btc_address, "tokens": transaction.tokens_earned})
 
     # If you want to return it as a JSON response:
     return JsonResponse({"pending_transactions": transactions_data})


### PR DESCRIPTION
## Summary

Two bug fixes in `website/views/bitcoin.py`:

### 1. Data loss in `pending_transactions_view`

The loop body uses list reassignment instead of `append()`:

```python
# Before (bug): overwrites list each iteration, only returns last entry
transactions_data = [{"user": user.username, ...}]

# After (fix): appends each entry, returns all transactions
transactions_data.append({"user": user.username, ...})
```

This means the endpoint only ever returned the **last** pending transaction instead of all of them.

### 2. Missing `@login_required` on `batch_send_bacon_tokens_view`

The `@login_required` decorator was commented out:

```python
# Before (bug):
# @login_required
def batch_send_bacon_tokens_view(request):

# After (fix):
@login_required
def batch_send_bacon_tokens_view(request):
```

This endpoint triggers Bitcoin token transfers to users. Without authentication, any unauthenticated request could invoke it.

## Test Plan

- [ ] Verify `pending_transactions_view` returns all users with pending tokens, not just the last one
- [ ] Verify `batch_send_bacon_tokens_view` returns 302 redirect to login for unauthenticated requests
- [ ] Verify authenticated users can still access `batch_send_bacon_tokens_view` normally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where pending transaction entries were not being properly accumulated, ensuring all eligible transactions now display correctly.

* **Security**
  * Restricted batch token sending functionality to authenticated users only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->