### PR TITLE
Replace timezone.timedelta with proper datetime.timedelta import

### DIFF
--- a/website/management/commands/check_security_txt.py
+++ b/website/management/commands/check_security_txt.py
@@ -1,5 +1,6 @@
 import logging
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import timedelta
 
 import requests
 from django.core.management.base import BaseCommand
@@ -75,7 +76,7 @@ class Command(BaseCommand):
             # Skip recently checked domains unless update_all is True
             if not update_all:
                 # Only check domains that haven't been checked in the last 7 days
-                last_week = timezone.now() - timezone.timedelta(days=7)
+                last_week = timezone.now() - timedelta(days=7)
                 domains = domains.filter(
                     Q(security_txt_checked_at__isnull=True) | Q(security_txt_checked_at__lt=last_week)
                 )

--- a/website/tests/test_badge_views.py
+++ b/website/tests/test_badge_views.py
@@ -1,9 +1,9 @@
 import io
+from datetime import timedelta
 from unittest.mock import patch
 
 from django.test import Client, TestCase
 from django.urls import reverse
-from django.utils import timezone
 from django.utils.timezone import now
 from PIL import Image
 
@@ -28,7 +28,7 @@ class BadgeViewsTest(TestCase):
         # Create IP records for last 7 days
         today = now().date()
         for i in range(7):
-            date = today - timezone.timedelta(days=i)
+            date = today - timedelta(days=i)
             badge_path = reverse("project-badge", kwargs={"slug": self.project.slug})
             IP.objects.create(address=f"192.168.1.{i}", path=badge_path, created=date, count=1)
 
@@ -127,7 +127,7 @@ class BadgeViewsTest(TestCase):
 
         # Simulate next day visit
         with patch("django.utils.timezone.now") as mock_now:
-            mock_now.return_value = now() + timezone.timedelta(days=1)
+            mock_now.return_value = now() + timedelta(days=1)
             response = self.client.get(url)
             self.assertEqual(response.status_code, 200)
 
@@ -149,7 +149,7 @@ class BadgeViewsTest(TestCase):
         self.assertTrue(image_data.startswith(b"\x89PNG"))
 
         # Check we have the expected number of historical records
-        seven_days_ago = now().date() - timezone.timedelta(days=7)
+        seven_days_ago = now().date() - timedelta(days=7)
         visit_count = IP.objects.filter(path=url, created__date__gte=seven_days_ago).count()
         # 7 from setup + 1 from this test
         self.assertEqual(visit_count, 8)

--- a/website/views/core.py
+++ b/website/views/core.py
@@ -1895,7 +1895,7 @@ def management_commands(request):
     available_commands = []
 
     # Get the date 30 days ago for stats
-    thirty_days_ago = timezone.now() - timezone.timedelta(days=30)
+    thirty_days_ago = timezone.now() - timedelta(days=30)
 
     # Get sort parameter from request
     sort_param = request.GET.get("sort", "name")
@@ -2000,7 +2000,7 @@ def management_commands(request):
 
             # Generate all dates in the 30-day range
             for i in range(30):
-                date = (timezone.now() - timezone.timedelta(days=29 - i)).date()
+                date = (timezone.now() - timedelta(days=29 - i)).date()
                 date_range.append(date)
                 date_values[date.isoformat()] = 0
 

--- a/website/views/organization.py
+++ b/website/views/organization.py
@@ -277,9 +277,7 @@ def weekly_report(request):
 
             for issue in issues:
                 report_data.append(
-                    f"Description: {issue.description}\n"
-                    f"Views: {issue.views}\n"
-                    f"Label: {issue.get_label_display()}\n\n"
+                    f"Description: {issue.description}\nViews: {issue.views}\nLabel: {issue.get_label_display()}\n\n"
                 )
 
             send_mail(
@@ -2666,7 +2664,7 @@ def update_organization_repos(request, slug):
         organization = get_object_or_404(Organization, slug=slug)
 
         # Check if repositories were updated in the last 24 hours
-        one_day_ago = timezone.timedelta(days=1)
+        one_day_ago = timedelta(days=1)
         if organization.repos_updated_at and timezone.now() < organization.repos_updated_at + one_day_ago:
             time_since_update = timezone.now() - organization.repos_updated_at
             hours_remaining = 24 - (time_since_update.total_seconds() / 3600)


### PR DESCRIPTION
# Replace `timezone.timedelta` with `timedelta` from datetime module

## Description

Several files use `timezone.timedelta(...)` instead of importing `timedelta` directly from the `datetime` module. While this happens to work in Django 5.x (because `django.utils.timezone` internally imports `timedelta`), it relies on an undocumented implementation detail of Django's internal imports rather than the public API.

The `timedelta` class is not part of `django.utils.timezone`'s documented API — it belongs to Python's `datetime` module. Using it through `timezone.timedelta` is fragile and could break if Django changes its internal imports.

## Fix

```python
from datetime import timedelta

# Before (relies on Django internals):
thirty_days_ago = timezone.now() - timezone.timedelta(days=30)

# After (uses proper import):
thirty_days_ago = timezone.now() - timedelta(days=30)
```

## Files Changed

| File | Line | Context |
|---|---|---|
| `website/views/core.py` | 1898, 2003 | `management_commands` view — 30-day stats |
| `website/views/organization.py` | 2669 | `update_organization_repos` — 24-hour cooldown |
| `website/management/commands/check_security_txt.py` | 78 | 7-day recheck filter |
| `website/tests/test_badge_views.py` | 31, 130, 152 | Badge test date math |

All four source files already had `from datetime import timedelta` in their imports (or it was added), so the fix simply replaces `timezone.timedelta` with `timedelta`.

Also removed the now-unused `from django.utils import timezone` import in `test_badge_views.py` (it was only used for `timezone.timedelta`, and the file uses `from django.utils.timezone import now` separately).