### PR TITLE
fix: replace bare except clauses with specific exception types

### DIFF
--- a/website/consumers.py
+++ b/website/consumers.py
@@ -358,7 +358,7 @@ class ChatConsumer(AsyncWebsocketConsumer):
     def check_room_exists(self):
         try:
             return Room.objects.filter(id=self.room_id).exists()
-        except (ValueError, Room.DoesNotExist):
+        except (ValueError, TypeError):
             return False
 
     @database_sync_to_async

--- a/website/consumers.py
+++ b/website/consumers.py
@@ -349,16 +349,16 @@ class ChatConsumer(AsyncWebsocketConsumer):
                 await self.send(
                     text_data=json.dumps({"type": "connection_status", "status": "disconnected", "code": close_code})
                 )
-            except:
+            except Exception:
                 pass
-        except:
+        except Exception:
             pass
 
     @database_sync_to_async
     def check_room_exists(self):
         try:
             return Room.objects.filter(id=self.room_id).exists()
-        except:
+        except (ValueError, Room.DoesNotExist):
             return False
 
     @database_sync_to_async

--- a/website/models.py
+++ b/website/models.py
@@ -529,7 +529,7 @@ class Trademark(models.Model):
 def validate_image(fieldfile_obj):
     try:
         filesize = fieldfile_obj.file.size
-    except:
+    except (AttributeError, FileNotFoundError):
         filesize = fieldfile_obj.size
     megabyte_limit = 3.0
     if filesize > megabyte_limit * 1024 * 1024:

--- a/website/views/issue.py
+++ b/website/views/issue.py
@@ -17,7 +17,6 @@ from allauth.account.signals import user_logged_in
 from allauth.socialaccount.models import SocialToken
 from better_profanity import profanity
 from bleach import clean
-from comments.models import Comment
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required, user_passes_test
@@ -59,6 +58,7 @@ from rest_framework.authtoken.models import Token
 from user_agents import parse
 
 from blt import settings
+from comments.models import Comment
 from website.duplicate_checker import check_for_duplicates, format_similar_bug
 from website.forms import CaptchaForm, GitHubIssueForm
 from website.models import (

--- a/website/views/issue.py
+++ b/website/views/issue.py
@@ -880,7 +880,7 @@ class IssueCreate(IssueBaseCreate, CreateView):
                     )
 
                     self.request.FILES["screenshot"] = ContentFile(decoded_file, name=complete_file_name)
-        except (IOError, OSError):
+        except Exception:
             tokenauth = False
         initial = super(IssueCreate, self).get_initial()
         if self.request.POST.get("screenshot-hash"):


### PR DESCRIPTION
## Problem

Several files use bare `except:` clauses, which is a Python anti-pattern (PEP 8, ruff rule E722). Bare excepts catch **all** exceptions including `SystemExit`, `KeyboardInterrupt`, and `GeneratorExit`, which can:

- Prevent graceful shutdown (catching `SystemExit`)
- Make Ctrl+C unresponsive (catching `KeyboardInterrupt`)
- Hide real bugs by silently swallowing unexpected errors
- Make debugging extremely difficult

## Changes

### `website/views/issue.py` (4 bare excepts fixed)

| Location | Context | Now catches |
|---|---|---|
| Token auth (~line 279) | API token validation loop | `Exception` |
| Token auth (~line 391) | `remove_user_from_issue` token check | `Exception` |
| `IssueCreate.get_initial` (~line 883) | JSON body parsing + base64 screenshot decoding | `Exception` |
| File upload (~line 1867) | `request.FILES["screenshot"]` access | `Exception` |

### `website/models.py` (1 bare except fixed)

| Location | Context | Now catches |
|---|---|---|
| `validate_image` (~line 532) | Fallback from `fieldfile_obj.file.size` to `fieldfile_obj.size` | `AttributeError, FileNotFoundError` |

### `website/consumers.py` (3 bare excepts fixed)

| Location | Context | Now catches |
|---|---|---|
| WebSocket disconnect send (~line 352) | Sending disconnect status during cleanup | `Exception` (intentionally broad for cleanup) |
| WebSocket disconnect outer (~line 354) | Outer cleanup handler | `Exception` (intentionally broad for cleanup) |
| `check_room_exists` (~line 361) | Room existence check | `ValueError, TypeError` |

## Why these specific exception types?

- **Token auth blocks**: Uses `Exception` since multiple operations (dict access, DB lookup, token comparison) could fail in various ways. Still allows `SystemExit` and `KeyboardInterrupt` to propagate.
- **IssueCreate.get_initial**: Large try block covering JSON parsing, dict access, base64 decoding, and file creation. `Exception` is appropriate for this broad scope.
- **validate_image**: Falls back between two size access patterns (`AttributeError` for missing `.file`, `FileNotFoundError` for missing file) — specific types warranted here.
- **WebSocket cleanup**: Uses `Exception` intentionally since cleanup should never raise, but still allows `SystemExit` and `KeyboardInterrupt` to propagate.
- **check_room_exists**: `filter().exists()` returns True/False and never raises `DoesNotExist`. The realistic exceptions are `ValueError` (non-numeric ID) and `TypeError` (None or wrong type).

## Test Plan
- [ ] Verify issue creation with token authentication still works
- [ ] Verify issue creation with screenshot upload still works
- [ ] Verify image validation still works for both FieldFile and InMemoryUploadedFile
- [ ] Verify WebSocket chat still connects and disconnects cleanly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved error handling precision across messaging, image validation, and issue management systems for enhanced stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->