### PR TITLE
fix(project): use get_object_or_404 in distribute_bacon

### DIFF
--- a/website/views/project.py
+++ b/website/views/project.py
@@ -120,7 +120,7 @@ def select_contribution(request):
 
 @user_passes_test(admin_required)
 def distribute_bacon(request, contribution_id):
-    contribution = Contribution.objects.get(id=contribution_id)
+    contribution = get_object_or_404(Contribution, id=contribution_id)
     if contribution.status == "closed" and not BaconToken.objects.filter(contribution=contribution).exists():
         token = create_bacon_token(contribution.user, contribution)
         if token:


### PR DESCRIPTION
## Description\n\nReplace bare `Contribution.objects.get()` with `get_object_or_404()` in the `distribute_bacon` view (`website/views/project.py`).\n\n## Problem\n\nThe `distribute_bacon` view uses `Contribution.objects.get(id=contribution_id)` directly. If an invalid `contribution_id` is passed in the URL, this raises an unhandled `Contribution.DoesNotExist` exception, resulting in a **500 Internal Server Error** instead of a proper 404 response.\n\n## Fix\n\nSwitch to `get_object_or_404(Contribution, id=contribution_id)` which is already imported and used elsewhere in the same file. This returns a proper **404 Not Found** response for invalid IDs.\n\n## Testing\n\n- Verified `get_object_or_404` is already imported at line 29\n- Verified the same pattern is used throughout the file (lines 69, 161, 839, 2079)\n- Single-line change, no side effects"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for non-existent contributions. The application now returns a proper "Not Found" response when attempting to access a contribution that doesn't exist, providing clearer feedback to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->