### PR TITLE
fix: use get_object_or_404 for Organization lookups in domain views

### DIFF
--- a/website/views/company.py
+++ b/website/views/company.py
@@ -1131,7 +1131,7 @@ class AddDomainView(View):
             domain_data["name"] = domain_data["name"].strip()
 
         managers_list = request.POST.getlist("user")
-        organization_obj = Organization.objects.get(id=id)
+        organization_obj = get_object_or_404(Organization, id=id)
 
         domain_exist = Domain.objects.filter(Q(name=domain_data["name"]) | Q(url=domain_data["url"])).exists()
 
@@ -1228,7 +1228,7 @@ class AddDomainView(View):
         domain_data["name"] = domain_data["name"].lower()
 
         managers_list = request.POST.getlist("user")
-        organization_obj = Organization.objects.get(id=id)
+        organization_obj = get_object_or_404(Organization, id=id)
 
         domain_exist = (
             Domain.objects.filter(Q(name=domain_data["name"]) | Q(url=domain_data["url"]))


### PR DESCRIPTION
## Problem

Two `Organization.objects.get(id=id)` calls in `company.py` lack error handling. If the organization ID is invalid or the organization was deleted between requests, Django raises an unhandled `Organization.DoesNotExist` exception, returning a 500 error instead of a proper 404.

### Affected Views

| View | Line | Method |
|---|---|---|
| `AddDomain.post()` | ~1134 | Adding a domain to an organization |
| `EditDomain.put()` | ~1231 | Editing a domain in an organization |

## Fix

Replace `Organization.objects.get(id=id)` with `get_object_or_404(Organization, id=id)` in both locations. `get_object_or_404` is already imported and used elsewhere in this file (e.g., line 2246, 2370).

## Why not try/except?

`get_object_or_404` is the Django-idiomatic pattern for views — it returns a proper 404 response with minimal boilerplate. The same pattern is already used throughout this file for other model lookups.

## Test Plan

- [ ] Adding a domain to a valid organization still works
- [ ] Accessing a domain view with an invalid organization ID returns 404 instead of 500

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling to display proper 404 responses when accessing non-existent organizations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->