### PR TITLE
fix: use get_object_or_404 for contribution lookup in distribute_bacon

### DIFF
--- a/website/views/project.py
+++ b/website/views/project.py
@@ -120,7 +120,7 @@ def select_contribution(request):
 
 @user_passes_test(admin_required)
 def distribute_bacon(request, contribution_id):
-    contribution = Contribution.objects.get(id=contribution_id)
+    contribution = get_object_or_404(Contribution, id=contribution_id)
     if contribution.status == "closed" and not BaconToken.objects.filter(contribution=contribution).exists():
         token = create_bacon_token(contribution.user, contribution)
         if token:


### PR DESCRIPTION
## Summary\n\nReplace bare `Contribution.objects.get()` with `get_object_or_404()` in `distribute_bacon` view to prevent uncaught `DoesNotExist` exception.\n\n## Changes\n\n**`website/views/project.py`**:\n- `distribute_bacon`: `Contribution.objects.get(id=contribution_id)` → `get_object_or_404(Contribution, id=contribution_id)`\n- The previous code would crash with an unhandled `Contribution.DoesNotExist` exception (500 error) if an admin navigated to a URL with an invalid contribution ID\n- `get_object_or_404` is already imported and used throughout the file\n\n## Test plan\n\n- [ ] Verify `distribute_bacon` returns 404 for non-existent contribution IDs\n- [ ] Verify `distribute_bacon` still works correctly for valid contributions