### PR TITLE
fix: remove @csrf_exempt from user-facing endpoints (set_theme, page_vote, bacon)

### DIFF
--- a/website/tests/test_core.py
+++ b/website/tests/test_core.py
@@ -198,11 +198,9 @@ class DarkModeTests(TestCase):
         self.assertEqual(data["theme"], "light")
 
     def test_set_theme_invalid_method(self):
-        """Test that GET request to set-theme endpoint returns error"""
+        """Test that GET request to set-theme endpoint returns 405"""
         response = self.client.get(reverse("set_theme"))
-        self.assertEqual(response.status_code, 400)
-        data = response.json()
-        self.assertEqual(data["status"], "error")
+        self.assertEqual(response.status_code, 405)
 
     def test_dark_mode_toggle_in_base_template(self):
         """Test that dark mode toggle is present in base template"""

--- a/website/views/bitcoin.py
+++ b/website/views/bitcoin.py
@@ -10,7 +10,7 @@ from django.http import JsonResponse
 from django.shortcuts import get_object_or_404, render
 from django.utils.decorators import method_decorator
 from django.views import View
-from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.http import require_POST
 from slack_sdk.errors import SlackApiError
 from slack_sdk.web import WebClient
 
@@ -106,7 +106,6 @@ def pending_transactions_view(request):
     return JsonResponse({"pending_transactions": transactions_data})
 
 
-@method_decorator(csrf_exempt, name="dispatch")
 @method_decorator(login_required, name="dispatch")
 class BaconSubmissionView(View):
     def post(self, request):
@@ -283,41 +282,38 @@ def bacon_requests_view(request):
 
 
 @login_required
-@csrf_exempt
+@require_POST
 def update_submission_status(request, submission_id):
     """Allows a mentor to update the submission status and bacon amount."""
-    if request.method == "POST":
-        try:
-            data = json.loads(request.body)
-            new_status = data.get("status")  # 'accepted' or 'declined'
-            new_bacon_amount = data.get("bacon_amount")
+    try:
+        data = json.loads(request.body)
+        new_status = data.get("status")  # 'accepted' or 'declined'
+        new_bacon_amount = data.get("bacon_amount")
 
-            submission = get_object_or_404(BaconSubmission, id=submission_id)
+        submission = get_object_or_404(BaconSubmission, id=submission_id)
 
-            # Check if the user is a mentor
-            mentor_badge = Badge.objects.filter(title="mentor").first()
-            is_mentor = UserBadge.objects.filter(user=request.user, badge=mentor_badge).exists()
+        # Check if the user is a mentor
+        mentor_badge = Badge.objects.filter(title="mentor").first()
+        is_mentor = UserBadge.objects.filter(user=request.user, badge=mentor_badge).exists()
 
-            if not is_mentor:
-                return JsonResponse({"error": "Unauthorized"}, status=403)
+        if not is_mentor:
+            return JsonResponse({"error": "Unauthorized"}, status=403)
 
-            # Update status and bacon amount if provided
-            if new_status:
-                submission.status = new_status
-            if new_bacon_amount is not None:
-                submission.bacon_amount = new_bacon_amount
+        # Update status and bacon amount if provided
+        if new_status:
+            submission.status = new_status
+        if new_bacon_amount is not None:
+            submission.bacon_amount = new_bacon_amount
 
-            submission.save()
-            return JsonResponse(
-                {"success": True, "new_status": submission.status, "new_bacon_amount": submission.bacon_amount}
-            )
+        submission.save()
+        return JsonResponse(
+            {"success": True, "new_status": submission.status, "new_bacon_amount": submission.bacon_amount}
+        )
 
-        except json.JSONDecodeError:
-            return JsonResponse({"error": "Invalid JSON format"}, status=400)
-        except Exception as e:
-            return JsonResponse({"error": "error updating submission status"}, status=400)
-
-    return JsonResponse({"error": "Invalid request method"}, status=405)
+    except json.JSONDecodeError:
+        return JsonResponse({"error": "Invalid JSON format"}, status=400)
+    except Exception:
+        return JsonResponse({"error": "error updating submission status"}, status=400)
 
 
 @login_required

--- a/website/views/core.py
+++ b/website/views/core.py
@@ -2119,11 +2119,11 @@ def run_management_command(request):
                             # Convert to appropriate type if needed
                             if action.type:
                                 try:
-                                    if action.type == int:
+                                    if action.type is int:
                                         arg_value = int(arg_value)
-                                    elif action.type == float:
+                                    elif action.type is float:
                                         arg_value = float(arg_value)
