### PR TITLE
Consolidate duplicate queries in IssueDetailView

### DIFF
--- a/website/views/issue.py
+++ b/website/views/issue.py
@@ -17,7 +17,6 @@ from allauth.account.signals import user_logged_in
 from allauth.socialaccount.models import SocialToken
 from better_profanity import profanity
 from bleach import clean
-from comments.models import Comment
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required, user_passes_test
@@ -59,6 +58,7 @@ from rest_framework.authtoken.models import Token
 from user_agents import parse
 
 from blt import settings
+from comments.models import Comment
 from website.duplicate_checker import check_for_duplicates, format_similar_bug
 from website.forms import CaptchaForm, GitHubIssueForm
 from website.models import (

--- a/website/views/issue.py
+++ b/website/views/issue.py
@@ -17,6 +17,7 @@ from allauth.account.signals import user_logged_in
 from allauth.socialaccount.models import SocialToken
 from better_profanity import profanity
 from bleach import clean
+from comments.models import Comment
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required, user_passes_test
@@ -58,7 +59,6 @@ from rest_framework.authtoken.models import Token
 from user_agents import parse
 
 from blt import settings
-from comments.models import Comment
 from website.duplicate_checker import check_for_duplicates, format_similar_bug
 from website.forms import CaptchaForm, GitHubIssueForm
 from website.models import (
@@ -1219,7 +1219,7 @@ class IssueCreate(IssueBaseCreate, CreateView):
                             if self.request.FILES.getlist("screenshots"):
                                 for idx, screenshot in enumerate(self.request.FILES.getlist("screenshots")):
                                     file_path = os.path.join(
-                                        temp_dir, f"screenshot_{idx+1}{Path(screenshot.name).suffix}"
+                                        temp_dir, f"screenshot_{idx + 1}{Path(screenshot.name).suffix}"
                                     )
                                     with open(file_path, "wb+") as destination:
                                         for chunk in screenshot.chunks():
@@ -1245,7 +1245,7 @@ class IssueCreate(IssueBaseCreate, CreateView):
                                         return HttpResponseRedirect("/")
 
                                     if os.path.exists(orig_path):
-                                        dest_path = os.path.join(temp_dir, f"screenshot_{idx+1}.png")
+                                        dest_path = os.path.join(temp_dir, f"screenshot_{idx + 1}.png")
                                         import shutil
 
                                         shutil.copy(orig_path, dest_path)
@@ -1752,14 +1752,19 @@ class IssueView(DetailView):
             context["wallet"] = Wallet.objects.get(user=self.request.user)
         context["issue_count"] = Issue.objects.filter(url__contains=self.object.domain_name).count()
         context["all_comment"] = self.object.comments.all()
-        context["all_users"] = User.objects.all()
-        context["likes"] = UserProfile.objects.filter(issue_upvoted=self.object).count()
-        context["likers"] = UserProfile.objects.filter(issue_upvoted=self.object)
-        context["dislikes"] = UserProfile.objects.filter(issue_downvoted=self.object).count()
-        context["dislikers"] = UserProfile.objects.filter(issue_downvoted=self.object)
 
-        context["flags"] = UserProfile.objects.filter(issue_flaged=self.object).count()
-        context["flagers"] = UserProfile.objects.filter(issue_flaged=self.object)
+        # Fetch each interaction group once, derive count from the list
+        likers = list(UserProfile.objects.filter(issue_upvoted=self.object))
+        context["likers"] = likers
+        context["likes"] = len(likers)
+
+        dislikers = list(UserProfile.objects.filter(issue_downvoted=self.object))
+        context["dislikers"] = dislikers
+        context["dislikes"] = len(dislikers)
+
+        flagers = list(UserProfile.objects.filter(issue_flaged=self.object))
+        context["flagers"] = flagers
+        context["flags"] = len(flagers)
 
         context["screenshots"] = IssueScreenshot.objects.filter(issue=self.object).all()
         context["content_type"] = ContentType.objects.get_for_model(Issue).model


### PR DESCRIPTION
## Summary\n\n- Consolidate 6 queries into 3 by fetching each interaction group once and deriving count from the list\n- Remove unused `context[\"all_users\"] = User.objects.all()` query\n\n## Problem\n\nIn `IssueDetailView.get_context_data()`, each interaction type (likes, dislikes, flags) ran **two separate queries**:\n\n```python\ncontext[\"likes\"] = UserProfile.objects.filter(issue_upvoted=self.object).count()   # Query 1\ncontext[\"likers\"] = UserProfile.objects.filter(issue_upvoted=self.object)           # Query 2\n```\n\nThis pattern was repeated for dislikes and flags, resulting in 6 queries where 3 would suffice.\n\nAdditionally, `context[\"all_users\"] = User.objects.all()` loaded every user from the database but was never used in any template.\n\n## Solution\n\nFetch each group as a list once, then derive the count:\n\n```python\nlikers = list(UserProfile.objects.filter(issue_upvoted=self.object))\ncontext[\"likers\"] = likers\ncontext[\"likes\"] = len(likers)\n```\n\nThis cuts 3 redundant `COUNT(*)` queries per page view and removes 1 full-table scan.\n\n## Test Plan\n\n- [ ] Verify issue detail pages display correct like/dislike/flag counts\n- [ ] Verify liker/disliker/flager lists render correctly\n- [ ] Run existing test suite for regressions