### PR TITLE
Fix unprotected objects.get and bare except clauses

### DIFF
--- a/website/consumers.py
+++ b/website/consumers.py
@@ -349,16 +349,16 @@ class ChatConsumer(AsyncWebsocketConsumer):
                 await self.send(
                     text_data=json.dumps({"type": "connection_status", "status": "disconnected", "code": close_code})
                 )
-            except:
+            except Exception:
                 pass
-        except:
+        except Exception:
             pass
 
     @database_sync_to_async
     def check_room_exists(self):
         try:
             return Room.objects.filter(id=self.room_id).exists()
-        except:
+        except Exception:
             return False
 
     @database_sync_to_async

--- a/website/views/project.py
+++ b/website/views/project.py
@@ -120,7 +120,7 @@ def select_contribution(request):
 
 @user_passes_test(admin_required)
 def distribute_bacon(request, contribution_id):
-    contribution = Contribution.objects.get(id=contribution_id)
+    contribution = get_object_or_404(Contribution, id=contribution_id)
     if contribution.status == "closed" and not BaconToken.objects.filter(contribution=contribution).exists():
         token = create_bacon_token(contribution.user, contribution)
         if token:


### PR DESCRIPTION
# Fix unprotected objects.get and bare except clauses

## Changes

### 1. `distribute_bacon` — unprotected `objects.get()` (project.py)

`Contribution.objects.get(id=contribution_id)` crashes with `Contribution.DoesNotExist` and returns a 500 error if the contribution ID is invalid. Changed to `get_object_or_404()` to properly return 404.

```python
# Before (returns 500 on invalid ID):
contribution = Contribution.objects.get(id=contribution_id)

# After (returns 404):
contribution = get_object_or_404(Contribution, id=contribution_id)
```

### 2. Bare `except:` in WebSocket consumer (consumers.py)

Three bare `except:` clauses in `ChatConsumer` catch **all** exceptions including `SystemExit` and `KeyboardInterrupt`, which prevents the process from being properly terminated.

**Locations fixed:**
- `disconnect()` handler — two bare except clauses
- `check_room_exists()` — one bare except clause

Changed all to `except Exception:` which still catches all runtime errors but allows system-level exceptions to propagate correctly.