### PR TITLE
Enforce POST for issue actions (like, dislike, flag, save)

### DIFF
--- a/website/templates/includes/_like_dislike_share.html
+++ b/website/templates/includes/_like_dislike_share.html
@@ -127,12 +127,28 @@
         });
     }
 
+    function getCookie(name) {
+        let cookieValue = null;
+        if (document.cookie && document.cookie !== '') {
+            const cookies = document.cookie.split(';');
+            for (let i = 0; i < cookies.length; i++) {
+                const cookie = cookies[i].trim();
+                if (cookie.substring(0, name.length + 1) === (name + '=')) {
+                    cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
+                    break;
+                }
+            }
+        }
+        return cookieValue;
+    }
+
     function like_unlike_handler(e) {
         e.preventDefault();
         var issue_pk = $(this).attr('name');
         $.ajax({
-            type: 'GET',
+            type: 'POST',
             url: '/like_issue/' + issue_pk + '/',
+            headers: {'X-CSRFToken': getCookie('csrftoken')},
             data: {},
             success: function (data) {
                 window.location.reload();
@@ -146,8 +162,9 @@
         e.preventDefault();
         var issue_pk = document.getElementById("dislike-btn").getAttribute("name");
         $.ajax({
-            type: 'GET',
+            type: 'POST',
             url: '/dislike_issue/' + issue_pk + '/',
+            headers: {'X-CSRFToken': getCookie('csrftoken')},
             data: {},
             success: function (data) {
                 window.location.reload();
@@ -161,8 +178,9 @@
         e.preventDefault();
         var issue_pk = $(this).attr('name');
         $.ajax({
-            type: 'GET',
+            type: 'POST',
             url: '/flag_issue/' + issue_pk + '/',
+            headers: {'X-CSRFToken': getCookie('csrftoken')},
             data: {},
             success: function (data) {
                 window.location.reload();
@@ -178,8 +196,9 @@
         e.preventDefault();
         var issue_pk = $(this).attr('name');
         $.ajax({
-            type: 'GET',
+            type: 'POST',
             url: '/save_issue/' + issue_pk + '/',
+            headers: {'X-CSRFToken': getCookie('csrftoken')},
             data: {},
             success: function (data) {
                 window.location.reload();

--- a/website/views/issue.py
+++ b/website/views/issue.py
@@ -96,6 +96,7 @@ logger = logging.getLogger(__name__)
 
 
 @login_required(login_url="/accounts/login")
+@require_POST
 def like_issue(request, issue_pk):
     issue = get_object_or_404(Issue, pk=int(issue_pk))
 
@@ -135,6 +136,7 @@ def like_issue(request, issue_pk):
 
 
 @login_required(login_url="/accounts/login")
+@require_POST
 def dislike_issue(request, issue_pk):
     issue = get_object_or_404(Issue, pk=int(issue_pk))
 
@@ -2029,6 +2031,7 @@ def comment_on_content(request, content_pk):
 
 
 @login_required(login_url="/accounts/login")
+@require_POST
 def unsave_issue(request, issue_pk):
     issue_pk = int(issue_pk)
     issue = Issue.objects.get(pk=issue_pk)
@@ -2038,6 +2041,7 @@ def unsave_issue(request, issue_pk):
 
 
 @login_required(login_url="/accounts/login")
+@require_POST
 def save_issue(request, issue_pk):
     issue_pk = int(issue_pk)
     issue = Issue.objects.get(pk=issue_pk)
@@ -2104,6 +2108,7 @@ def IssueEdit(request):
 
 
 @login_required(login_url="/accounts/login")
+@require_POST
 def flag_issue(request, issue_pk):
     context = {}
     issue_pk = int(issue_pk)


### PR DESCRIPTION
Fixes #4058

State-changing issue actions were accessible via GET requests, which is a security concern (CSRF, prefetching, crawlers can trigger them).

**Changes:**

**Backend (`website/views/issue.py`):**
- Added `@require_POST` decorator to `like_issue`, `dislike_issue`, `unsave_issue`, `save_issue`, and `flag_issue`
- `require_POST` was already imported but unused for these views
- Matches the pattern already used in `organization.py` for `like_activity`, `dislike_activity`, `approve_activity`

**Frontend (`_like_dislike_share.html`):**
- Updated AJAX calls for like, dislike, flag, and bookmark from `type: 'GET'` to `type: 'POST'`
- Added `getCookie` helper to read Django's CSRF token from cookies
- Added `X-CSRFToken` header to each POST request

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Technical updates to issue action endpoints (like, dislike, save, flag) to improve system reliability and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->