### PR TITLE
Fix duplicate CACHES configuration overriding production cache settings

### DIFF
--- a/blt/settings.py
+++ b/blt/settings.py
@@ -479,32 +479,6 @@ else:
         CACHES = {"default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"}}
 
 if DEBUG or TESTING:
-    CACHES = {
-        "default": {
-            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
-            "LOCATION": "unique-snowflake",
-        }
-    }
-else:
-    # temp to check memory usage
-    CACHES = {
-        "default": {
-            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
-            "LOCATION": "unique-snowflake",
-        }
-    }
-
-    # CACHES = {
-    #     "default": {
-    #         "BACKEND": "django_redis.cache.RedisCache",
-    #         "LOCATION": os.environ.get("REDISCLOUD_URL"),
-    #         "OPTIONS": {
-    #             "CLIENT_CLASS": "django_redis.client.DefaultClient",
-    #         },
-    #     }
-    # }
-
-if DEBUG or TESTING:
     anon_throttle = 100000
     user_throttle = 100000
 

--- a/blt/settings.py
+++ b/blt/settings.py
@@ -19,7 +19,7 @@ env_file = os.path.join(BASE_DIR, ".env")
 environ.Env.read_env(env_file)
 
 print(f"Reading .env file from {env_file}")
-print(f"DATABASE_URL: {os.environ.get('DATABASE_URL', 'not set')}")
+print(f"DATABASE_URL configured")
 
 PROJECT_ROOT = os.path.dirname(os.path.abspath(__file__))
 GITHUB_TOKEN = os.environ.get("GITHUB_TOKEN", "blank")
@@ -478,31 +478,7 @@ else:
     else:
         CACHES = {"default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"}}
 
-if DEBUG or TESTING:
-    CACHES = {
-        "default": {
-            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
-            "LOCATION": "unique-snowflake",
-        }
-    }
-else:
-    # temp to check memory usage
-    CACHES = {
-        "default": {
-            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
-            "LOCATION": "unique-snowflake",
-        }
-    }
 
-    # CACHES = {
-    #     "default": {
-    #         "BACKEND": "django_redis.cache.RedisCache",
-    #         "LOCATION": os.environ.get("REDISCLOUD_URL"),
-    #         "OPTIONS": {
-    #             "CLIENT_CLASS": "django_redis.client.DefaultClient",
-    #         },
-    #     }
-    # }
 
 if DEBUG or TESTING:
     anon_throttle = 100000

--- a/blt/settings.py
+++ b/blt/settings.py
@@ -19,7 +19,7 @@ env_file = os.path.join(BASE_DIR, ".env")
 environ.Env.read_env(env_file)
 
 print(f"Reading .env file from {env_file}")
-print("DATABASE_URL configured")
+print(f"DATABASE_URL: {os.environ.get('DATABASE_URL', 'not set')}")
 
 PROJECT_ROOT = os.path.dirname(os.path.abspath(__file__))
 GITHUB_TOKEN = os.environ.get("GITHUB_TOKEN", "blank")
@@ -478,7 +478,31 @@ else:
     else:
         CACHES = {"default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"}}
 
+if DEBUG or TESTING:
+    CACHES = {
+        "default": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "LOCATION": "unique-snowflake",
+        }
+    }
+else:
+    # temp to check memory usage
+    CACHES = {
+        "default": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "LOCATION": "unique-snowflake",
+        }
+    }
 
+    # CACHES = {
+    #     "default": {
+    #         "BACKEND": "django_redis.cache.RedisCache",
+    #         "LOCATION": os.environ.get("REDISCLOUD_URL"),
+    #         "OPTIONS": {
+    #             "CLIENT_CLASS": "django_redis.client.DefaultClient",
+    #         },
+    #     }
+    # }
 
 if DEBUG or TESTING:
     anon_throttle = 100000

--- a/blt/settings.py
+++ b/blt/settings.py
@@ -19,7 +19,7 @@ env_file = os.path.join(BASE_DIR, ".env")
 environ.Env.read_env(env_file)
 
 print(f"Reading .env file from {env_file}")
-print(f"DATABASE_URL configured")
+print("DATABASE_URL configured")
 
 PROJECT_ROOT = os.path.dirname(os.path.abspath(__file__))
 GITHUB_TOKEN = os.environ.get("GITHUB_TOKEN", "blank")


### PR DESCRIPTION
## Description

This PR removes a duplicate `CACHES` configuration block in `settings.py`
that was unintentionally overriding the earlier cache configuration.

As a result, production deployments always used `LocMemCache`
even when another cache backend was configured.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Consolidated caching into a single environment-conditional configuration, removing verbose per-mode cache branches and obsolete commented blocks. Retains fallback behavior when no external cache service is configured. Throttling and rate-limit values remain unchanged. Improves configuration clarity and maintainability; no functional changes for end users are expected and deployments are unaffected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->