### PR TITLE
Fix incorrect url_type in edit_lecture video validation

### DIFF
--- a/website/views/education.py
+++ b/website/views/education.py
@@ -355,7 +355,7 @@ def edit_lecture(request, lecture_id):
     if lecture.content_type == "VIDEO":
         video_url = request.POST.get("video_url", "")
         if not is_valid_url(video_url, "video"):
-            messages.error(request, "Only YouTube URLs are allowed for video lectures.")
+            messages.error(request, "Only YouTube and Vimeo URLs are allowed for video lectures.")
             if is_standalone:
                 return redirect("view_lecture", lecture_id)
             else:

--- a/website/views/education.py
+++ b/website/views/education.py
@@ -354,7 +354,7 @@ def edit_lecture(request, lecture_id):
 
     if lecture.content_type == "VIDEO":
         video_url = request.POST.get("video_url", "")
-        if not is_valid_url(video_url, "youtube"):
+        if not is_valid_url(video_url, "video"):
             messages.error(request, "Only YouTube URLs are allowed for video lectures.")
             if is_standalone:
                 return redirect("view_lecture", lecture_id)


### PR DESCRIPTION
## Description

Fix a bug in `edit_lecture` where video URL validation always fails.

The `is_valid_url()` helper only recognizes `"video"` and `"live"` as valid `url_type` values:

```python
def is_valid_url(url, url_type):
    if url_type == "video":
        allowed_domains = {"www.youtube.com", "youtube.com", "youtu.be", "vimeo.com", ...}
    elif url_type == "live":
        allowed_domains = {"zoom.us", "meet.google.com", ...}
    else:
        return False  # <-- Any other value returns False
```

`edit_lecture` passes `"youtube"` instead of `"video"`:

```python
# Before (broken) - always returns False
if not is_valid_url(video_url, "youtube"):

# After (fixed) - correctly validates YouTube/Vimeo URLs
if not is_valid_url(video_url, "video"):
```

This means editing a lecture to update its video URL would always show the error message "Only YouTube URLs are allowed for video lectures" even for valid YouTube/Vimeo URLs.

The `add_lecture` view already uses the correct value `"video"` — this fix aligns `edit_lecture` with that behavior.

## Changes
- `website/views/education.py`: Changed `is_valid_url(video_url, "youtube")` to `is_valid_url(video_url, "video")` in `edit_lecture`