### PR TITLE
fix: use get_object_or_404 for organization lookups in domain management

### DIFF
--- a/website/views/company.py
+++ b/website/views/company.py
@@ -1131,7 +1131,7 @@ class AddDomainView(View):
             domain_data["name"] = domain_data["name"].strip()
 
         managers_list = request.POST.getlist("user")
-        organization_obj = Organization.objects.get(id=id)
+        organization_obj = get_object_or_404(Organization, id=id)
 
         domain_exist = Domain.objects.filter(Q(name=domain_data["name"]) | Q(url=domain_data["url"])).exists()
 
@@ -1228,7 +1228,7 @@ class AddDomainView(View):
         domain_data["name"] = domain_data["name"].lower()
 
         managers_list = request.POST.getlist("user")
-        organization_obj = Organization.objects.get(id=id)
+        organization_obj = get_object_or_404(Organization, id=id)
 
         domain_exist = (
             Domain.objects.filter(Q(name=domain_data["name"]) | Q(url=domain_data["url"]))


### PR DESCRIPTION
## Summary\n\nReplace bare `Organization.objects.get(id=id)` calls with `get_object_or_404()` in `ManageDomainView`'s `post` and `put` methods to prevent uncaught `DoesNotExist` exceptions.\n\n## Changes\n\n**`website/views/company.py`**:\n\n| Method | Line | Before | After |\n|---|---|---|---|\n| `ManageDomainView.post` | ~1134 | `Organization.objects.get(id=id)` | `get_object_or_404(Organization, id=id)` |\n| `ManageDomainView.put` | ~1231 | `Organization.objects.get(id=id)` | `get_object_or_404(Organization, id=id)` |\n\nBoth calls had no `try/except` wrapper, so an invalid organization ID in the URL would crash with a 500 error instead of returning a proper 404.\n\n## Test plan\n\n- [ ] Verify adding a domain to a non-existent organization returns 404 instead of 500\n- [ ] Verify editing a domain for a non-existent organization returns 404 instead of 500\n- [ ] Verify normal domain add/edit operations still work correctly