### PR TITLE
fix(initsuperuser): remove redundant save and modernize style

### DIFF
--- a/website/management/commands/initsuperuser.py
+++ b/website/management/commands/initsuperuser.py
@@ -11,12 +11,11 @@ logger = logging.getLogger(__name__)
 class Command(LoggedBaseCommand):
     def handle(self, *args, **options):
         for user in settings.SUPERUSERS:
-            USERNAME = user[0]
-            EMAIL = user[1]
-            PASSWORD = user[2]
-            logger.info("Creating superuser for %s (%s)" % (USERNAME, EMAIL))
+            username = user[0]
+            email = user[1]
+            password = user[2]
+            logger.info(f"Creating superuser for {username} ({email})")
             if settings.DEBUG:
-                superuser = User.objects.create_superuser(username=USERNAME, email=EMAIL, password=PASSWORD)
-                superuser.save()
+                User.objects.create_superuser(username=username, email=email, password=password)
             else:
                 logger.info("Skipping superuser creation in non-debug mode")

--- a/website/management/commands/initsuperuser.py
+++ b/website/management/commands/initsuperuser.py
@@ -9,6 +9,8 @@ logger = logging.getLogger(__name__)
 
 
 class Command(LoggedBaseCommand):
+    help = "Create superuser accounts from SUPERUSERS setting (debug only)"
+
     def handle(self, *args, **options):
         for user in settings.SUPERUSERS:
             username = user[0]


### PR DESCRIPTION
## Summary\n\nCleans up the `initsuperuser` management command:\n\n- **Redundant `.save()`**: `User.objects.create_superuser()` already saves to the database, so the subsequent `superuser.save()` was an unnecessary extra query.\n- **Old-style formatting**: Replaced `%` string formatting with f-strings.\n- **Variable naming**: Changed `USERNAME`, `EMAIL`, `PASSWORD` (SCREAMING_CASE suggests constants) to lowercase since these are local loop variables.\n\n## Test Plan\n- [ ] `python manage.py initsuperuser` creates superusers correctly in DEBUG mode\n- [ ] No duplicate save queries in database logs"