### PR TITLE
Remove unused all_users query from IssueDetailView

### DIFF
--- a/website/views/issue.py
+++ b/website/views/issue.py
@@ -17,6 +17,7 @@ from allauth.account.signals import user_logged_in
 from allauth.socialaccount.models import SocialToken
 from better_profanity import profanity
 from bleach import clean
+from comments.models import Comment
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required, user_passes_test
@@ -58,7 +59,6 @@ from rest_framework.authtoken.models import Token
 from user_agents import parse
 
 from blt import settings
-from comments.models import Comment
 from website.duplicate_checker import check_for_duplicates, format_similar_bug
 from website.forms import CaptchaForm, GitHubIssueForm
 from website.models import (
@@ -1219,7 +1219,7 @@ class IssueCreate(IssueBaseCreate, CreateView):
                             if self.request.FILES.getlist("screenshots"):
                                 for idx, screenshot in enumerate(self.request.FILES.getlist("screenshots")):
                                     file_path = os.path.join(
-                                        temp_dir, f"screenshot_{idx+1}{Path(screenshot.name).suffix}"
+                                        temp_dir, f"screenshot_{idx + 1}{Path(screenshot.name).suffix}"
                                     )
                                     with open(file_path, "wb+") as destination:
                                         for chunk in screenshot.chunks():
@@ -1245,7 +1245,7 @@ class IssueCreate(IssueBaseCreate, CreateView):
                                         return HttpResponseRedirect("/")
 
                                     if os.path.exists(orig_path):
-                                        dest_path = os.path.join(temp_dir, f"screenshot_{idx+1}.png")
+                                        dest_path = os.path.join(temp_dir, f"screenshot_{idx + 1}.png")
                                         import shutil
 
                                         shutil.copy(orig_path, dest_path)
@@ -1752,7 +1752,6 @@ class IssueView(DetailView):
             context["wallet"] = Wallet.objects.get(user=self.request.user)
         context["issue_count"] = Issue.objects.filter(url__contains=self.object.domain_name).count()
         context["all_comment"] = self.object.comments.all()
-        context["all_users"] = User.objects.all()
         context["likes"] = UserProfile.objects.filter(issue_upvoted=self.object).count()
         context["likers"] = UserProfile.objects.filter(issue_upvoted=self.object)
         context["dislikes"] = UserProfile.objects.filter(issue_downvoted=self.object).count()


### PR DESCRIPTION
## Summary\n\n- Remove `context[\"all_users\"] = User.objects.all()` from `IssueDetailView.get_context_data()`\n- This query loads **every user** from the database on each issue detail page view\n- The `all_users` variable is never referenced in any template (confirmed via grep)\n- Eliminates an unnecessary full-table scan that grows linearly with user count\n\n## Details\n\nThe `all_users` context variable was being set but never consumed by any template. This means every visit to an issue detail page triggered a `SELECT * FROM auth_user` query for no reason. As the user table grows, this becomes increasingly expensive.\n\n## Test Plan\n\n- [ ] Verify issue detail pages render correctly without the `all_users` context\n- [ ] Confirm no template references `all_users`\n- [ ] Run existing test suite to check for regressions