### PR TITLE
fix(update_repo_stars): use configured GitHub token instead of None

### DIFF
--- a/website/management/commands/update_repo_stars.py
+++ b/website/management/commands/update_repo_stars.py
@@ -46,9 +46,9 @@ class Command(BaseCommand):
                             api_url = f"https://api.github.com/repos/{repo_path}"
                             headers = {"Accept": "application/vnd.github.v3+json"}
 
-                            # Add GitHub token if available
+                            # Add GitHub token if available (settings may default to "blank")
                             github_token = getattr(settings, "GITHUB_TOKEN", None)
-                            if github_token:
+                            if github_token and github_token != "blank":
                                 headers["Authorization"] = f"token {github_token}"
 
                             response = requests.get(api_url, headers=headers)

--- a/website/management/commands/update_repo_stars.py
+++ b/website/management/commands/update_repo_stars.py
@@ -3,6 +3,7 @@ import time
 from urllib.parse import urlparse
 
 import requests
+from django.conf import settings
 from django.core.management.base import BaseCommand
 from django.utils import timezone
 
@@ -46,7 +47,7 @@ class Command(BaseCommand):
                             headers = {"Accept": "application/vnd.github.v3+json"}
 
                             # Add GitHub token if available
-                            github_token = None
+                            github_token = getattr(settings, "GITHUB_TOKEN", None)
                             if github_token:
                                 headers["Authorization"] = f"token {github_token}"
 


### PR DESCRIPTION
## Summary

The `update_repo_stars` management command fetches star counts from the GitHub API for all repositories in the database. However, the GitHub API token was never actually used -- the variable was hardcoded to `None`, causing every request to be unauthenticated.

This PR fixes the token retrieval so the command can make authenticated API calls when `GITHUB_TOKEN` is configured.

## Problem

In `website/management/commands/update_repo_stars.py`, the original code was:

```python
github_token = None
if github_token:
    headers["Authorization"] = f"token {github_token}"
```

Since `github_token` was always `None`, the `if` block never executed, and every GitHub API request was unauthenticated. The unauthenticated rate limit is **60 requests/hour**, compared to **5,000/hour** with a token. This means the command would hit rate limits quickly when updating many repositories.

## Changes

**File:** `website/management/commands/update_repo_stars.py` (4 additions, 3 deletions)

1. **Added `from django.conf import settings`** -- import Django settings to access the configured token.
2. **Replaced `github_token = None`** with `github_token = getattr(settings, "GITHUB_TOKEN", None)` -- reads the token from Django settings, matching the pattern used by other commands like `update_projects.py`.
3. **Added `"blank"` guard** -- changed `if github_token:` to `if github_token and github_token != "blank":` because `settings.GITHUB_TOKEN` defaults to the string `"blank"` when the environment variable is not set. Without this guard, the code would send an invalid `Authorization: token blank` header, causing 401 errors.

## How It Works After the Fix

- If `GITHUB_TOKEN` is set to a real token: authenticated requests at 5,000 req/hour
- If `GITHUB_TOKEN` is unset (defaults to `"blank"`): falls back to unauthenticated requests at 60 req/hour (no invalid header sent)
- If `GITHUB_TOKEN` is explicitly `None` via `getattr` fallback: same graceful fallback

## Test Plan

- [ ] Run `python manage.py update_repo_stars` with `GITHUB_TOKEN` configured in environment
- [ ] Verify the `Authorization` header is sent (check GitHub rate limit response headers show 5,000 limit)
- [ ] Run without `GITHUB_TOKEN` set and verify it falls back to unauthenticated requests (60 req/hour limit) without 401 errors