### PR TITLE
fix(leaderboard): eliminate N+1 queries with annotation

### DIFF
--- a/website/management/commands/leaderboard.py
+++ b/website/management/commands/leaderboard.py
@@ -1,27 +1,26 @@
-from django.contrib.auth.models import User
+from django.db.models import Count
 
 from website.management.base import LoggedBaseCommand
-from website.models import Issue, UserProfile
+from website.models import UserProfile
 
 
 class Command(LoggedBaseCommand):
     help = "Update user based on number of bugs"
 
     def handle(self, *args, **options):
-        all_user_prof = UserProfile.objects.all()
-        all_user = User.objects.all()
-        for user_ in all_user:
-            user_prof = UserProfile.objects.get(user=user_)
-            total_issues = Issue.objects.filter(user=user_).count()
+        profiles = UserProfile.objects.annotate(total_issues=Count("user__issue"))
+
+        for profile in profiles:
+            total_issues = profile.total_issues
             if total_issues <= 10:
-                user_prof.title = 1
+                profile.title = 1
             elif total_issues <= 50:
-                user_prof.title = 2
+                profile.title = 2
             elif total_issues <= 200:
-                user_prof.title = 3
+                profile.title = 3
             else:
-                user_prof.title = 4
+                profile.title = 4
 
-            user_prof.save()
+            profile.save(update_fields=["title"])
 
-        return str("All users updated.")
+        return "All users updated."


### PR DESCRIPTION
## Summary

The `leaderboard` management command had severe N+1 query issues — for every user in the database it executed 2 separate queries (`UserProfile.objects.get` + `Issue.objects.filter().count()`), plus an individual `save()`. For a database with 10,000 users, this meant ~30,000 queries.

### Changes

- Replace per-user queries with a single annotated queryset using `Count('user__issue')` — reduces to 1 query + N writes
- Remove unused `all_user_prof` variable (fetched but never referenced)
- Remove unnecessary `str()` wrapper on return string literal
- Use `save(update_fields=["title"])` to minimize database write overhead
- Remove unused `User` and `Issue` imports (only `UserProfile` needed now)

### Before (N+1 pattern)
```python
all_user_prof = UserProfile.objects.all()  # unused
all_user = User.objects.all()              # query 1
for user_ in all_user:
    user_prof = UserProfile.objects.get(user=user_)         # N queries
    total_issues = Issue.objects.filter(user=user_).count()  # N queries
    # ... title logic ...
    user_prof.save()                                         # N writes
```

### After (single annotated query)
```python
profiles = UserProfile.objects.annotate(total_issues=Count("user__issue"))
for profile in profiles:
    # ... title logic using profile.total_issues ...
    profile.save(update_fields=["title"])
```