### PR TITLE
Fix missing @ decorator on app.action("select_repository") handler

### DIFF
--- a/website/views/slackbot.py
+++ b/website/views/slackbot.py
@@ -232,8 +232,7 @@ if app:
         except Exception as e:
             logger.error(f"Error handling /discover command: {e}")
 
-    app.action("select_repository")
-
+    @app.action("select_repository")
     def handle_repository_selection(ack, body, client):
         try:
             ack()


### PR DESCRIPTION
## Summary

In `website/views/slackbot.py`, the `select_repository` action handler was never registered with slack_bolt because `app.action("select_repository")` was called as a plain function instead of being used as a `@` decorator:

```python
# Before (bug): called as function, return value discarded
app.action("select_repository")

def handle_repository_selection(ack, body, client):
    ...

# After (fix): properly used as decorator to register the handler
@app.action("select_repository")
def handle_repository_selection(ack, body, client):
    ...
```

Without the `@`, the decorator function returned by `app.action("select_repository")` was never applied to `handle_repository_selection`. This meant the function was defined but never connected to the Slack action, so selecting a repository from the `/discover` command dropdown would silently do nothing.

Note that other action handlers in the same file (`pagination_prev`, `pagination_next`) correctly use the `@` decorator syntax.

## Test Plan

- [ ] Run `/discover` in Slack (no search term) to list OWASP-BLT repositories
- [ ] Select a repository from the dropdown menu
- [ ] Verify that the bot responds with the latest issues from the selected repository