-                                    elif action.type == bool:
+                                    elif action.type is bool:
                                         arg_value = arg_value.lower() in ("true", "yes", "1")
                                 except (ValueError, TypeError):
                                     warning_msg = (

--- a/website/views/core.py
+++ b/website/views/core.py
@@ -39,8 +39,7 @@ from django.shortcuts import redirect, render
 from django.template.loader import render_to_string
 from django.urls import reverse
 from django.utils import timezone
-from django.views.decorators.csrf import csrf_exempt
-from django.views.decorators.http import require_GET
+from django.views.decorators.http import require_GET, require_POST
 from django.views.generic import ListView, TemplateView, View
 
 from website.models import (
@@ -2996,28 +2995,19 @@ def invite_organization(request):
     return render(request, "invite.html", context)
 
 
-@csrf_exempt
+@require_POST
 def set_theme(request):
     """View to save user's theme preference"""
-    if request.method == "POST":
-        try:
-            import json
+    try:
+        import json
 
-            data = json.loads(request.body)
-            theme = data.get("theme", "light")
+        data = json.loads(request.body)
+        theme = data.get("theme", "light")
 
-            # Save theme in session
-            request.session["theme"] = theme
+        # Save theme in session
+        request.session["theme"] = theme
 
-            # If user is authenticated, could also save to user profile - confirm if we have theme_preference
-            # if request.user.is_authenticated:
-            #     profile = request.user.userprofile
-            #     profile.theme_preference = theme
-            #     profile.save()
-
-            return JsonResponse({"status": "success", "theme": theme})
-        except Exception as e:
-            logging.exception("Error occurred while setting theme")
-            return JsonResponse({"status": "error", "message": "An internal error occurred."}, status=400)
-
-    return JsonResponse({"status": "error", "message": "Invalid request method"}, status=400)
+        return JsonResponse({"status": "success", "theme": theme})
+    except Exception:
+        logging.exception("Error occurred while setting theme")
+        return JsonResponse({"status": "error", "message": "An internal error occurred."}, status=400)

--- a/website/views/issue.py
+++ b/website/views/issue.py
@@ -17,7 +17,6 @@ from allauth.account.signals import user_logged_in
 from allauth.socialaccount.models import SocialToken
 from better_profanity import profanity
 from bleach import clean
-from comments.models import Comment
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required, user_passes_test
@@ -59,6 +58,7 @@ from rest_framework.authtoken.models import Token
 from user_agents import parse
 
 from blt import settings
+from comments.models import Comment
 from website.duplicate_checker import check_for_duplicates, format_similar_bug
 from website.forms import CaptchaForm, GitHubIssueForm
 from website.models import (

--- a/website/views/issue.py
+++ b/website/views/issue.py
@@ -17,6 +17,7 @@ from allauth.account.signals import user_logged_in
 from allauth.socialaccount.models import SocialToken
 from better_profanity import profanity
 from bleach import clean
+from comments.models import Comment
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required, user_passes_test
@@ -58,7 +59,6 @@ from rest_framework.authtoken.models import Token
 from user_agents import parse
 
 from blt import settings
-from comments.models import Comment
 from website.duplicate_checker import check_for_duplicates, format_similar_bug
 from website.forms import CaptchaForm, GitHubIssueForm
 from website.models import (
@@ -1219,7 +1219,7 @@ class IssueCreate(IssueBaseCreate, CreateView):
                             if self.request.FILES.getlist("screenshots"):
                                 for idx, screenshot in enumerate(self.request.FILES.getlist("screenshots")):
                                     file_path = os.path.join(
-                                        temp_dir, f"screenshot_{idx+1}{Path(screenshot.name).suffix}"
+                                        temp_dir, f"screenshot_{idx + 1}{Path(screenshot.name).suffix}"
                                     )
                                     with open(file_path, "wb+") as destination:
                                         for chunk in screenshot.chunks():
@@ -1245,7 +1245,7 @@ class IssueCreate(IssueBaseCreate, CreateView):
                                         return HttpResponseRedirect("/")
 
                                     if os.path.exists(orig_path):
-                                        dest_path = os.path.join(temp_dir, f"screenshot_{idx+1}.png")
+                                        dest_path = os.path.join(temp_dir, f"screenshot_{idx + 1}.png")
                                         import shutil
 
                                         shutil.copy(orig_path, dest_path)
@@ -2534,38 +2534,35 @@ class GitHubIssueDetailView(DetailView):
 
 
 @login_required(login_url="/accounts/login")
-@csrf_exempt
+@require_POST
 def page_vote(request):
     """
     Handle upvote/downvote for a page
     """
-    if request.method == "POST":
-        template_name = request.POST.get("template_name")
-        vote_type = request.POST.get("vote_type")
+    template_name = request.POST.get("template_name")
+    vote_type = request.POST.get("vote_type")
 
-        if not template_name or vote_type not in ["upvote", "downvote"]:
-            return JsonResponse({"status": "error", "message": "Invalid parameters"})
+    if not template_name or vote_type not in ["upvote", "downvote"]:
+        return JsonResponse({"status": "error", "message": "Invalid parameters"})
 
-        # Clean the template name to use as a key
-        page_key = template_name.replace("/", "_").replace(".html", "")
-        vote_key = f"{vote_type}_{page_key}"
+    # Clean the template name to use as a key
+    page_key = template_name.replace("/", "_").replace(".html", "")
+    vote_key = f"{vote_type}_{page_key}"
 
-        # Get or create the DailyStats entry
-        try:
-            stat, created = DailyStats.objects.get_or_create(name=vote_key, defaults={"value": "0"})
-            # Increment the vote count
-            current_value = int(stat.value)
-            stat.value = str(current_value + 1)
-            stat.save()
+    # Get or create the DailyStats entry
+    try:
+        stat, created = DailyStats.objects.get_or_create(name=vote_key, defaults={"value": "0"})
+        # Increment the vote count
+        current_value = int(stat.value)
+        stat.value = str(current_value + 1)
+        stat.save()
 
-            # Get the counts for both vote types
-            upvotes, downvotes = get_page_votes(template_name)
+        # Get the counts for both vote types
+        upvotes, downvotes = get_page_votes(template_name)
 
-            return JsonResponse({"status": "success", "upvotes": upvotes, "downvotes": downvotes})
-        except Exception:
-            return JsonResponse({"status": "error", "message": "An error occurred while processing your vote"})
-
-    return JsonResponse({"status": "error", "message": "Invalid request method"})
+        return JsonResponse({"status": "success", "upvotes": upvotes, "downvotes": downvotes})
+    except Exception:
+        return JsonResponse({"status": "error", "message": "An error occurred while processing your vote"})
 
 
 class GsocView(View):


### PR DESCRIPTION
## Problem

Four user-facing endpoints unnecessarily use `@csrf_exempt`, bypassing Django's CSRF protection even though all frontend callers already include CSRF tokens in their requests.

### Affected Endpoints

| Endpoint | File | Risk |
|---|---|---|
| `set_theme()` | `core.py` | Session manipulation via crafted link |
| `page_vote()` | `issue.py` | Vote manipulation without user consent |
| `update_submission_status()` | `bitcoin.py` | Mentor action hijacking |
| `BaconSubmissionView` | `bitcoin.py` | Fake bacon submissions |

### Why This Matters

With `@csrf_exempt`, an attacker can craft a malicious page that submits requests to these endpoints on behalf of any logged-in user. For example:
- Silently change a user's theme preference
- Submit fake upvotes/downvotes on pages
- If a mentor visits a malicious page, their session could be used to approve/decline bacon submissions

## Changes

### Backend

- **`core.py:set_theme()`** — Replaced `@csrf_exempt` with `@require_POST`, removed unused `csrf_exempt` import
- **`issue.py:page_vote()`** — Replaced `@csrf_exempt` with `@require_POST`
- **`bitcoin.py:update_submission_status()`** — Replaced `@csrf_exempt` with `@require_POST`
- **`bitcoin.py:BaconSubmissionView`** — Removed `@method_decorator(csrf_exempt)` from class

### Cleanup

- Removed redundant `if request.method == "POST"` checks (handled by `@require_POST`)
- Removed unreachable "Invalid request method" return statements
- Updated `test_set_theme_invalid_method` to expect 405 (from `@require_POST`) instead of 400

### No Frontend Changes Needed

All frontend callers already send `X-CSRFToken` headers:
- `bacon.html` uses `"X-CSRFToken": "{{ csrf_token }}"` for bacon submission and status updates
- `page_stats.html` uses `'X-CSRFToken': csrftoken` for page votes

## Related

This is part of a series hardening CSRF protection across the codebase:
- PR #5648 — Enforced POST for like/dislike/flag/save
- PR #5650 — Enforced POST for resolve/create_github_issue/subscribe

### Endpoints NOT changed (legitimate `@csrf_exempt`)

- `bounty.py:bounty_payout()` — GitHub Action webhook (API token auth)
- `slack_handlers.py` — Slack webhooks (Slack signature verification)
- `user.py:github_webhook()` — GitHub webhook (signature verification)