### PR TITLE
Use get_object_or_404 for issue lookups in view functions

### DIFF
--- a/website/views/issue.py
+++ b/website/views/issue.py
@@ -17,7 +17,6 @@ from allauth.account.signals import user_logged_in
 from allauth.socialaccount.models import SocialToken
 from better_profanity import profanity
 from bleach import clean
-from comments.models import Comment
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required, user_passes_test
@@ -59,6 +58,7 @@ from rest_framework.authtoken.models import Token
 from user_agents import parse
 
 from blt import settings
+from comments.models import Comment
 from website.duplicate_checker import check_for_duplicates, format_similar_bug
 from website.forms import CaptchaForm, GitHubIssueForm
 from website.models import (

--- a/website/views/issue.py
+++ b/website/views/issue.py
@@ -17,6 +17,7 @@ from allauth.account.signals import user_logged_in
 from allauth.socialaccount.models import SocialToken
 from better_profanity import profanity
 from bleach import clean
+from comments.models import Comment
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required, user_passes_test
@@ -58,7 +59,6 @@ from rest_framework.authtoken.models import Token
 from user_agents import parse
 
 from blt import settings
-from comments.models import Comment
 from website.duplicate_checker import check_for_duplicates, format_similar_bug
 from website.forms import CaptchaForm, GitHubIssueForm
 from website.models import (
@@ -156,8 +156,7 @@ def dislike_issue(request, issue_pk):
 
 @login_required(login_url="/accounts/login")
 def vote_count(request, issue_pk):
-    issue_pk = int(issue_pk)
-    issue = Issue.objects.get(pk=issue_pk)
+    issue = get_object_or_404(Issue, pk=int(issue_pk))
 
     total_upvotes = UserProfile.objects.filter(issue_upvoted=issue).count()
     total_downvotes = UserProfile.objects.filter(issue_downvoted=issue).count()
@@ -245,7 +244,7 @@ def create_github_issue(request, id):
 @login_required(login_url="/accounts/login")
 @csrf_exempt
 def resolve(request, id):
-    issue = Issue.objects.get(id=id)
+    issue = get_object_or_404(Issue, id=id)
     if request.user.is_superuser or request.user == issue.user:
         if issue.status == "open":
             issue.status = "close"
@@ -390,7 +389,7 @@ def remove_user_from_issue(request, id):
     except:
         pass
 
-    issue = Issue.objects.get(id=id)
+    issue = get_object_or_404(Issue, id=id)
     if request.user.is_superuser or request.user == issue.user:
         issue.remove_user()
         # Remove user from corresponding activity object that was created
@@ -1219,7 +1218,7 @@ class IssueCreate(IssueBaseCreate, CreateView):
                             if self.request.FILES.getlist("screenshots"):
                                 for idx, screenshot in enumerate(self.request.FILES.getlist("screenshots")):
                                     file_path = os.path.join(
-                                        temp_dir, f"screenshot_{idx+1}{Path(screenshot.name).suffix}"
+                                        temp_dir, f"screenshot_{idx + 1}{Path(screenshot.name).suffix}"
                                     )
                                     with open(file_path, "wb+") as destination:
                                         for chunk in screenshot.chunks():
@@ -1245,7 +1244,7 @@ class IssueCreate(IssueBaseCreate, CreateView):
                                         return HttpResponseRedirect("/")
 
                                     if os.path.exists(orig_path):
-                                        dest_path = os.path.join(temp_dir, f"screenshot_{idx+1}.png")
+                                        dest_path = os.path.join(temp_dir, f"screenshot_{idx + 1}.png")
                                         import shutil
 
                                         shutil.copy(orig_path, dest_path)
@@ -2030,8 +2029,7 @@ def comment_on_content(request, content_pk):
 
 @login_required(login_url="/accounts/login")
 def unsave_issue(request, issue_pk):
-    issue_pk = int(issue_pk)
-    issue = Issue.objects.get(pk=issue_pk)
+    issue = get_object_or_404(Issue, pk=int(issue_pk))
     userprof = UserProfile.objects.get(user=request.user)
     userprof.issue_saved.remove(issue)
     return HttpResponse("OK")
@@ -2039,8 +2037,7 @@ def unsave_issue(request, issue_pk):
 
 @login_required(login_url="/accounts/login")
 def save_issue(request, issue_pk):
-    issue_pk = int(issue_pk)
-    issue = Issue.objects.get(pk=issue_pk)
+    issue = get_object_or_404(Issue, pk=int(issue_pk))
     userprof = UserProfile.objects.get(user=request.user)
 
     already_saved = userprof.issue_saved.filter(pk=issue_pk).exists()
@@ -2106,8 +2103,7 @@ def IssueEdit(request):
 @login_required(login_url="/accounts/login")
 def flag_issue(request, issue_pk):
     context = {}
-    issue_pk = int(issue_pk)
-    issue = Issue.objects.get(pk=issue_pk)
+    issue = get_object_or_404(Issue, pk=int(issue_pk))
     userprof = UserProfile.objects.get(user=request.user)
     if userprof in UserProfile.objects.filter(issue_flaged=issue):
         userprof.issue_flaged.remove(issue)


### PR DESCRIPTION
## Summary\n\n- Replace bare `Issue.objects.get()` with `get_object_or_404()` in 6 view functions\n- Affected views: `vote_count`, `resolve`, `remove_user_from_issue`, `unsave_issue`, `save_issue`, `flag_issue`\n\n## Problem\n\nSeveral view functions use `Issue.objects.get(pk=...)` to look up issues from URL parameters. When an invalid issue PK is passed, this raises an unhandled `Issue.DoesNotExist` exception, resulting in a **500 Internal Server Error** instead of a proper **404 Not Found** response.\n\nOther views in the same file (e.g., `like_issue`, `dislike_issue`, `create_github_issue`) already use `get_object_or_404()` correctly -- this PR makes the pattern consistent across all issue views.\n\n## Test Plan\n\n- [ ] Test each affected view with a valid issue PK (should work normally)\n- [ ] Test each affected view with an invalid issue PK (should return 404, not 500)\n- [ ] Run existing test suite for regressions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when accessing non-existent issues—users now receive proper 404 responses instead of generic errors, providing clearer feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->