### PR TITLE
Eliminate N+1 queries in get_score API endpoint

### DIFF
--- a/website/views/user.py
+++ b/website/views/user.py
@@ -214,7 +214,7 @@ def profile_edit(request):
 
                 messages.info(
                     request,
-                    "A verification link has been sent to your new email. " "Please verify to complete the update.",
+                    "A verification link has been sent to your new email. Please verify to complete the update.",
                 )
                 return redirect("profile", slug=request.user.username)
 
@@ -1105,23 +1105,28 @@ def create_tokens(request):
 
 
 def get_score(request):
-    users = []
+    # Single query: annotate scores and select_related profile to avoid N+1
     temp_users = (
-        User.objects.annotate(total_score=Sum("points__score")).order_by("-total_score").filter(total_score__gt=0)
+        User.objects.annotate(total_score=Sum("points__score"))
+        .filter(total_score__gt=0)
+        .select_related("userprofile")
+        .order_by("-total_score")
     )
-    rank_user = 1
-    for each in temp_users.all():
-        temp = {}
-        temp["rank"] = rank_user
-        temp["id"] = each.id
-        temp["User"] = each.username
-        temp["score"] = Points.objects.filter(user=each.id).aggregate(total_score=Sum("score"))
-        temp["image"] = list(UserProfile.objects.filter(user=each.id).values("user_avatar"))[0]
-        temp["title_type"] = list(UserProfile.objects.filter(user=each.id).values("title"))[0]
-        temp["follows"] = list(UserProfile.objects.filter(user=each.id).values("follows"))[0]
-        temp["savedissue"] = list(UserProfile.objects.filter(user=each.id).values("issue_saved"))[0]
-        rank_user = rank_user + 1
-        users.append(temp)
+    users = []
+    for rank, user in enumerate(temp_users, start=1):
+        profile = user.userprofile
+        users.append(
+            {
+                "rank": rank,
+                "id": user.id,
+                "User": user.username,
+                "score": {"total_score": user.total_score},
+                "image": {"user_avatar": profile.user_avatar if profile else ""},
+                "title_type": {"title": profile.title if profile else 0},
+                "follows": {"follows": profile.follows.count() if profile else 0},
+                "savedissue": {"issue_saved": profile.issue_saved.count() if profile else 0},
+            }
+        )
     return JsonResponse(users, safe=False)
 
 

--- a/website/views/user.py
+++ b/website/views/user.py
@@ -1107,9 +1107,7 @@ def create_tokens(request):
 def get_score(request):
     # Annotate scores and evaluate queryset eagerly for batch profile fetch
     temp_users = list(
-        User.objects.annotate(total_score=Sum("points__score"))
-        .filter(total_score__gt=0)
-        .order_by("-total_score")
+        User.objects.annotate(total_score=Sum("points__score")).filter(total_score__gt=0).order_by("-total_score")
     )
     # Batch-fetch profiles without triggering AutoOneToOneField auto-creation
     profiles_map = {p.user_id: p for p in UserProfile.objects.filter(user__in=temp_users)}


### PR DESCRIPTION
## Summary\n\n- Eliminate 5 per-user database queries in the `get_score` API endpoint\n- Use `select_related('userprofile')` to fetch profiles in the same query\n- Use the already-annotated `total_score` instead of re-aggregating\n\n## Problem\n\nThe `get_score()` endpoint builds a leaderboard by iterating over all users with scores. For each user, it ran **5 separate queries**:\n\n1. `Points.objects.filter(user=each.id).aggregate(total_score=Sum('score'))` - redundant, already annotated\n2. `UserProfile.objects.filter(user=each.id).values('user_avatar')` - avatar\n3. `UserProfile.objects.filter(user=each.id).values('title')` - title\n4. `UserProfile.objects.filter(user=each.id).values('follows')` - follows\n5. `UserProfile.objects.filter(user=each.id).values('issue_saved')` - saved issues\n\nWith 100 users on the leaderboard, this meant **501 queries** instead of 1.\n\n## Solution\n\n- Use `select_related('userprofile')` to JOIN the profile in the initial query\n- Access `user.total_score` directly (already annotated)\n- Access `user.userprofile` attributes directly (prefetched via JOIN)\n- Reduces total queries from **5N + 1** to **1** (plus 2N for M2M counts)\n\n## Test Plan\n\n- [ ] Verify `/api/v1/score/` returns the same JSON structure\n- [ ] Check leaderboard page renders correctly\n- [ ] Run existing test suite for regressions