### PR TITLE
chore: Added Manahil Afzal as GSoC'26 mentee

### DIFF
--- a/blt/settings.py
+++ b/blt/settings.py
@@ -66,6 +66,13 @@ SCOUT_MONITOR = True
 SCOUT_KEY = os.environ.get("SCOUT_KEY")
 SCOUT_NAME = PROJECT_NAME
 
+ALLOWED_HOSTS = ['*']
+CSRF_TRUSTED_ORIGINS = [
+    'https://*.github.dev',
+    'https://*.app.github.dev',
+    'http://localhost:*',
+]
+
 
 INSTALLED_APPS = (
     # "scout_apm.django",

--- a/website/templates/gsoc.html
+++ b/website/templates/gsoc.html
@@ -1,1205 +1,1803 @@
-{% extends "base.html" %}
-{% load static %}
-{% load custom_tags %}
-{% block title %}
-    Google Summer of Code with OWASP
-{% endblock title %}
-{% block description %}
-    Join the Google Summer of Code program with OWASP and contribute to open source security projects.
-{% endblock description %}
-{% block keywords %}
-    GSoC, Google Summer of Code, OWASP, Open Source, Student Program, Mentorship
-{% endblock keywords %}
-{% block og_title %}
-    Google Summer of Code with OWASP
-{% endblock og_title %}
-{% block og_description %}
-    Learn about the Google Summer of Code (GSoC) program, its benefits, and its partnership with OWASP {% env 'PROJECT_NAME' %}.
-{% endblock og_description %}
-{% block extra_head %}
-    <style>
-.mentor-description-container {
+{% extends "base.html" %} {% load static %} {% load custom_tags %} {% block
+title %} Google Summer of Code with OWASP {% endblock title %} {% block
+description %} Join the Google Summer of Code program with OWASP and contribute
+to open source security projects. {% endblock description %} {% block keywords
+%} GSoC, Google Summer of Code, OWASP, Open Source, Student Program, Mentorship
+{% endblock keywords %} {% block og_title %} Google Summer of Code with OWASP {%
+endblock og_title %} {% block og_description %} Learn about the Google Summer of
+Code (GSoC) program, its benefits, and its partnership with OWASP {% env
+'PROJECT_NAME' %}. {% endblock og_description %} {% block extra_head %}
+<style>
+  .mentor-description-container {
     max-height: 8rem;
     overflow-y: auto;
     scrollbar-width: none;
     -ms-overflow-style: none;
-}
-.mentor-description-container::-webkit-scrollbar {
+  }
+  .mentor-description-container::-webkit-scrollbar {
     display: none;
-}
-.mentor-description-text {
+  }
+  .mentor-description-text {
     scrollbar-width: none;
     -ms-overflow-style: none;
-}
-.mentor-description-text::-webkit-scrollbar {
+  }
+  .mentor-description-text::-webkit-scrollbar {
     display: none;
-}
-    </style>
-{% endblock extra_head %}
-{% block content %}
-    {% include "includes/sidenav.html" %}
-    <!-- Hero Section -->
-    <div class="mt-[100px] bg-zinc-100 py-16">
-        <div class="w-[85%] mx-auto">
-            <div class="flex flex-col md:flex-row items-center gap-8">
-                <div class="md:w-1/3 flex justify-center">
-                    <div class="relative">
-                        <div class="absolute -inset-4 bg-[#e74c3c] rounded-full blur-md opacity-30 animate-pulse"></div>
-                        <img src="{% static 'images/gsoc.png' %}"
-                             alt="Google Summer of Code Logo"
-                             class="w-[160px] h-auto object-contain relative"
-                             width="200"
-                             height="200" />
-                    </div>
-                </div>
-                <div class="md:w-2/3">
-                    <h1 class="text-4xl md:text-5xl font-bold text-gray-900 dark:text-gray-100 mb-4">Google Summer of Code</h1>
-                    <h2 class="text-xl md:text-2xl font-medium text-red-500 mb-6">
-                        with Open Worldwide Application Security Project (OWASP) Foundation
-                    </h2>
-                    <p class="text-xl text-gray-700 dark:text-gray-300 leading-relaxed mb-2">
-                        The
-                        <a href="https://summerofcode.withgoogle.com/"
-                           class="text-[#e74c3c] hover:text-red-700 hover:underline transition-colors font-medium">Google Summer of Code program</a>
-                        (GSoC) is designed to encourage student participation in open source
-                        development. Through GSoC, accepted student applicants will be paired
-                        with OWASP mentors that will guide them through their coding tasks.
-                    </p>
-                    <p class="text-gray-700 dark:text-gray-300 leading-relaxed mb-6">
-                        <i class="fas fa-info-circle mr-2"></i> This program is done
-                        completely online. Students and mentors from more than 100 countries
-                        have participated in past years.
-                    </p>
-                    <div class="flex flex-wrap gap-4">
-                        <a href="https://owasp.org/www-community/initiatives/gsoc/"
-                           class="inline-flex items-center px-6 py-3 bg-red-500 shadow-md hover:bg-red-600 hover:text-white text-white font-medium rounded-lg transition-colors duration-200">
-                            <i class="fas fa-code-branch mr-2"></i> Browse Projects
-                        </a>
-                        <a href="https://summerofcode.withgoogle.com/"
-                           class="inline-flex items-center px-6 py-3 bg-white dark:bg-gray-800 shadow-md hover:bg-gray-100 hover:text-gray-800 text-gray-800 dark:text-gray-200 font-medium rounded-lg transition-colors border border-gray-300 dark:border-gray-600 duration-200">
-                            <i class="fas fa-external-link-alt mr-2"></i> Official GSoC Site
-                        </a>
-                    </div>
-                </div>
-            </div>
+  }
+</style>
+{% endblock extra_head %} {% block content %} {% include "includes/sidenav.html"
+%}
+<!-- Hero Section -->
+<div class="mt-[100px] bg-zinc-100 py-16">
+  <div class="w-[85%] mx-auto">
+    <div class="flex flex-col md:flex-row items-center gap-8">
+      <div class="md:w-1/3 flex justify-center">
+        <div class="relative">
+          <div
+            class="absolute -inset-4 bg-[#e74c3c] rounded-full blur-md opacity-30 animate-pulse"
+          ></div>
+          <img
+            src="{% static 'images/gsoc.png' %}"
+            alt="Google Summer of Code Logo"
+            class="w-[160px] h-auto object-contain relative"
+            width="200"
+            height="200"
+          />
         </div>
+      </div>
+      <div class="md:w-2/3">
+        <h1
+          class="text-4xl md:text-5xl font-bold text-gray-900 dark:text-gray-100 mb-4"
+        >
+          Google Summer of Code
+        </h1>
+        <h2 class="text-xl md:text-2xl font-medium text-red-500 mb-6">
+          with Open Worldwide Application Security Project (OWASP) Foundation
+        </h2>
+        <p
+          class="text-xl text-gray-700 dark:text-gray-300 leading-relaxed mb-2"
+        >
+          The
+          <a
+            href="https://summerofcode.withgoogle.com/"
+            class="text-[#e74c3c] hover:text-red-700 hover:underline transition-colors font-medium"
+            >Google Summer of Code program</a
+          >
+          (GSoC) is designed to encourage student participation in open source
+          development. Through GSoC, accepted student applicants will be paired
+          with OWASP mentors that will guide them through their coding tasks.
+        </p>
+        <p class="text-gray-700 dark:text-gray-300 leading-relaxed mb-6">
+          <i class="fas fa-info-circle mr-2"></i> This program is done
+          completely online. Students and mentors from more than 100 countries
+          have participated in past years.
+        </p>
+        <div class="flex flex-wrap gap-4">
+          <a
+            href="https://owasp.org/www-community/initiatives/gsoc/"
+            class="inline-flex items-center px-6 py-3 bg-red-500 shadow-md hover:bg-red-600 hover:text-white text-white font-medium rounded-lg transition-colors duration-200"
+          >
+            <i class="fas fa-code-branch mr-2"></i> Browse Projects
+          </a>
+          <a
+            href="https://summerofcode.withgoogle.com/"
+            class="inline-flex items-center px-6 py-3 bg-white dark:bg-gray-800 shadow-md hover:bg-gray-100 hover:text-gray-800 text-gray-800 dark:text-gray-200 font-medium rounded-lg transition-colors border border-gray-300 dark:border-gray-600 duration-200"
+          >
+            <i class="fas fa-external-link-alt mr-2"></i> Official GSoC Site
+          </a>
+        </div>
+      </div>
     </div>
-    <!-- Main Content -->
-    <div class="py-16 px-4 sm:px-6 lg:px-8 bg-white dark:bg-gray-800">
-        <div class="w-[85%] mx-auto">
-            <!-- Stats Section -->
-            <div class="mb-16">
-                <div class="grid grid-cols-1 sm:grid-cols-3 gap-6">
-                    <div class="bg-white dark:bg-gray-800 shadow-lg rounded-xl overflow-hidden transform">
-                        <div class="p-2 bg-[#e74c3c]"></div>
-                        <div class="p-6 text-center">
-                            <div class="text-5xl font-bold mb-2 text-[#e74c3c]">100+</div>
-                            <div class="text-gray-700 dark:text-gray-300 font-medium">Countries Participated</div>
-                        </div>
-                    </div>
-                    <div class="bg-white dark:bg-gray-800 shadow-lg rounded-xl overflow-hidden transform">
-                        <div class="p-2 bg-[#e74c3c]"></div>
-                        <div class="p-6 text-center">
-                            <div class="text-5xl font-bold mb-2 text-[#e74c3c]">7</div>
-                            <div class="text-gray-700 dark:text-gray-300 font-medium">Years with OWASP BLT</div>
-                        </div>
-                    </div>
-                    <div class="bg-white dark:bg-gray-800 shadow-lg rounded-xl overflow-hidden transform">
-                        <div class="p-2 bg-[#e74c3c]"></div>
-                        <div class="p-6 text-center">
-                            <div class="text-5xl font-bold mb-2 text-[#e74c3c]">20+</div>
-                            <div class="text-gray-700 dark:text-gray-300 font-medium">Successful Projects</div>
-                        </div>
-                    </div>
-                </div>
+  </div>
+</div>
+<!-- Main Content -->
+<div class="py-16 px-4 sm:px-6 lg:px-8 bg-white dark:bg-gray-800">
+  <div class="w-[85%] mx-auto">
+    <!-- Stats Section -->
+    <div class="mb-16">
+      <div class="grid grid-cols-1 sm:grid-cols-3 gap-6">
+        <div
+          class="bg-white dark:bg-gray-800 shadow-lg rounded-xl overflow-hidden transform"
+        >
+          <div class="p-2 bg-[#e74c3c]"></div>
+          <div class="p-6 text-center">
+            <div class="text-5xl font-bold mb-2 text-[#e74c3c]">100+</div>
+            <div class="text-gray-700 dark:text-gray-300 font-medium">
+              Countries Participated
             </div>
-            <!-- Benefits Section -->
-            <div class="mb-20">
-                <h2 class="text-3xl font-bold text-center text-gray-900 dark:text-gray-100 mb-2">Program Benefits</h2>
-                <div class="w-20 h-1 bg-[#e74c3c] mx-auto mb-12 rounded-full"></div>
-                <div class="grid grid-cols-1 lg:grid-cols-2 gap-10">
-                    <!-- Student Benefits -->
-                    <div class="bg-white dark:bg-gray-800 rounded-xl shadow-lg transition-all duration-300 p-8 border border-gray-100 dark:border-gray-800">
-                        <div class="flex items-center mb-6">
-                            <div class="w-12 h-12 flex items-center justify-center bg-red-100 text-[#e74c3c] rounded-full mr-4">
-                                <i class="fas fa-user-graduate text-xl" aria-hidden="true"></i>
-                            </div>
-                            <h3 class="text-2xl font-bold text-gray-900 dark:text-gray-100">For Students</h3>
-                        </div>
-                        <ul class="space-y-4">
-                            <li class="flex items-start">
-                                <i class="fas fa-check-circle text-[#e74c3c] mt-1 mr-3"
-                                   aria-hidden="true"></i>
-                                <p class="text-gray-700 dark:text-gray-300">Gaining exposure to real-world software development scenarios</p>
-                            </li>
-                            <li class="flex items-start">
-                                <i class="fas fa-check-circle text-[#e74c3c] mt-1 mr-3"
-                                   aria-hidden="true"></i>
-                                <p class="text-gray-700 dark:text-gray-300">
-                                    An opportunity for employment in areas related to their academic
-                                    pursuits
-                                </p>
-                            </li>
-                            <li class="flex items-start">
-                                <i class="fas fa-check-circle text-[#e74c3c] mt-1 mr-3"
-                                   aria-hidden="true"></i>
-                                <p class="text-gray-700 dark:text-gray-300">
-                                    Google will be offering successful student contributors a
-                                    stipend
-                                </p>
-                            </li>
-                            <li class="flex items-start">
-                                <i class="fas fa-check-circle text-[#e74c3c] mt-1 mr-3"
-                                   aria-hidden="true"></i>
-                                <p class="text-gray-700 dark:text-gray-300">Build your professional network</p>
-                            </li>
-                            <li class="flex items-start">
-                                <i class="fas fa-check-circle text-[#e74c3c] mt-1 mr-3"
-                                   aria-hidden="true"></i>
-                                <p class="text-gray-700 dark:text-gray-300">Gain valuable experience in cybersecurity</p>
-                            </li>
-                            <li class="flex items-start">
-                                <i class="fas fa-check-circle text-[#e74c3c] mt-1 mr-3"
-                                   aria-hidden="true"></i>
-                                <p class="text-gray-700 dark:text-gray-300">Receive a certificate upon completion</p>
-                            </li>
-                        </ul>
-                    </div>
-                    <!-- Mentor Benefits -->
-                    <div class="bg-white dark:bg-gray-800 rounded-xl shadow-lg transition-all duration-300 p-8 border border-gray-100 dark:border-gray-800">
-                        <div class="flex items-center mb-6">
-                            <div class="w-12 h-12 flex items-center justify-center bg-red-100 text-[#e74c3c] rounded-full mr-4">
-                                <i class="fas fa-chalkboard-teacher text-xl" aria-hidden="true"></i>
-                            </div>
-                            <h3 class="text-2xl font-bold text-gray-900 dark:text-gray-100">For Mentors</h3>
-                        </div>
-                        <ul class="space-y-4">
-                            <li class="flex items-start">
-                                <i class="fas fa-check-circle text-[#e74c3c] mt-1 mr-3"
-                                   aria-hidden="true"></i>
-                                <p class="text-gray-700 dark:text-gray-300">Shape the next generation of open-source developers</p>
-                            </li>
-                            <li class="flex items-start">
-                                <i class="fas fa-check-circle text-[#e74c3c] mt-1 mr-3"
-                                   aria-hidden="true"></i>
-                                <p class="text-gray-700 dark:text-gray-300">Enhance project visibility and community engagement</p>
-                            </li>
-                            <li class="flex items-start">
-                                <i class="fas fa-check-circle text-[#e74c3c] mt-1 mr-3"
-                                   aria-hidden="true"></i>
-                                <p class="text-gray-700 dark:text-gray-300">Develop leadership and mentoring skills</p>
-                            </li>
-                            <li class="flex items-start">
-                                <i class="fas fa-check-circle text-[#e74c3c] mt-1 mr-3"
-                                   aria-hidden="true"></i>
-                                <p class="text-gray-700 dark:text-gray-300">Expand your professional network within OWASP</p>
-                            </li>
-                            <li class="flex items-start">
-                                <i class="fas fa-check-circle text-[#e74c3c] mt-1 mr-3"
-                                   aria-hidden="true"></i>
-                                <p class="text-gray-700 dark:text-gray-300">Recognition in the global security community</p>
-                            </li>
-                            <li class="flex items-start">
-                                <i class="fas fa-check-circle text-[#e74c3c] mt-1 mr-3"
-                                   aria-hidden="true"></i>
-                                <p class="text-gray-700 dark:text-gray-300">Contribute to the growth of open-source security projects</p>
-                            </li>
-                        </ul>
-                    </div>
-                </div>
+          </div>
+        </div>
+        <div
+          class="bg-white dark:bg-gray-800 shadow-lg rounded-xl overflow-hidden transform"
+        >
+          <div class="p-2 bg-[#e74c3c]"></div>
+          <div class="p-6 text-center">
+            <div class="text-5xl font-bold mb-2 text-[#e74c3c]">7</div>
+            <div class="text-gray-700 dark:text-gray-300 font-medium">
+              Years with OWASP BLT
             </div>
-            <!-- OWASP Partnership Card -->
-            <div class="bg-white rounded-xl shadow-lg transition-all duration-300 p-8 mb-20 border border-gray-100">
-                <h2 class="text-3xl font-bold text-gray-900 mb-6">OWASP BLT & GSOC Partnership</h2>
-                <div class="space-y-6 text-gray-700">
-                    <p class="leading-relaxed">
-                        OWASP is an open community dedicated to enabling organizations to
-                        conceive, develop, acquire, operate, and maintain applications that
-                        can be trusted. OWASP has been an active participant in the Google
-                        Summer of Code program, providing students with the opportunity to
-                        contribute to various OWASP projects.
-                    </p>
-                    <p class="leading-relaxed">
-                        OWASP BLT (Bug Logging Tool) has been participating in the Google
-                        Summer of Code program for the past 5 consecutive years, from 2020 to
-                        2024. OWASP BLT is an open-source platform dedicated to making the
-                        internet safer through community-driven bug reporting and
-                        collaboration.
-                    </p>
-                    <p class="leading-relaxed">
-                        All students currently enrolled in an accredited institution are
-                        welcome to participate in the Google Summer of Code program, hopefully
-                        along with the OWASP Foundation.
-                    </p>
-                </div>
+          </div>
+        </div>
+        <div
+          class="bg-white dark:bg-gray-800 shadow-lg rounded-xl overflow-hidden transform"
+        >
+          <div class="p-2 bg-[#e74c3c]"></div>
+          <div class="p-6 text-center">
+            <div class="text-5xl font-bold mb-2 text-[#e74c3c]">20+</div>
+            <div class="text-gray-700 dark:text-gray-300 font-medium">
+              Successful Projects
             </div>
-            <!-- Project Ideas Section -->
-            <div class="mb-20">
-                <h2 class="text-3xl font-bold text-center text-gray-900 dark:text-gray-100 mb-2">Project Ideas</h2>
-                <div class="w-20 h-1 bg-[#e74c3c] mx-auto mb-12 rounded-full"></div>
-                <!-- OWASP BLT Projects (Highlighted) -->
-                <div class="mb-12">
-                    <a href="https://github.com/OWASP-BLT/BLT/milestones"
-                       rel="noopener noreferrer"
-                       target="_blank"
-                       class="block p-8 bg-gradient-to-br from-red-50 to-red-100 border-2 border-red-200 rounded-xl transition-all">
-                        <div class="flex flex-col md:flex-row items-center justify-between">
-                            <div class="mb-6 md:mb-0">
-                                <h3 class="text-2xl font-bold text-red-700 mb-3">OWASP BLT Project Ideas</h3>
-                                <p class="text-red-600 text-lg mb-4">
-                                    Explore exciting project opportunities with OWASP Bug Logging
-                                    Tool
-                                </p>
-                                <span class="inline-block px-4 py-2 bg-white dark:bg-gray-800 text-[#e74c3c] rounded-full font-medium">Featured Projects</span>
-                            </div>
-                            <div class="text-center">
-                                <div class="w-24 h-24 flex items-center justify-center bg-white dark:bg-gray-800 rounded-full mb-4 shadow-md mx-auto">
-                                    <i class="fa-solid fa-lightbulb text-[#e74c3c] text-4xl"></i>
-                                </div>
-                                <span class="inline-flex items-center text-[#e74c3c] font-medium">
-                                    Browse Now <i class="fa-solid fa-arrow-right ml-2"></i>
-                                </span>
-                            </div>
-                        </div>
-                    </a>
-                </div>
-                <!-- Past Ideas Grid -->
-                <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
-                    <a href="https://owasp.org/www-community/initiatives/gsoc/gsoc2025ideas"
-                       target="_blank"
-                       rel="noopener noreferrer"
-                       class="group block p-5 bg-white dark:bg-gray-800 shadow-md rounded-lg border border-gray-100 dark:border-gray-800 transition-all">
-                        <div class="flex items-center">
-                            <span class="font-semibold text-gray-900 dark:text-gray-100 group-hover:text-[#e74c3c] transition-colors">GSOC Project Ideas 2025</span>
-                            <i class="fa-solid fa-link ml-auto text-gray-400 dark:text-gray-600 group-hover:text-[#e74c3c]"></i>
-                        </div>
-                    </a>
-                    <a href="https://owasp.org/www-community/initiatives/gsoc/gsoc2024ideas"
-                       target="_blank"
-                       rel="noopener noreferrer"
-                       class="group block p-5 bg-white dark:bg-gray-800 shadow-md rounded-lg border border-gray-100 dark:border-gray-800 transition-all">
-                        <div class="flex items-center">
-                            <span class="font-semibold text-gray-900 dark:text-gray-100 group-hover:text-[#e74c3c] transition-colors">GSOC Project Ideas 2024</span>
-                            <i class="fa-solid fa-link ml-auto text-gray-400 dark:text-gray-600 group-hover:text-[#e74c3c]"></i>
-                        </div>
-                    </a>
-                    <a href="https://owasp.org/www-community/initiatives/gsoc/gsoc2023ideas"
-                       target="_blank"
-                       rel="noopener noreferrer"
-                       class="group block p-5 bg-white dark:bg-gray-800 shadow-md rounded-lg border border-gray-100 dark:border-gray-800 transition-all">
-                        <div class="flex items-center">
-                            <span class="font-semibold text-gray-900 dark:text-gray-100 group-hover:text-[#e74c3c] transition-colors">GSOC Project Ideas 2023</span>
-                            <i class="fa-solid fa-link ml-auto text-gray-400 dark:text-gray-600 group-hover:text-[#e74c3c]"></i>
-                        </div>
-                    </a>
-                    <a href="https://owasp.org/www-community/initiatives/gsoc/gsoc2022ideas"
-                       target="_blank"
-                       rel="noopener noreferrer"
-                       class="group block p-5 bg-white dark:bg-gray-800 shadow-md rounded-lg border border-gray-100 dark:border-gray-800 transition-all">
-                        <div class="flex items-center">
-                            <span class="font-semibold text-gray-900 dark:text-gray-100 group-hover:text-[#e74c3c] transition-colors">GSOC Project Ideas 2022</span>
-                            <i class="fa-solid fa-link ml-auto text-gray-400 dark:text-gray-600 group-hover:text-[#e74c3c]"></i>
-                        </div>
-                    </a>
-                    <a href="https://owasp.org/www-community/initiatives/gsoc/gsoc2021ideas"
-                       target="_blank"
-                       rel="noopener noreferrer"
-                       class="group block p-5 bg-white dark:bg-gray-800 shadow-md rounded-lg border border-gray-100 dark:border-gray-800 transition-all">
-                        <div class="flex items-center">
-                            <span class="font-semibold text-gray-900 dark:text-gray-100 group-hover:text-[#e74c3c] transition-colors">GSOC Project Ideas 2021</span>
-                            <i class="fa-solid fa-link ml-auto text-gray-400 dark:text-gray-600 group-hover:text-[#e74c3c]"></i>
-                        </div>
-                    </a>
-                    <a href="https://owasp.org/www-community/initiatives/gsoc/gsoc2020ideas"
-                       target="_blank"
-                       rel="noopener noreferrer"
-                       class="group block p-5 bg-white dark:bg-gray-800 shadow-md rounded-lg border border-gray-100 dark:border-gray-800 transition-all">
-                        <div class="flex items-center">
-                            <span class="font-semibold text-gray-900 dark:text-gray-100 group-hover:text-[#e74c3c] transition-colors">GSOC Project Ideas 2020</span>
-                            <i class="fa-solid fa-link ml-auto text-gray-400 dark:text-gray-600 group-hover:text-[#e74c3c]"></i>
-                        </div>
-                    </a>
-                    <a href="https://owasp.org/www-community/initiatives/gsoc/gsoc2019ideas"
-                       target="_blank"
-                       rel="noopener noreferrer"
-                       class="group block p-5 bg-white dark:bg-gray-800 shadow-md rounded-lg border border-gray-100 dark:border-gray-800 transition-all">
-                        <div class="flex items-center">
-                            <span class="font-semibold text-gray-900 dark:text-gray-100 group-hover:text-[#e74c3c] transition-colors">GSOC Project Ideas 2019</span>
-                            <i class="fa-solid fa-link ml-auto text-gray-400 dark:text-gray-600 group-hover:text-[#e74c3c]"></i>
-                        </div>
-                    </a>
-                    <a href="https://owasp.org/www-community/initiatives/gsoc/gsoc2018ideas"
-                       target="_blank"
-                       rel="noopener noreferrer"
-                       class="group block p-5 bg-white dark:bg-gray-800 shadow-md rounded-lg border border-gray-100 dark:border-gray-800 transition-all">
-                        <div class="flex items-center">
-                            <span class="font-semibold text-gray-900 dark:text-gray-100 group-hover:text-[#e74c3c] transition-colors">GSOC Project Ideas 2018</span>
-                            <i class="fa-solid fa-link ml-auto text-gray-400 dark:text-gray-600 group-hover:text-[#e74c3c]"></i>
-                        </div>
-                    </a>
-                    <a href="https://owasp.org/www-community/initiatives/gsoc/gsoc2017ideas"
-                       target="_blank"
-                       rel="noopener noreferrer"
-                       class="group block p-5 bg-white dark:bg-gray-800 shadow-md rounded-lg border border-gray-100 dark:border-gray-800 transition-all">
-                        <div class="flex items-center">
-                            <span class="font-semibold text-gray-900 dark:text-gray-100 group-hover:text-[#e74c3c] transition-colors">GSOC Project Ideas 2017</span>
-                            <i class="fa-solid fa-link ml-auto text-gray-400 dark:text-gray-600 group-hover:text-[#e74c3c]"></i>
-                        </div>
-                    </a>
-                </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <!-- Benefits Section -->
+    <div class="mb-20">
+      <h2
+        class="text-3xl font-bold text-center text-gray-900 dark:text-gray-100 mb-2"
+      >
+        Program Benefits
+      </h2>
+      <div class="w-20 h-1 bg-[#e74c3c] mx-auto mb-12 rounded-full"></div>
+      <div class="grid grid-cols-1 lg:grid-cols-2 gap-10">
+        <!-- Student Benefits -->
+        <div
+          class="bg-white dark:bg-gray-800 rounded-xl shadow-lg transition-all duration-300 p-8 border border-gray-100 dark:border-gray-800"
+        >
+          <div class="flex items-center mb-6">
+            <div
+              class="w-12 h-12 flex items-center justify-center bg-red-100 text-[#e74c3c] rounded-full mr-4"
+            >
+              <i class="fas fa-user-graduate text-xl" aria-hidden="true"></i>
             </div>
-            <!-- Past Events -->
-            <div class="bg-white dark:bg-gray-800 rounded-xl shadow-lg transition-all duration-300 p-8 mb-20 border border-gray-100 dark:border-gray-800">
-                <h2 class="text-3xl font-bold text-gray-900 dark:text-gray-100 mb-6">Past GSOC Events</h2>
-                <div class="grid grid-cols-1 lg:grid-cols-2 gap-8">
-                    <!-- 2023 -->
-                    <div class="bg-white dark:bg-gray-800 rounded-lg shadow-md transition-all border border-gray-200 dark:border-gray-700 overflow-hidden">
-                        <div class="p-2 bg-[#e74c3c]"></div>
-                        <div class="p-6">
-                            <a href="https://summerofcode.withgoogle.com/archive/2023/organizations/owasp-foundation"
-                               target="_blank"
-                               rel="noopener noreferrer"
-                               class="text-xl font-bold text-gray-900 dark:text-gray-100 hover:text-[#e74c3c] transition-colors flex items-center mb-4">
-                                <i aria-hidden="true" class="fas fa-calendar-alt mr-2 text-[#e74c3c]"></i>
-                                2023 GSOC Archive
-                            </a>
-                            <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4">
-                                <h4 class="text-lg font-semibold text-gray-800 dark:text-gray-200 mb-2 flex items-center">
-                                    <i aria-hidden="true" class="fas fa-users mr-2 text-[#e74c3c]"></i>
-                                    Mentors
-                                </h4>
-                                <p class="text-gray-700 dark:text-gray-300 leading-relaxed">
-                                    Abraham Aranguren, Aryan Prasad, Aryan Ranjan, Ben de Haan,
-                                    Björn Kimminich, Christian Folini, DonnieBLT, fzipitria, Jannik
-                                    Hollenbach, José Carlos Chávez, Mrigank Anand, Rick M,
-                                    ShubhamPalriwala, Simon Bennetts, thc202, Timo Pagel, Viyat
-                                </p>
-                            </div>
-                        </div>
-                    </div>
-                    <!-- 2022 -->
-                    <div class="bg-white dark:bg-gray-800 rounded-lg shadow-md transition-all border border-gray-200 dark:border-gray-700 overflow-hidden">
-                        <div class="p-2 bg-[#e74c3c]"></div>
-                        <div class="p-6">
-                            <a href="https://summerofcode.withgoogle.com/archive/2022/organizations/owasp-foundation"
-                               target="_blank"
-                               rel="noopener noreferrer"
-                               class="text-xl font-bold text-gray-900 dark:text-gray-100 hover:text-[#e74c3c] transition-colors flex items-center mb-4">
-                                <i aria-hidden="true" class="fas fa-calendar-alt mr-2 text-[#e74c3c]"></i>
-                                2022 GSOC Archive
-                            </a>
-                            <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4">
-                                <h4 class="text-lg font-semibold text-gray-800 dark:text-gray-200 mb-2 flex items-center">
-                                    <i aria-hidden="true" class="fas fa-users mr-2 text-[#e74c3c]"></i>
-                                    Mentors
-                                </h4>
-                                <p class="text-gray-700 dark:text-gray-300 leading-relaxed">
-                                    Abraham Aranguren, Ade Yoseman Putra, Ankit Choudhary, Björn
-                                    Kimminich, Dhiren Serai, Franziska, fzipitria, Glenn Ten Cate,
-                                    Jannik Hollenbach, Rejah Rehim, Rick M, Saeed Dehqan, Sam
-                                    Stepanyan, Sparsh Agrawal, thc202, Timo Pagel, Viyat
-                                </p>
-                            </div>
-                        </div>
-                    </div>
-                    <!-- 2021 -->
-                    <div class="bg-white dark:bg-gray-800 rounded-lg shadow-md transition-all border border-gray-200 dark:border-gray-700 overflow-hidden">
-                        <div class="p-2 bg-[#e74c3c]"></div>
-                        <div class="p-6">
-                            <a href="https://summerofcode.withgoogle.com/archive/2021/organizations/owasp-foundation"
-                               target="_blank"
-                               rel="noopener noreferrer"
-                               class="text-xl font-bold text-gray-900 dark:text-gray-100 hover:text-[#e74c3c] transition-colors flex items-center mb-4">
-                                <i aria-hidden="true" class="fas fa-calendar-alt mr-2 text-[#e74c3c]"></i>
-                                2021 GSOC Archive
-                            </a>
-                            <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4">
-                                <h4 class="text-lg font-semibold text-gray-800 dark:text-gray-200 mb-2 flex items-center">
-                                    <i aria-hidden="true" class="fas fa-users mr-2 text-[#e74c3c]"></i>
-                                    Mentors
-                                </h4>
-                                <p class="text-gray-700 dark:text-gray-300 leading-relaxed">
-                                    8f040, Abe, Abraham Aranguren, Ade Yoseman Putra, Ali Razmjoo
-                                    Qalaei, Anshul Singhal, Ashrith N Shetty, Björn Kimminich,
-                                    Damien Carol, Dhiren Devinder Serai, Glenn ten Cate, Jannik
-                                    Hollenbach, madchap, Mohit Sharma-2, Rejah Rehim, Riccardo Cate,
-                                    Rick M, Saeed Dehqan-1, Sam Stepanyan, Simon Bennetts, Sourav
-                                    Badami, thc202
-                                </p>
-                            </div>
-                        </div>
-                    </div>
-                    <!-- 2020 -->
-                    <div class="bg-white dark:bg-gray-800 rounded-lg shadow-md transition-all border border-gray-200 dark:border-gray-700 overflow-hidden">
-                        <div class="p-2 bg-[#e74c3c]"></div>
-                        <div class="p-6">
-                            <a href="https://summerofcode.withgoogle.com/archive/2020/organizations/owasp-foundation"
-                               target="_blank"
-                               rel="noopener noreferrer"
-                               class="text-xl font-bold text-gray-900 dark:text-gray-100 hover:text-[#e74c3c] transition-colors flex items-center mb-4">
-                                <i aria-hidden="true" class="fas fa-calendar-alt mr-2 text-[#e74c3c]"></i>
-                                2020 GSOC Archive
-                            </a>
-                            <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4">
-                                <h4 class="text-lg font-semibold text-gray-800 dark:text-gray-200 mb-2 flex items-center">
-                                    <i aria-hidden="true" class="fas fa-users mr-2 text-[#e74c3c]"></i>
-                                    Mentors
-                                </h4>
-                                <p class="text-gray-700 dark:text-gray-300 leading-relaxed">
-                                    Abe, Abraham Aranguren, Ade Yoseman Putra, Adrian Winckles, Ali
-                                    Razmjoo Qalaei, Björn Kimminich, Felipe Zipitria, Glenn ten
-                                    Cate, Jannik Hollenbach, Mohit Sharma, Rejah Rehim A A, Rejah
-                                    Rehim, Ricardo Pereira, Riccardo ten Cate, Rick M, S,
-                                    securestep9, Simon Bennetts, Soham Marik, souravbadami, spyros,
-                                    Sri Harsha G, Timo Pagel, Viyat Bhalodia
-                                </p>
-                            </div>
-                        </div>
-                    </div>
-                </div>
+            <h3 class="text-2xl font-bold text-gray-900 dark:text-gray-100">
+              For Students
+            </h3>
+          </div>
+          <ul class="space-y-4">
+            <li class="flex items-start">
+              <i
+                class="fas fa-check-circle text-[#e74c3c] mt-1 mr-3"
+                aria-hidden="true"
+              ></i>
+              <p class="text-gray-700 dark:text-gray-300">
+                Gaining exposure to real-world software development scenarios
+              </p>
+            </li>
+            <li class="flex items-start">
+              <i
+                class="fas fa-check-circle text-[#e74c3c] mt-1 mr-3"
+                aria-hidden="true"
+              ></i>
+              <p class="text-gray-700 dark:text-gray-300">
+                An opportunity for employment in areas related to their academic
+                pursuits
+              </p>
+            </li>
+            <li class="flex items-start">
+              <i
+                class="fas fa-check-circle text-[#e74c3c] mt-1 mr-3"
+                aria-hidden="true"
+              ></i>
+              <p class="text-gray-700 dark:text-gray-300">
+                Google will be offering successful student contributors a
+                stipend
+              </p>
+            </li>
+            <li class="flex items-start">
+              <i
+                class="fas fa-check-circle text-[#e74c3c] mt-1 mr-3"
+                aria-hidden="true"
+              ></i>
+              <p class="text-gray-700 dark:text-gray-300">
+                Build your professional network
+              </p>
+            </li>
+            <li class="flex items-start">
+              <i
+                class="fas fa-check-circle text-[#e74c3c] mt-1 mr-3"
+                aria-hidden="true"
+              ></i>
+              <p class="text-gray-700 dark:text-gray-300">
+                Gain valuable experience in cybersecurity
+              </p>
+            </li>
+            <li class="flex items-start">
+              <i
+                class="fas fa-check-circle text-[#e74c3c] mt-1 mr-3"
+                aria-hidden="true"
+              ></i>
+              <p class="text-gray-700 dark:text-gray-300">
+                Receive a certificate upon completion
+              </p>
+            </li>
+          </ul>
+        </div>
+        <!-- Mentor Benefits -->
+        <div
+          class="bg-white dark:bg-gray-800 rounded-xl shadow-lg transition-all duration-300 p-8 border border-gray-100 dark:border-gray-800"
+        >
+          <div class="flex items-center mb-6">
+            <div
+              class="w-12 h-12 flex items-center justify-center bg-red-100 text-[#e74c3c] rounded-full mr-4"
+            >
+              <i
+                class="fas fa-chalkboard-teacher text-xl"
+                aria-hidden="true"
+              ></i>
             </div>
-            <!-- Success Stories -->
-            <div class="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-100 dark:border-gray-800 p-8 mb-12">
-                <h2 class="text-3xl font-bold text-gray-900 dark:text-gray-100 mb-2 text-center">Success Stories</h2>
-                <div class="w-20 h-1 bg-[#e74c3c] mx-auto mb-8 rounded-full"></div>
-                <div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
-                    <!-- Shirish Jain -->
-                    <div class="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md border border-gray-100 dark:border-gray-800">
-                        <div class="flex items-center gap-4 mb-6">
-                            <div class="w-16 h-16 bg-red-100 rounded-full flex items-center justify-center">
-                                <i class="fas fa-code text-[#e74c3c] text-2xl"></i>
-                            </div>
-                            <div>
-                                <h3 class="text-2xl font-semibold">Shirish Jain</h3>
-                                <p class="text-gray-600 dark:text-gray-400">GSoC 2023</p>
-                            </div>
-                        </div>
-                        <p class="text-gray-700 dark:text-gray-300 mb-6 text-lg">
-                            Successfully implemented the Sizzle Time Tracking feature during
-                            GSoC 2023.
-                        </p>
-                        <div class="flex gap-4">
-                            <a href="https://medium.com/@shirishjain.2001/gsoc-2023-final-report-owasp-bug-logging-tool-f70d6368f9f5"
-                               class="flex-1 hover:text-white bg-[#e74c3c] text-white py-2 px-4 rounded-lg hover:bg-red-700 transition-colors text-center flex items-center justify-center gap-2">
-                                <i class="fas fa-book-open"></i>
-                                <span>Read Blog</span>
-                            </a>
-                            <a href="https://blt.owasp.org/contributors/?contributor=37"
-                               class="flex-1 border-2 border-[#e74c3c] text-[#e74c3c] py-2 px-4 rounded-lg hover:bg-[#e74c3c] hover:text-white transition-colors text-center flex items-center justify-center gap-2">
-                                <i class="fas fa-user"></i>
-                                <span>Profile</span>
-                            </a>
-                        </div>
-                    </div>
-                    <!-- Aryan Ranjan -->
-                    <div class="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md border border-gray-100 dark:border-gray-800">
-                        <div class="flex items-center gap-4 mb-6">
-                            <div class="w-16 h-16 bg-red-100 rounded-full flex items-center justify-center">
-                                <i class="fas fa-comments text-[#e74c3c] text-2xl"></i>
-                            </div>
-                            <div>
-                                <h3 class="text-2xl font-semibold">Aryan Ranjan</h3>
-                                <p class="text-gray-600 dark:text-gray-400">GSoC 2023</p>
-                            </div>
-                        </div>
-                        <p class="text-gray-700 dark:text-gray-300 mb-6 text-lg">Developed the Discussion Room feature during GSoC 2023.</p>
-                        <div class="flex gap-4">
-                            <a href="https://medium.com/@justary27/my-gsoc22-voyage-beginning-4296df5af625"
-                               class="flex-1 hover:text-white bg-[#e74c3c] text-white py-2 px-4 rounded-lg hover:bg-red-700 transition-colors text-center flex items-center justify-center gap-2">
-                                <i class="fas fa-book-open"></i>
-                                <span>Read Blog</span>
-                            </a>
-                            <a href="https://blt.owasp.org/contributors/?contributor=1"
-                               class="flex-1 border-2 border-[#e74c3c] text-[#e74c3c] py-2 px-4 rounded-lg hover:bg-[#e74c3c] hover:text-white transition-colors text-center flex items-center justify-center gap-2">
-                                <i class="fas fa-user"></i>
-                                <span>Profile</span>
-                            </a>
-                        </div>
-                    </div>
-                    <!-- Swapnil Shinde -->
-                    <div class="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md border border-gray-100 dark:border-gray-800">
-                        <div class="flex items-center gap-4 mb-6">
-                            <div class="w-16 h-16 bg-red-100 rounded-full flex items-center justify-center">
-                                <i class="fas fa-bug text-[#e74c3c] text-2xl"></i>
-                            </div>
-                            <div>
-                                <h3 class="text-2xl font-semibold">Swapnil Shinde</h3>
-                                <p class="text-gray-600 dark:text-gray-400">GSoC 2022</p>
-                            </div>
-                        </div>
-                        <p class="text-gray-700 dark:text-gray-300 mb-6 text-lg">Contributed to OWASP BLT development.</p>
-                        <div class="flex gap-4">
-                            <a href="https://gist.github.com/AtmegaBuzz/512a85827b5cc993e35c274dcbada669"
-                               class="flex-1 hover:text-white bg-[#e74c3c] text-white py-2 px-4 rounded-lg hover:bg-red-700 transition-colors text-center flex items-center justify-center gap-2">
-                                <i class="fas fa-file-alt"></i>
-                                <span>Report</span>
-                            </a>
-                            <a href="https://blt.owasp.org/contributors/?contributor=3"
-                               class="flex-1 border-2 border-[#e74c3c] text-[#e74c3c] py-2 px-4 rounded-lg hover:bg-[#e74c3c] hover:text-white transition-colors text-center flex items-center justify-center gap-2">
-                                <i class="fas fa-user"></i>
-                                <span>Profile</span>
-                            </a>
-                        </div>
-                    </div>
-                    <!-- Bishal Das -->
-                    <div class="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md border border-gray-100 dark:border-gray-800">
-                        <div class="flex items-center gap-4 mb-6">
-                            <div class="w-16 h-16 bg-red-100 rounded-full flex items-center justify-center">
-                                <i class="fas fa-graduation-cap text-[#e74c3c] text-2xl"></i>
-                            </div>
-                            <div>
-                                <h3 class="text-2xl font-semibold">Bishal Das</h3>
-                                <p class="text-gray-600 dark:text-gray-400">GSoC 2024</p>
-                            </div>
-                        </div>
-                        <p class="text-gray-700 dark:text-gray-300 mb-6 text-lg">GSoC Learning journey with OWASP BLT.</p>
-                        <div class="flex gap-4">
-                            <a href="https://bishaldas.hashnode.dev/gsoc-2024-a-summer-of-learning-coding-and-growth"
-                               class="flex-1 hover:text-white bg-[#e74c3c] text-white py-2 px-4 rounded-lg hover:bg-red-700 transition-colors text-center flex items-center justify-center gap-2">
-                                <i class="fas fa-book-open"></i>
-                                <span>Read Blog</span>
-                            </a>
-                            <a href="https://blt.owasp.org/contributors/?contributor=5"
-                               class="flex-1 border-2 border-[#e74c3c] text-[#e74c3c] py-2 px-4 rounded-lg hover:bg-[#e74c3c] hover:text-white transition-colors text-center flex items-center justify-center gap-2">
-                                <i class="fas fa-user"></i>
-                                <span>Profile</span>
-                            </a>
-                        </div>
-                    </div>
-                    <!-- Shubham Palriwala -->
-                    <div class="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md border border-gray-100 dark:border-gray-800">
-                        <div class="flex items-center gap-4 mb-6">
-                            <div class="w-16 h-16 bg-red-100 rounded-full flex items-center justify-center">
-                                <i class="fas fa-flask text-[#e74c3c] text-2xl"></i>
-                            </div>
-                            <div>
-                                <h3 class="text-2xl font-semibold">Shubham Palriwala</h3>
-                                <p class="text-gray-600 dark:text-gray-400">OWASP Juice Shop</p>
-                            </div>
-                        </div>
-                        <p class="text-gray-700 dark:text-gray-300 mb-6 text-lg">OWASP Juice Shop Journey</p>
-                        <div class="flex gap-4">
-                            <a href="https://medium.com/@shubhampalriwala/google-summer-of-code-journey-with-owasp-juice-shop-c1ca15c8e170"
-                               class="flex-1 hover:text-white bg-[#e74c3c] text-white py-2 px-4 rounded-lg hover:bg-red-700 transition-colors text-center flex items-center justify-center gap-2">
-                                <i class="fas fa-book-open"></i>
-                                <span>Read Blog</span>
-                            </a>
-                        </div>
-                    </div>
-                    <!-- Akshay Behl -->
-                    <div class="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md border border-gray-100 dark:border-gray-800">
-                        <div class="flex items-center gap-4 mb-6">
-                            <div class="w-16 h-16 bg-red-100 rounded-full flex items-center justify-center">
-                                <i class="fas fa-network-wired text-[#e74c3c] text-2xl"></i>
-                            </div>
-                            <div>
-                                <h3 class="text-2xl font-semibold">Akshay Behl</h3>
-                                <p class="text-gray-600 dark:text-gray-400">OWASP Nettacker</p>
-                            </div>
-                        </div>
-                        <p class="text-gray-700 dark:text-gray-300 mb-6 text-lg">OWASP Nettacker Experience</p>
-                        <div class="flex gap-4">
-                            <a href="https://medium.com/@akshaybehl231/diving-into-open-source-owasp-nettacker-gsoc24-e73114f37a11"
-                               class="flex-1 hover:text-white bg-[#e74c3c] text-white py-2 px-4 rounded-lg hover:bg-red-700 transition-colors text-center flex items-center justify-center gap-2">
-                                <i class="fas fa-book-open"></i>
-                                <span>Read Blog</span>
-                            </a>
-                        </div>
-                    </div>
-                    <!-- Chakshu Gupta -->
-                    <div class="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md border border-gray-100 dark:border-gray-800">
-                        <div class="flex items-center gap-4 mb-6">
-                            <div class="w-16 h-16 bg-red-100 rounded-full flex items-center justify-center">
-                                <i class="fas fa-shield-alt text-[#e74c3c] text-2xl"></i>
-                            </div>
-                            <div>
-                                <h3 class="text-2xl font-semibold">Chakshu Gupta</h3>
-                                <p class="text-gray-600 dark:text-gray-400">OWASP Honeypot Project</p>
-                            </div>
-                        </div>
-                        <p class="text-gray-700 dark:text-gray-300 mb-6 text-lg">OWASP Honeypot Project Journey</p>
-                        <div class="flex gap-4">
-                            <a href="https://medium.com/@ChGDream/my-google-summer-of-code-2020-journey-with-owasp-b772c3e67c3f"
-                               class="flex-1 hover:text-white bg-[#e74c3c] text-white py-2 px-4 rounded-lg hover:bg-red-700 transition-colors text-center flex items-center justify-center gap-2">
-                                <i class="fas fa-book-open"></i>
-                                <span>Read Blog</span>
-                            </a>
-                        </div>
-                    </div>
-                    <!-- Rishabh Keshan -->
-                    <div class="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md border border-gray-100 dark:border-gray-800">
-                        <div class="flex items-center gap-4 mb-6">
-                            <div class="w-16 h-16 bg-red-100 rounded-full flex items-center justify-center">
-                                <i class="fas fa-cube text-[#e74c3c] text-2xl"></i>
-                            </div>
-                            <div>
-                                <h3 class="text-2xl font-semibold">Rishabh Keshan</h3>
-                                <p class="text-gray-600 dark:text-gray-400">Web3 Juice Shop</p>
-                            </div>
-                        </div>
-                        <p class="text-gray-700 dark:text-gray-300 mb-6 text-lg">Web3 Journey with Juice Shop</p>
-                        <div class="flex gap-4">
-                            <a href="https://medium.com/@ChGDream/my-google-summer-of-code-2020-journey-with-owasp-b772c3e67c3f"
-                               class="flex-1 hover:text-white bg-[#e74c3c] text-white py-2 px-4 rounded-lg hover:bg-red-700 transition-colors text-center flex items-center justify-center gap-2">
-                                <i class="fas fa-book-open"></i>
-                                <span>Read Blog</span>
-                            </a>
-                        </div>
-                    </div>
-                </div>
+            <h3 class="text-2xl font-bold text-gray-900 dark:text-gray-100">
+              For Mentors
+            </h3>
+          </div>
+          <ul class="space-y-4">
+            <li class="flex items-start">
+              <i
+                class="fas fa-check-circle text-[#e74c3c] mt-1 mr-3"
+                aria-hidden="true"
+              ></i>
+              <p class="text-gray-700 dark:text-gray-300">
+                Shape the next generation of open-source developers
+              </p>
+            </li>
+            <li class="flex items-start">
+              <i
+                class="fas fa-check-circle text-[#e74c3c] mt-1 mr-3"
+                aria-hidden="true"
+              ></i>
+              <p class="text-gray-700 dark:text-gray-300">
+                Enhance project visibility and community engagement
+              </p>
+            </li>
+            <li class="flex items-start">
+              <i
+                class="fas fa-check-circle text-[#e74c3c] mt-1 mr-3"
+                aria-hidden="true"
+              ></i>
+              <p class="text-gray-700 dark:text-gray-300">
+                Develop leadership and mentoring skills
+              </p>
+            </li>
+            <li class="flex items-start">
+              <i
+                class="fas fa-check-circle text-[#e74c3c] mt-1 mr-3"
+                aria-hidden="true"
+              ></i>
+              <p class="text-gray-700 dark:text-gray-300">
+                Expand your professional network within OWASP
+              </p>
+            </li>
+            <li class="flex items-start">
+              <i
+                class="fas fa-check-circle text-[#e74c3c] mt-1 mr-3"
+                aria-hidden="true"
+              ></i>
+              <p class="text-gray-700 dark:text-gray-300">
+                Recognition in the global security community
+              </p>
+            </li>
+            <li class="flex items-start">
+              <i
+                class="fas fa-check-circle text-[#e74c3c] mt-1 mr-3"
+                aria-hidden="true"
+              ></i>
+              <p class="text-gray-700 dark:text-gray-300">
+                Contribute to the growth of open-source security projects
+              </p>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+    <!-- OWASP Partnership Card -->
+    <div
+      class="bg-white rounded-xl shadow-lg transition-all duration-300 p-8 mb-20 border border-gray-100"
+    >
+      <h2 class="text-3xl font-bold text-gray-900 mb-6">
+        OWASP BLT & GSOC Partnership
+      </h2>
+      <div class="space-y-6 text-gray-700">
+        <p class="leading-relaxed">
+          OWASP is an open community dedicated to enabling organizations to
+          conceive, develop, acquire, operate, and maintain applications that
+          can be trusted. OWASP has been an active participant in the Google
+          Summer of Code program, providing students with the opportunity to
+          contribute to various OWASP projects.
+        </p>
+        <p class="leading-relaxed">
+          OWASP BLT (Bug Logging Tool) has been participating in the Google
+          Summer of Code program for the past 5 consecutive years, from 2020 to
+          2024. OWASP BLT is an open-source platform dedicated to making the
+          internet safer through community-driven bug reporting and
+          collaboration.
+        </p>
+        <p class="leading-relaxed">
+          All students currently enrolled in an accredited institution are
+          welcome to participate in the Google Summer of Code program, hopefully
+          along with the OWASP Foundation.
+        </p>
+      </div>
+    </div>
+    <!-- Project Ideas Section -->
+    <div class="mb-20">
+      <h2
+        class="text-3xl font-bold text-center text-gray-900 dark:text-gray-100 mb-2"
+      >
+        Project Ideas
+      </h2>
+      <div class="w-20 h-1 bg-[#e74c3c] mx-auto mb-12 rounded-full"></div>
+      <!-- OWASP BLT Projects (Highlighted) -->
+      <div class="mb-12">
+        <a
+          href="https://github.com/OWASP-BLT/BLT/milestones"
+          rel="noopener noreferrer"
+          target="_blank"
+          class="block p-8 bg-gradient-to-br from-red-50 to-red-100 border-2 border-red-200 rounded-xl transition-all"
+        >
+          <div class="flex flex-col md:flex-row items-center justify-between">
+            <div class="mb-6 md:mb-0">
+              <h3 class="text-2xl font-bold text-red-700 mb-3">
+                OWASP BLT Project Ideas
+              </h3>
+              <p class="text-red-600 text-lg mb-4">
+                Explore exciting project opportunities with OWASP Bug Logging
+                Tool
+              </p>
+              <span
+                class="inline-block px-4 py-2 bg-white dark:bg-gray-800 text-[#e74c3c] rounded-full font-medium"
+                >Featured Projects</span
+              >
             </div>
-            <!-- GSoC 2026 Students Section -->
-            <div class="mb-20">
-                <h2 class="text-3xl font-bold text-center text-gray-900 dark:text-gray-100 mb-2">2026 Contributors</h2>
-                <div class="w-20 h-1 bg-[#e74c3c] mx-auto mb-12 rounded-full"></div>
-                <div class="flex items-start space-x-6 mb-8">
-                    <div class="bg-red-100 rounded-full p-3 flex-shrink-0">
-                        <i class="fas fa-star text-[#e74c3c] text-xl"></i>
-                    </div>
-                    <div>
-                        <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100 mb-2">Lead Mentor</h3>
-                        <p class="text-lg text-gray-800 dark:text-gray-200 font-medium mb-1">Donnie Brown (All years)</p>
-                    </div>
-                </div>
-                <div class="space-y-8">
-                    <!-- Md Kaif Ansari -->
-                    <div class="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-100 dark:border-gray-800 p-8">
-                        <div class="flex items-center gap-6 mb-6">
-                            <div class="w-20 h-20 bg-red-100 rounded-full flex items-center justify-center">
-                                <i class="fab fa-github text-[#e74c3c] text-3xl"></i>
-                            </div>
-                            <div class="flex-1">
-                                <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100">Md Kaif Ansari</h3>
-                                <p class="text-lg text-gray-600 dark:text-gray-400 mb-2">2026 Contributor</p>
-                                <div class="flex gap-4">
-                                    <a href="https://github.com/mdkaifansari04"
-                                       target="_blank"
-                                       rel="noopener noreferrer"
-                                       class="inline-flex items-center px-4 py-2 bg-[#e74c3c] text-white rounded-lg hover:bg-red-700 transition-colors">
-                                        <i class="fab fa-github mr-2"></i>
-                                        GitHub Profile
-                                    </a>
-                                    <a href="https://mdkaifansari04.github.io/MY-GSOC-TOOL/"
-                                       target="_blank"
-                                       rel="noopener noreferrer"
-                                       class="inline-flex items-center px-4 py-2 border-2 border-[#e74c3c] text-[#e74c3c] rounded-lg hover:bg-[#e74c3c] hover:text-white transition-colors">
-                                        <i class="fas fa-tools mr-2"></i>
-                                        GSoC-Tool
-                                    </a>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-                            <!-- Rinkit Adhana -->
-                            <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4 border border-gray-200 dark:border-gray-700">
-                                <div class="flex items-center gap-3 mb-3">
-                                    <div class="w-10 h-10 bg-red-100 rounded-full flex items-center justify-center">
-                                        <i class="fas fa-code text-[#e74c3c] text-sm"></i>
-                                    </div>
-                                    <div>
-                                        <h4 class="text-lg font-bold text-gray-900 dark:text-gray-100">Rinkit Adhana</h4>
-                                        <p class="text-sm text-gray-600 dark:text-gray-400">Full Stack Development</p>
-                                    </div>
-                                </div>
-                                <div class="mentor-description-container">
-                                    <p class="text-gray-600 dark:text-gray-400 text-base leading-relaxed mentor-description-text">
-                                        As a full stack engineer and active BLT contributor, I bring
-                                        hands-on experience from both sides of the development
-                                        process. Having participated in GSoC 2025, I understand the
-                                        challenges new contributors face and can guide you through
-                                        your open source journey. I specialize in helping developers
-                                        build scalable web applications, navigate complex codebases,
-                                        and contribute effectively to real-world projects. My goal is
-                                        to share practical knowledge and help you grow as a developer
-                                        while making meaningful contributions to BLT.
-                                    </p>
-                                </div>
-                            </div>
-                            <!-- Raj Gupta -->
-                            <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4 border border-gray-200 dark:border-gray-700">
-                                <div class="flex items-center gap-3 mb-3">
-                                    <div class="w-10 h-10 bg-red-100 rounded-full flex items-center justify-center">
-                                        <i class="fas fa-code text-[#e74c3c] text-sm"></i>
-                                    </div>
-                                    <div>
-                                        <h4 class="text-lg font-bold text-gray-900 dark:text-gray-100">Raj Gupta</h4>
-                                        <p class="text-sm text-gray-600 dark:text-gray-400">Full Stack Development mentor</p>
-                                    </div>
-                                </div>
-                                <div class="mentor-description-container">
-                                    <p class="text-gray-600 dark:text-gray-400 text-base leading-relaxed mentor-description-text">
-                                        I’m a full stack developer with prior Google Summer of Code (GSoC)
-                                        experience and a strong passion for open source. Having worked as a
-                                        contributor, I understand the challenges of getting started - from
-                                        reading large codebases to making meaningful pull requests. As a
-                                        mentor, I enjoy guiding contributors through best practices, code
-                                        reviews, and real-world problem solving. I continue to actively
-                                        contribute to open source because I believe collaboration and
-                                        knowledge sharing are what truly drive impactful software.
-                                    </p>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    <!-- Preetham -->
-                    <div class="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-100 dark:border-gray-800 p-8">
-                        <div class="flex items-center gap-6 mb-6">
-                            <div class="w-20 h-20 bg-red-100 rounded-full flex items-center justify-center">
-                                <i class="fab fa-github text-[#e74c3c] text-3xl"></i>
-                            </div>
-                            <div class="flex-1">
-                                <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100">Preetham</h3>
-                                <p class="text-lg text-gray-600 dark:text-gray-400 mb-2">2026 Contributor</p>
-                                <div class="flex gap-4">
-                                    <a href="https://github.com/Pritz395"
-                                       target="_blank"
-                                       rel="noopener noreferrer"
-                                       class="inline-flex items-center px-4 py-2 bg-[#e74c3c] text-white rounded-lg hover:bg-red-700 transition-colors">
-                                        <i class="fab fa-github mr-2"></i>
-                                        GitHub Profile
-                                    </a>
-                                    <a href="https://Pritz395.github.io/MY-GSOC-TOOL/"
-                                       target="_blank"
-                                       rel="noopener noreferrer"
-                                       class="inline-flex items-center px-4 py-2 border-2 border-[#e74c3c] text-[#e74c3c] rounded-lg hover:bg-[#e74c3c] hover:text-white transition-colors">
-                                        <i class="fas fa-tools mr-2"></i>
-                                        GSoC-Tool
-                                    </a>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-                            <!-- Vinamra Vaswani -->
-                            <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4 border border-gray-200 dark:border-gray-700">
-                                <div class="flex items-center gap-3 mb-3">
-                                    <div class="w-10 h-10 bg-red-100 rounded-full flex items-center justify-center">
-                                        <i class="fas fa-code text-[#e74c3c] text-sm"></i>
-                                    </div>
-                                    <div>
-                                        <h4 class="text-lg font-bold text-gray-900 dark:text-gray-100">Vinamra Vaswani</h4>
-                                        <p class="text-sm text-gray-600 dark:text-gray-400">Backend Systems</p>
-                                    </div>
-                                </div>
-                                <div class="mentor-description-container">
-                                    <p class="text-gray-600 dark:text-gray-400 text-base leading-relaxed mentor-description-text">
-                                        I am a software engineer experienced in building
-                                        production-grade backend systems using Python, FastAPI, and
-                                        MongoDB, with a focus on clean architecture and real-world
-                                        problem solving. Through open-source style projects and
-                                        mentorship programs, I have guided juniors in working with
-                                        real codebases, collaborative workflows, and maintainable
-                                        engineering practices. As a GSoC mentor, my goal is to help
-                                        students move from tutorials to confident real-world
-                                        contributors, while giving back to open source by supporting
-                                        their technical and professional growth in a learning-first
-                                        environment.
-                                    </p>
-                                </div>
-                            </div>
-                            <!-- Carla Voorhees -->
-                            <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4 border border-gray-200 dark:border-gray-700">
-                                <div class="flex items-center gap-3 mb-3">
-                                    <div class="w-10 h-10 bg-red-100 rounded-full flex items-center justify-center">
-                                        <i class="fas fa-code text-[#e74c3c] text-sm"></i>
-                                    </div>
-                                    <div>
-                                        <h4 class="text-lg font-bold text-gray-900 dark:text-gray-100">Carla Voorhees</h4>
-                                        <p class="text-sm text-gray-600 dark:text-gray-400">Technical Product Manager</p>
-                                    </div>
-                                </div>
-                                <div class="mentor-description-container">
-                                    <p class="text-gray-600 dark:text-gray-400 text-base leading-relaxed mentor-description-text">
-                                        I am a technical product manager with a background in cybersecurity
-                                        and data management. I have experience mentoring students,
-                                        helping them navigate complex requirements and understand best practices.
-                                        I focus on guiding students through the product development lifecycle,
-                                        from ideation to deployment, while fostering a collaborative and
-                                        inclusive learning environment. I help them to understand how to take
-                                        requirements and designs and turn them into working code. My goal is to empower
-                                        students to become confident contributors to open source communities.
-                                    </p>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    <!-- Siddharth Bansal -->
-                    <div class="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-100 dark:border-gray-800 p-8">
-                        <div class="flex items-center gap-6 mb-6">
-                            <div class="w-20 h-20 bg-red-100 rounded-full flex items-center justify-center">
-                                <i class="fab fa-github text-[#e74c3c] text-3xl"></i>
-                            </div>
-                            <div class="flex-1">
-                                <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100">Siddharth Bansal</h3>
-                                <p class="text-lg text-gray-600 dark:text-gray-400 mb-2">2026 Contributor</p>
-                                <div class="flex gap-4">
-                                    <a href="https://github.com/sidd190"
-                                       target="_blank"
-                                       rel="noopener noreferrer"
-                                       class="inline-flex items-center px-4 py-2 bg-[#e74c3c] text-white rounded-lg hover:bg-red-700 transition-colors">
-                                        <i class="fab fa-github mr-2"></i>
-                                        GitHub Profile
-                                    </a>
-                                    <a href="https://sidd190.github.io/MY-GSOC-TOOL/"
-                                       target="_blank"
-                                       rel="noopener noreferrer"
-                                       class="inline-flex items-center px-4 py-2 border-2 border-[#e74c3c] text-[#e74c3c] rounded-lg hover:bg-[#e74c3c] hover:text-white transition-colors">
-                                        <i class="fas fa-tools mr-2"></i>
-                                        GSoC-Tool
-                                    </a>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-                            <!-- Jigyasu Rajput -->
-                            <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4 border border-gray-200 dark:border-gray-700">
-                                <div class="flex items-center gap-3 mb-3">
-                                    <div class="w-10 h-10 bg-red-100 rounded-full flex items-center justify-center">
-                                        <i class="fas fa-code text-[#e74c3c] text-sm"></i>
-                                    </div>
-                                    <div>
-                                        <h4 class="text-lg font-bold text-gray-900 dark:text-gray-100">Jigyasu Rajput</h4>
-                                        <p class="text-sm text-gray-600 dark:text-gray-400">Full Stack Development</p>
-                                    </div>
-                                </div>
-                                <div class="mentor-description-container">
-                                    <p class="text-gray-600 dark:text-gray-400 text-base leading-relaxed mentor-description-text">
-                                        I'm a full-stack developer with prior GSoC experience and a
-                                        deep love for open source. Having been a contributor myself, I
-                                        know how overwhelming it can feel at the start — from
-                                        understanding huge codebases to shipping your first meaningful
-                                        PR. As a mentor, I focus on helping people build confidence
-                                        through clean practices, thoughtful code reviews, and
-                                        real-world problem solving. I stay active in open source
-                                        because collaboration and shared learning are what actually
-                                        move great software forward.
-                                    </p>
-                                </div>
-                            </div>
-                            <!-- Rishab Kumar Jha -->
-                            <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4 border border-gray-200 dark:border-gray-700">
-                                <div class="flex items-center gap-3 mb-3">
-                                    <div class="w-10 h-10 bg-red-100 rounded-full flex items-center justify-center">
-                                        <i class="fas fa-code text-[#e74c3c] text-sm"></i>
-                                    </div>
-                                    <div>
-                                        <h4 class="text-lg font-bold text-gray-900 dark:text-gray-100">Rishab Kumar Jha</h4>
-                                        <p class="text-sm text-gray-600 dark:text-gray-400">Full Stack/Blockchain</p>
-                                    </div>
-                                </div>
-                                <div class="mentor-description-container">
-                                    <p class="text-gray-600 dark:text-gray-400 text-base leading-relaxed mentor-description-text">
-                                        I'm a software developer interested in distributed systems,
-                                        web3, cloud native technologies & deep-tech. As a past GSoC
-                                        and LFX alumnus myself, I understand the pain points of new
-                                        contributors. Happy to mentor and help mentees navigate
-                                        open-source effectively.
-                                    </p>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    <!-- Manahil Afzal -->
-                  <div class="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-100 dark:border-gray-800 p-8">
-                        <div class="flex items-center gap-6 mb-6">
-                            <div class="w-20 h-20 bg-red-100 rounded-full flex items-center justify-center">
-                                <i class="fab fa-github text-[#e74c3c] text-3xl"></i>
-                            </div>
-                            <div class="flex-1">
-                                <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100">Manahil Afzal</h3>
-                                <p class="text-lg text-gray-600 dark:text-gray-400 mb-2">MERN Stack Engineer / 2026 Contributor</p>
-                                <p class="text-gray-600 dark:text-gray-400 mb-4 text-sm">
-                                    Passionate about building meaningful web applications. Exploring cloud, AI, and open source programs like GSoC & Outreachy. Interested in contributing to organizations like OWASP Foundation & Apache.
-                                </p>
-                                <div class="flex gap-4">
-                                    <a href="https://github.com/Manahil-Afzal"
-                                       target="_blank"
-                                       rel="noopener noreferrer"
-                                       class="inline-flex items-center px-4 py-2 bg-[#e74c3c] text-white rounded-lg hover:bg-red-700 transition-colors">
-                                        <i class="fab fa-github mr-2"></i>
-                                        GitHub Profile
-                                    </a>
-                                    <a href="https://manahil-afzal.github.io/MY-GSOC-TOOL/"
-                                       target="_blank"
-                                       rel="noopener noreferrer"
-                                       class="inline-flex items-center px-4 py-2 border-2 border-[#e74c3c] text-[#e74c3c] rounded-lg hover:bg-[#e74c3c] hover:text-white transition-colors">
-                                        <i class="fas fa-tools mr-2"></i>
-                                        GSoC-Tool
-                                    </a>
-                                </div>
-                            </div>
-                        </div>
-                      </div>
-                    <!-- Sakshee Suman -->
-                    <div class="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-100 dark:border-gray-800 p-8">
-                        <div class="flex items-center gap-6 mb-6">
-                            <div class="w-20 h-20 bg-red-100 rounded-full flex items-center justify-center">
-                                <i class="fab fa-github text-[#e74c3c] text-3xl"></i>
-                            </div>
-                            <div class="flex-1">
-                                <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100">Sakshee Suman</h3>
-                                <p class="text-lg text-gray-600 dark:text-gray-400 mb-2">2026 Contributor</p>
-                                <div class="flex gap-4">
-                                    <a href="https://github.com/e-esakman"
-                                       target="_blank"
-                                       rel="noopener noreferrer"
-                                       class="inline-flex items-center px-4 py-2 bg-[#e74c3c] text-white rounded-lg hover:bg-red-700 transition-colors">
-                                        <i class="fab fa-github mr-2"></i>
-                                        GitHub Profile
-                                    </a>
-                                    <a href="https://e-esakman.github.io/MY-GSOC-TOOL/"
-                                       target="_blank"
-                                       rel="noopener noreferrer"
-                                       class="inline-flex items-center px-4 py-2 border-2 border-[#e74c3c] text-[#e74c3c] rounded-lg hover:bg-[#e74c3c] hover:text-white transition-colors">
-                                        <i class="fas fa-tools mr-2"></i>
-                                        GSoC-Tool
-                                    </a>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    <!-- Arnav Kirti -->
-                    <div class="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-100 dark:border-gray-800 p-8">
-                        <div class="flex items-center gap-6 mb-6">
-                            <div class="w-20 h-20 bg-red-100 rounded-full flex items-center justify-center">
-                                <i class="fab fa-github text-[#e74c3c] text-3xl"></i>
-                            </div>
-                            <div class="flex-1">
-                                <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100">Arnav Kirti</h3>
-                                <p class="text-lg text-gray-600 dark:text-gray-400 mb-2">2026 Contributor</p>
-                                <div class="flex gap-4">
-                                    <a href="https://github.com/arnavkirti"
-                                       target="_blank"
-                                       rel="noopener noreferrer"
-                                       class="inline-flex items-center px-4 py-2 bg-[#e74c3c] text-white rounded-lg hover:bg-red-700 transition-colors">
-                                        <i class="fab fa-github mr-2"></i>
-                                        GitHub Profile
-                                    </a>
-                                    <a href="https://arnavkirti.github.io/MY-GSOC-TOOL/"
-                                       target="_blank"
-                                       rel="noopener noreferrer"
-                                       class="inline-flex items-center px-4 py-2 border-2 border-[#e74c3c] text-[#e74c3c] rounded-lg hover:bg-[#e74c3c] hover:text-white transition-colors">
-                                        <i class="fas fa-tools mr-2"></i>
-                                        GSoC-Tool
-                                    </a>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    <!-- Savio D'souza -->
-                    <div class="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-100 dark:border-gray-800 p-8">
-                        <div class="flex items-center gap-6 mb-6">
-                            <div class="w-20 h-20 bg-red-100 rounded-full flex items-center justify-center">
-                                <i class="fab fa-github text-[#e74c3c] text-3xl"></i>
-                            </div>
-                            <div class="flex-1">
-                                <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100">Savio D'souza</h3>
-                                <p class="text-lg text-gray-600 dark:text-gray-400 mb-2">2026 Contributor</p>
-                                <div class="flex gap-4">
-                                    <a href="https://github.com/S3DFX-CYBER"
-                                       target="_blank"
-                                       rel="noopener noreferrer"
-                                       class="inline-flex items-center px-4 py-2 bg-[#e74c3c] text-white rounded-lg hover:bg-red-700 transition-colors">
-                                        <i class="fab fa-github mr-2"></i>
-                                        GitHub Profile
-                                    </a>
-                                    <a href="https://S3DFX-CYBER.github.io/MY-GSOC-TOOL/"
-                                       target="_blank"
-                                       rel="noopener noreferrer"
-                                       class="inline-flex items-center px-4 py-2 border-2 border-[#e74c3c] text-[#e74c3c] rounded-lg hover:bg-[#e74c3c] hover:text-white transition-colors">
-                                        <i class="fas fa-tools mr-2"></i>
-                                        GSoC-Tool
-                                    </a>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    <!-- Jayant Malvi -->
-                    <div class="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-100 dark:border-gray-800 p-8">
-                        <div class="flex items-center gap-6 mb-6">
-                            <div class="w-20 h-20 bg-red-100 rounded-full flex items-center justify-center">
-                                <i class="fab fa-github text-[#e74c3c] text-3xl"></i>
-                            </div>
-                            <div class="flex-1">
-                                <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100">Jayant Malvi</h3>
-                                <p class="text-lg text-gray-600 dark:text-gray-400 mb-2">2026 Contributor</p>
-                                <div class="flex gap-4">
-                                    <a href="https://github.com/Jayant2908"
-                                       target="_blank"
-                                       rel="noopener noreferrer"
-                                       class="inline-flex items-center px-4 py-2 bg-[#e74c3c] text-white rounded-lg hover:bg-red-700 transition-colors">
-                                        <i class="fab fa-github mr-2"></i>
-                                        GitHub Profile
-                                    </a>
-                                    <a href="https://Jayant2908.github.io/MY-GSOC-TOOL/"
-                                       target="_blank"
-                                       rel="noopener noreferrer"
-                                       class="inline-flex items-center px-4 py-2 border-2 border-[#e74c3c] text-[#e74c3c] rounded-lg hover:bg-[#e74c3c] hover:text-white transition-colors">
-                                        <i class="fas fa-tools mr-2"></i>
-                                        GSoC-Tool
-                                    </a>
-                                </div>
-                            </div>
-                        </div>
-                        <!-- Mentors grid -->
-                        <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-                            <!-- Manikandan Chandran -->
-                            <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4 border border-gray-200 dark:border-gray-700">
-                                <div class="flex items-center gap-3 mb-3">
-                                    <div class="w-10 h-10 bg-red-100 rounded-full flex items-center justify-center">
-                                        <i class="fas fa-code text-[#e74c3c] text-sm"></i>
-                                    </div>
-                                    <div>
-                                        <h4 class="text-lg font-bold text-gray-900 dark:text-gray-100">Manikandan Chandran</h4>
-                                        <p class="text-sm text-gray-600 dark:text-gray-400">React/OAuth/REST API</p>
-                                    </div>
-                                </div>
-                                <div class="mentor-description-container">
-                                    <p class="text-gray-600 dark:text-gray-400 text-base leading-relaxed mentor-description-text">
-                                        Mentors teams on building secure React apps with real-world OAuth flows and robust REST APIs.
-                                    </p>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- Available Mentors Section -->
-                <div class="mt-16 bg-gray-50 dark:bg-gray-900 rounded-xl p-8 border border-gray-200 dark:border-gray-700">
-                    <h3 class="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-6 text-center">
-                        Available Mentors for Future Students
-                    </h3>
-                    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-                        <!-- Manikandan Chandran -->
-                        <div class="bg-white dark:bg-gray-800 rounded-lg p-6 border border-gray-200 dark:border-gray-700">
-                            <div class="flex items-center gap-3 mb-3">
-                                <div class="w-12 h-12 bg-red-100 rounded-full flex items-center justify-center">
-                                    <i class="fas fa-chalkboard-teacher text-[#e74c3c] text-lg"></i>
-                                </div>
-                                <div>
-                                    <h4 class="text-lg font-bold text-gray-900 dark:text-gray-100">Manikandan Chandran</h4>
-                                    <p class="text-sm text-gray-600 dark:text-gray-400">React/OAuth/REST API</p>
-                                </div>
-                            </div>
-                            <p class="text-gray-600 dark:text-gray-400 text-sm">
-                                Mentors teams on building secure React apps with real-world OAuth
-                                flows and robust REST APIs.
-                            </p>
-                        </div>
-                        <!-- Ahmed ElSheikh -->
-                        <div class="bg-white dark:bg-gray-800 rounded-lg p-6 border border-gray-200 dark:border-gray-700">
-                            <div class="flex items-center gap-3 mb-3">
-                                <div class="w-12 h-12 bg-red-100 rounded-full flex items-center justify-center">
-                                    <i class="fas fa-chalkboard-teacher text-[#e74c3c] text-lg"></i>
-                                </div>
-                                <div>
-                                    <h4 class="text-lg font-bold text-gray-900 dark:text-gray-100">Ahmed ElSheikh</h4>
-                                    <p class="text-sm text-gray-600 dark:text-gray-400">React/OAuth/REST API</p>
-                                </div>
-                            </div>
-                            <p class="text-gray-600 dark:text-gray-400 text-sm">
-                                Cybersecurity analyst and AI security engineer specializing in
-                                secure system design.
-                            </p>
-                        </div>
-                    </div>
-                </div>
+            <div class="text-center">
+              <div
+                class="w-24 h-24 flex items-center justify-center bg-white dark:bg-gray-800 rounded-full mb-4 shadow-md mx-auto"
+              >
+                <i class="fa-solid fa-lightbulb text-[#e74c3c] text-4xl"></i>
+              </div>
+              <span class="inline-flex items-center text-[#e74c3c] font-medium">
+                Browse Now <i class="fa-solid fa-arrow-right ml-2"></i>
+              </span>
             </div>
-            <!-- Past Mentors Section -->
-            <div class="bg-white dark:bg-gray-800 rounded-xl shadow-lg transition-all duration-300 p-8 mb-20 border border-gray-100 dark:border-gray-800">
-                <h2 class="text-3xl font-bold text-gray-900 dark:text-gray-100 text-center mb-2">Past GSoC Mentors</h2>
-                <div class="w-20 h-1 bg-[#e74c3c] mx-auto mb-8 rounded-full"></div>
-                <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
-                    <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-6 border border-gray-200 dark:border-gray-700">
-                        <h4 class="text-lg font-bold text-gray-900 dark:text-gray-100 mb-3 flex items-center">
-                            <i aria-hidden="true" class="fas fa-calendar-alt text-[#e74c3c] mr-2"></i>2025
-                        </h4>
-                        <ul class="space-y-2 text-gray-700 dark:text-gray-300">
-                            <li class="flex items-start">
-                                <i class="fas fa-user-tie text-[#e74c3c] mt-1 mr-2"></i>
-                                <span>Rahul Negi
-                                    <span class="text-gray-500 dark:text-gray-500">(Python/Django Mentor)</span></span>
-                                </li>
-                                <li class="flex items-start">
-                                    <i class="fas fa-user-tie text-[#e74c3c] mt-1 mr-2"></i>
-                                    <span>Bishal Das
-                                        <span class="text-gray-500 dark:text-gray-500">(Django & UI/UX Mentor)</span></span>
-                                    </li>
-                                    <li class="flex items-start">
-                                        <i class="fas fa-user-tie text-[#e74c3c] mt-1 mr-2"></i>
-                                        <span>Sudhir Palavalasa
-                                            <span class="text-gray-500 dark:text-gray-500">(Backend and OAuth mentor)</span></span>
-                                        </li>
-                                    </ul>
-                                </div>
-                                <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-6 border border-gray-200 dark:border-gray-700">
-                                    <h4 class="text-lg font-bold text-gray-900 dark:text-gray-100 mb-3 flex items-center">
-                                        <i aria-hidden="true" class="fas fa-calendar-alt text-[#e74c3c] mr-2"></i>2024
-                                    </h4>
-                                    <ul class="space-y-2 text-gray-700 dark:text-gray-300">
-                                        <li class="flex items-start">
-                                            <i class="fas fa-user-tie text-[#e74c3c] mt-1 mr-2"></i>
-                                            <span>Swapnil Shinde
-                                                <span class="text-gray-500 dark:text-gray-500">(Django and blockchain mentor)</span></span>
-                                            </li>
-                                            <li class="flex items-start">
-                                                <i class="fas fa-user-tie text-[#e74c3c] mt-1 mr-2"></i>
-                                                <span>Arkadii Yakovets
-                                                    <span class="text-gray-500 dark:text-gray-500">(Python/Django mentor)</span></span>
-                                                </li>
-                                            </ul>
-                                        </div>
-                                        <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-6 border border-gray-200 dark:border-gray-700">
-                                            <h4 class="text-lg font-bold text-gray-900 dark:text-gray-100 mb-3 flex items-center">
-                                                <i aria-hidden="true" class="fas fa-calendar-alt text-[#e74c3c] mr-2"></i>2023
-                                            </h4>
-                                            <ul class="space-y-2 text-gray-700 dark:text-gray-300">
-                                                <li class="flex items-start">
-                                                    <i class="fas fa-user-tie text-[#e74c3c] mt-1 mr-2"></i>
-                                                    <span>Aryan Ranjan
-                                                        <span class="text-gray-500 dark:text-gray-500">(Flutter and Django Mentor)</span></span>
-                                                    </li>
-                                                </ul>
-                                            </div>
-                                            <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-6 border border-gray-200 dark:border-gray-700">
-                                                <h4 class="text-lg font-bold text-gray-900 dark:text-gray-100 mb-3 flex items-center">
-                                                    <i aria-hidden="true" class="fas fa-calendar-alt text-[#e74c3c] mr-2"></i>2022
-                                                </h4>
-                                                <ul class="space-y-2 text-gray-700 dark:text-gray-300">
-                                                    <li class="flex items-start">
-                                                        <i class="fas fa-user-tie text-[#e74c3c] mt-1 mr-2"></i>
-                                                        <span>Sourav Badami
-                                                            <span class="text-gray-500 dark:text-gray-500">(Django Mentor)</span></span>
-                                                        </li>
-                                                        <li class="flex items-start">
-                                                            <i class="fas fa-user-tie text-[#e74c3c] mt-1 mr-2"></i>
-                                                            <span>Rahul Badami
-                                                                <span class="text-gray-500 dark:text-gray-500">(Payments Mentor)</span></span>
-                                                            </li>
-                                                            <li class="flex items-start">
-                                                                <i class="fas fa-user-tie text-[#e74c3c] mt-1 mr-2"></i>
-                                                                <span>Ankit Choudhary
-                                                                    <span class="text-gray-500 dark:text-gray-500">(Flutter Mentor)</span></span>
-                                                                </li>
-                                                                <li class="flex items-start">
-                                                                    <i class="fas fa-user-tie text-[#e74c3c] mt-1 mr-2"></i>
-                                                                    <span>Sparsh Agrawal
-                                                                        <span class="text-gray-500 dark:text-gray-500">(Flutter Mentor)</span></span>
-                                                                    </li>
-                                                                </ul>
-                                                            </div>
-                                                            <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-6 border border-gray-200 dark:border-gray-700">
-                                                                <h4 class="text-lg font-bold text-gray-900 dark:text-gray-100 mb-3 flex items-center">
-                                                                    <i aria-hidden="true" class="fas fa-calendar-alt text-[#e74c3c] mr-2"></i>2020-2021
-                                                                </h4>
-                                                                <ul class="space-y-2 text-gray-700 dark:text-gray-300">
-                                                                    <li class="flex items-start">
-                                                                        <i class="fas fa-user-tie text-[#e74c3c] mt-1 mr-2"></i>
-                                                                        <span>Sourav Badami
-                                                                            <span class="text-gray-500 dark:text-gray-500">(Django Mentor)</span></span>
-                                                                        </li>
-                                                                    </ul>
-                                                                </div>
-                                                            </div>
-                                                        </div>
-                                                    </div>
-                                                </div>
-                                            {% endblock content %}
+          </div>
+        </a>
+      </div>
+      <!-- Past Ideas Grid -->
+      <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <a
+          href="https://owasp.org/www-community/initiatives/gsoc/gsoc2025ideas"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="group block p-5 bg-white dark:bg-gray-800 shadow-md rounded-lg border border-gray-100 dark:border-gray-800 transition-all"
+        >
+          <div class="flex items-center">
+            <span
+              class="font-semibold text-gray-900 dark:text-gray-100 group-hover:text-[#e74c3c] transition-colors"
+              >GSOC Project Ideas 2025</span
+            >
+            <i
+              class="fa-solid fa-link ml-auto text-gray-400 dark:text-gray-600 group-hover:text-[#e74c3c]"
+            ></i>
+          </div>
+        </a>
+        <a
+          href="https://owasp.org/www-community/initiatives/gsoc/gsoc2024ideas"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="group block p-5 bg-white dark:bg-gray-800 shadow-md rounded-lg border border-gray-100 dark:border-gray-800 transition-all"
+        >
+          <div class="flex items-center">
+            <span
+              class="font-semibold text-gray-900 dark:text-gray-100 group-hover:text-[#e74c3c] transition-colors"
+              >GSOC Project Ideas 2024</span
+            >
+            <i
+              class="fa-solid fa-link ml-auto text-gray-400 dark:text-gray-600 group-hover:text-[#e74c3c]"
+            ></i>
+          </div>
+        </a>
+        <a
+          href="https://owasp.org/www-community/initiatives/gsoc/gsoc2023ideas"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="group block p-5 bg-white dark:bg-gray-800 shadow-md rounded-lg border border-gray-100 dark:border-gray-800 transition-all"
+        >
+          <div class="flex items-center">
+            <span
+              class="font-semibold text-gray-900 dark:text-gray-100 group-hover:text-[#e74c3c] transition-colors"
+              >GSOC Project Ideas 2023</span
+            >
+            <i
+              class="fa-solid fa-link ml-auto text-gray-400 dark:text-gray-600 group-hover:text-[#e74c3c]"
+            ></i>
+          </div>
+        </a>
+        <a
+          href="https://owasp.org/www-community/initiatives/gsoc/gsoc2022ideas"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="group block p-5 bg-white dark:bg-gray-800 shadow-md rounded-lg border border-gray-100 dark:border-gray-800 transition-all"
+        >
+          <div class="flex items-center">
+            <span
+              class="font-semibold text-gray-900 dark:text-gray-100 group-hover:text-[#e74c3c] transition-colors"
+              >GSOC Project Ideas 2022</span
+            >
+            <i
+              class="fa-solid fa-link ml-auto text-gray-400 dark:text-gray-600 group-hover:text-[#e74c3c]"
+            ></i>
+          </div>
+        </a>
+        <a
+          href="https://owasp.org/www-community/initiatives/gsoc/gsoc2021ideas"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="group block p-5 bg-white dark:bg-gray-800 shadow-md rounded-lg border border-gray-100 dark:border-gray-800 transition-all"
+        >
+          <div class="flex items-center">
+            <span
+              class="font-semibold text-gray-900 dark:text-gray-100 group-hover:text-[#e74c3c] transition-colors"
+              >GSOC Project Ideas 2021</span
+            >
+            <i
+              class="fa-solid fa-link ml-auto text-gray-400 dark:text-gray-600 group-hover:text-[#e74c3c]"
+            ></i>
+          </div>
+        </a>
+        <a
+          href="https://owasp.org/www-community/initiatives/gsoc/gsoc2020ideas"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="group block p-5 bg-white dark:bg-gray-800 shadow-md rounded-lg border border-gray-100 dark:border-gray-800 transition-all"
+        >
+          <div class="flex items-center">
+            <span
+              class="font-semibold text-gray-900 dark:text-gray-100 group-hover:text-[#e74c3c] transition-colors"
+              >GSOC Project Ideas 2020</span
+            >
+            <i
+              class="fa-solid fa-link ml-auto text-gray-400 dark:text-gray-600 group-hover:text-[#e74c3c]"
+            ></i>
+          </div>
+        </a>
+        <a
+          href="https://owasp.org/www-community/initiatives/gsoc/gsoc2019ideas"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="group block p-5 bg-white dark:bg-gray-800 shadow-md rounded-lg border border-gray-100 dark:border-gray-800 transition-all"
+        >
+          <div class="flex items-center">
+            <span
+              class="font-semibold text-gray-900 dark:text-gray-100 group-hover:text-[#e74c3c] transition-colors"
+              >GSOC Project Ideas 2019</span
+            >
+            <i
+              class="fa-solid fa-link ml-auto text-gray-400 dark:text-gray-600 group-hover:text-[#e74c3c]"
+            ></i>
+          </div>
+        </a>
+        <a
+          href="https://owasp.org/www-community/initiatives/gsoc/gsoc2018ideas"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="group block p-5 bg-white dark:bg-gray-800 shadow-md rounded-lg border border-gray-100 dark:border-gray-800 transition-all"
+        >
+          <div class="flex items-center">
+            <span
+              class="font-semibold text-gray-900 dark:text-gray-100 group-hover:text-[#e74c3c] transition-colors"
+              >GSOC Project Ideas 2018</span
+            >
+            <i
+              class="fa-solid fa-link ml-auto text-gray-400 dark:text-gray-600 group-hover:text-[#e74c3c]"
+            ></i>
+          </div>
+        </a>
+        <a
+          href="https://owasp.org/www-community/initiatives/gsoc/gsoc2017ideas"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="group block p-5 bg-white dark:bg-gray-800 shadow-md rounded-lg border border-gray-100 dark:border-gray-800 transition-all"
+        >
+          <div class="flex items-center">
+            <span
+              class="font-semibold text-gray-900 dark:text-gray-100 group-hover:text-[#e74c3c] transition-colors"
+              >GSOC Project Ideas 2017</span
+            >
+            <i
+              class="fa-solid fa-link ml-auto text-gray-400 dark:text-gray-600 group-hover:text-[#e74c3c]"
+            ></i>
+          </div>
+        </a>
+      </div>
+    </div>
+    <!-- Past Events -->
+    <div
+      class="bg-white dark:bg-gray-800 rounded-xl shadow-lg transition-all duration-300 p-8 mb-20 border border-gray-100 dark:border-gray-800"
+    >
+      <h2 class="text-3xl font-bold text-gray-900 dark:text-gray-100 mb-6">
+        Past GSOC Events
+      </h2>
+      <div class="grid grid-cols-1 lg:grid-cols-2 gap-8">
+        <!-- 2023 -->
+        <div
+          class="bg-white dark:bg-gray-800 rounded-lg shadow-md transition-all border border-gray-200 dark:border-gray-700 overflow-hidden"
+        >
+          <div class="p-2 bg-[#e74c3c]"></div>
+          <div class="p-6">
+            <a
+              href="https://summerofcode.withgoogle.com/archive/2023/organizations/owasp-foundation"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="text-xl font-bold text-gray-900 dark:text-gray-100 hover:text-[#e74c3c] transition-colors flex items-center mb-4"
+            >
+              <i
+                aria-hidden="true"
+                class="fas fa-calendar-alt mr-2 text-[#e74c3c]"
+              ></i>
+              2023 GSOC Archive
+            </a>
+            <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4">
+              <h4
+                class="text-lg font-semibold text-gray-800 dark:text-gray-200 mb-2 flex items-center"
+              >
+                <i
+                  aria-hidden="true"
+                  class="fas fa-users mr-2 text-[#e74c3c]"
+                ></i>
+                Mentors
+              </h4>
+              <p class="text-gray-700 dark:text-gray-300 leading-relaxed">
+                Abraham Aranguren, Aryan Prasad, Aryan Ranjan, Ben de Haan,
+                Björn Kimminich, Christian Folini, DonnieBLT, fzipitria, Jannik
+                Hollenbach, José Carlos Chávez, Mrigank Anand, Rick M,
+                ShubhamPalriwala, Simon Bennetts, thc202, Timo Pagel, Viyat
+              </p>
+            </div>
+          </div>
+        </div>
+        <!-- 2022 -->
+        <div
+          class="bg-white dark:bg-gray-800 rounded-lg shadow-md transition-all border border-gray-200 dark:border-gray-700 overflow-hidden"
+        >
+          <div class="p-2 bg-[#e74c3c]"></div>
+          <div class="p-6">
+            <a
+              href="https://summerofcode.withgoogle.com/archive/2022/organizations/owasp-foundation"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="text-xl font-bold text-gray-900 dark:text-gray-100 hover:text-[#e74c3c] transition-colors flex items-center mb-4"
+            >
+              <i
+                aria-hidden="true"
+                class="fas fa-calendar-alt mr-2 text-[#e74c3c]"
+              ></i>
+              2022 GSOC Archive
+            </a>
+            <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4">
+              <h4
+                class="text-lg font-semibold text-gray-800 dark:text-gray-200 mb-2 flex items-center"
+              >
+                <i
+                  aria-hidden="true"
+                  class="fas fa-users mr-2 text-[#e74c3c]"
+                ></i>
+                Mentors
+              </h4>
+              <p class="text-gray-700 dark:text-gray-300 leading-relaxed">
+                Abraham Aranguren, Ade Yoseman Putra, Ankit Choudhary, Björn
+                Kimminich, Dhiren Serai, Franziska, fzipitria, Glenn Ten Cate,
+                Jannik Hollenbach, Rejah Rehim, Rick M, Saeed Dehqan, Sam
+                Stepanyan, Sparsh Agrawal, thc202, Timo Pagel, Viyat
+              </p>
+            </div>
+          </div>
+        </div>
+        <!-- 2021 -->
+        <div
+          class="bg-white dark:bg-gray-800 rounded-lg shadow-md transition-all border border-gray-200 dark:border-gray-700 overflow-hidden"
+        >
+          <div class="p-2 bg-[#e74c3c]"></div>
+          <div class="p-6">
+            <a
+              href="https://summerofcode.withgoogle.com/archive/2021/organizations/owasp-foundation"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="text-xl font-bold text-gray-900 dark:text-gray-100 hover:text-[#e74c3c] transition-colors flex items-center mb-4"
+            >
+              <i
+                aria-hidden="true"
+                class="fas fa-calendar-alt mr-2 text-[#e74c3c]"
+              ></i>
+              2021 GSOC Archive
+            </a>
+            <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4">
+              <h4
+                class="text-lg font-semibold text-gray-800 dark:text-gray-200 mb-2 flex items-center"
+              >
+                <i
+                  aria-hidden="true"
+                  class="fas fa-users mr-2 text-[#e74c3c]"
+                ></i>
+                Mentors
+              </h4>
+              <p class="text-gray-700 dark:text-gray-300 leading-relaxed">
+                8f040, Abe, Abraham Aranguren, Ade Yoseman Putra, Ali Razmjoo
+                Qalaei, Anshul Singhal, Ashrith N Shetty, Björn Kimminich,
+                Damien Carol, Dhiren Devinder Serai, Glenn ten Cate, Jannik
+                Hollenbach, madchap, Mohit Sharma-2, Rejah Rehim, Riccardo Cate,
+                Rick M, Saeed Dehqan-1, Sam Stepanyan, Simon Bennetts, Sourav
+                Badami, thc202
+              </p>
+            </div>
+          </div>
+        </div>
+        <!-- 2020 -->
+        <div
+          class="bg-white dark:bg-gray-800 rounded-lg shadow-md transition-all border border-gray-200 dark:border-gray-700 overflow-hidden"
+        >
+          <div class="p-2 bg-[#e74c3c]"></div>
+          <div class="p-6">
+            <a
+              href="https://summerofcode.withgoogle.com/archive/2020/organizations/owasp-foundation"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="text-xl font-bold text-gray-900 dark:text-gray-100 hover:text-[#e74c3c] transition-colors flex items-center mb-4"
+            >
+              <i
+                aria-hidden="true"
+                class="fas fa-calendar-alt mr-2 text-[#e74c3c]"
+              ></i>
+              2020 GSOC Archive
+            </a>
+            <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4">
+              <h4
+                class="text-lg font-semibold text-gray-800 dark:text-gray-200 mb-2 flex items-center"
+              >
+                <i
+                  aria-hidden="true"
+                  class="fas fa-users mr-2 text-[#e74c3c]"
+                ></i>
+                Mentors
+              </h4>
+              <p class="text-gray-700 dark:text-gray-300 leading-relaxed">
+                Abe, Abraham Aranguren, Ade Yoseman Putra, Adrian Winckles, Ali
+                Razmjoo Qalaei, Björn Kimminich, Felipe Zipitria, Glenn ten
+                Cate, Jannik Hollenbach, Mohit Sharma, Rejah Rehim A A, Rejah
+                Rehim, Ricardo Pereira, Riccardo ten Cate, Rick M, S,
+                securestep9, Simon Bennetts, Soham Marik, souravbadami, spyros,
+                Sri Harsha G, Timo Pagel, Viyat Bhalodia
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <!-- Success Stories -->
+    <div
+      class="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-100 dark:border-gray-800 p-8 mb-12"
+    >
+      <h2
+        class="text-3xl font-bold text-gray-900 dark:text-gray-100 mb-2 text-center"
+      >
+        Success Stories
+      </h2>
+      <div class="w-20 h-1 bg-[#e74c3c] mx-auto mb-8 rounded-full"></div>
+      <div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
+        <!-- Shirish Jain -->
+        <div
+          class="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md border border-gray-100 dark:border-gray-800"
+        >
+          <div class="flex items-center gap-4 mb-6">
+            <div
+              class="w-16 h-16 bg-red-100 rounded-full flex items-center justify-center"
+            >
+              <i class="fas fa-code text-[#e74c3c] text-2xl"></i>
+            </div>
+            <div>
+              <h3 class="text-2xl font-semibold">Shirish Jain</h3>
+              <p class="text-gray-600 dark:text-gray-400">GSoC 2023</p>
+            </div>
+          </div>
+          <p class="text-gray-700 dark:text-gray-300 mb-6 text-lg">
+            Successfully implemented the Sizzle Time Tracking feature during
+            GSoC 2023.
+          </p>
+          <div class="flex gap-4">
+            <a
+              href="https://medium.com/@shirishjain.2001/gsoc-2023-final-report-owasp-bug-logging-tool-f70d6368f9f5"
+              class="flex-1 hover:text-white bg-[#e74c3c] text-white py-2 px-4 rounded-lg hover:bg-red-700 transition-colors text-center flex items-center justify-center gap-2"
+            >
+              <i class="fas fa-book-open"></i>
+              <span>Read Blog</span>
+            </a>
+            <a
+              href="https://blt.owasp.org/contributors/?contributor=37"
+              class="flex-1 border-2 border-[#e74c3c] text-[#e74c3c] py-2 px-4 rounded-lg hover:bg-[#e74c3c] hover:text-white transition-colors text-center flex items-center justify-center gap-2"
+            >
+              <i class="fas fa-user"></i>
+              <span>Profile</span>
+            </a>
+          </div>
+        </div>
+        <!-- Aryan Ranjan -->
+        <div
+          class="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md border border-gray-100 dark:border-gray-800"
+        >
+          <div class="flex items-center gap-4 mb-6">
+            <div
+              class="w-16 h-16 bg-red-100 rounded-full flex items-center justify-center"
+            >
+              <i class="fas fa-comments text-[#e74c3c] text-2xl"></i>
+            </div>
+            <div>
+              <h3 class="text-2xl font-semibold">Aryan Ranjan</h3>
+              <p class="text-gray-600 dark:text-gray-400">GSoC 2023</p>
+            </div>
+          </div>
+          <p class="text-gray-700 dark:text-gray-300 mb-6 text-lg">
+            Developed the Discussion Room feature during GSoC 2023.
+          </p>
+          <div class="flex gap-4">
+            <a
+              href="https://medium.com/@justary27/my-gsoc22-voyage-beginning-4296df5af625"
+              class="flex-1 hover:text-white bg-[#e74c3c] text-white py-2 px-4 rounded-lg hover:bg-red-700 transition-colors text-center flex items-center justify-center gap-2"
+            >
+              <i class="fas fa-book-open"></i>
+              <span>Read Blog</span>
+            </a>
+            <a
+              href="https://blt.owasp.org/contributors/?contributor=1"
+              class="flex-1 border-2 border-[#e74c3c] text-[#e74c3c] py-2 px-4 rounded-lg hover:bg-[#e74c3c] hover:text-white transition-colors text-center flex items-center justify-center gap-2"
+            >
+              <i class="fas fa-user"></i>
+              <span>Profile</span>
+            </a>
+          </div>
+        </div>
+        <!-- Swapnil Shinde -->
+        <div
+          class="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md border border-gray-100 dark:border-gray-800"
+        >
+          <div class="flex items-center gap-4 mb-6">
+            <div
+              class="w-16 h-16 bg-red-100 rounded-full flex items-center justify-center"
+            >
+              <i class="fas fa-bug text-[#e74c3c] text-2xl"></i>
+            </div>
+            <div>
+              <h3 class="text-2xl font-semibold">Swapnil Shinde</h3>
+              <p class="text-gray-600 dark:text-gray-400">GSoC 2022</p>
+            </div>
+          </div>
+          <p class="text-gray-700 dark:text-gray-300 mb-6 text-lg">
+            Contributed to OWASP BLT development.
+          </p>
+          <div class="flex gap-4">
+            <a
+              href="https://gist.github.com/AtmegaBuzz/512a85827b5cc993e35c274dcbada669"
+              class="flex-1 hover:text-white bg-[#e74c3c] text-white py-2 px-4 rounded-lg hover:bg-red-700 transition-colors text-center flex items-center justify-center gap-2"
+            >
+              <i class="fas fa-file-alt"></i>
+              <span>Report</span>
+            </a>
+            <a
+              href="https://blt.owasp.org/contributors/?contributor=3"
+              class="flex-1 border-2 border-[#e74c3c] text-[#e74c3c] py-2 px-4 rounded-lg hover:bg-[#e74c3c] hover:text-white transition-colors text-center flex items-center justify-center gap-2"
+            >
+              <i class="fas fa-user"></i>
+              <span>Profile</span>
+            </a>
+          </div>
+        </div>
+        <!-- Bishal Das -->
+        <div
+          class="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md border border-gray-100 dark:border-gray-800"
+        >
+          <div class="flex items-center gap-4 mb-6">
+            <div
+              class="w-16 h-16 bg-red-100 rounded-full flex items-center justify-center"
+            >
+              <i class="fas fa-graduation-cap text-[#e74c3c] text-2xl"></i>
+            </div>
+            <div>
+              <h3 class="text-2xl font-semibold">Bishal Das</h3>
+              <p class="text-gray-600 dark:text-gray-400">GSoC 2024</p>
+            </div>
+          </div>
+          <p class="text-gray-700 dark:text-gray-300 mb-6 text-lg">
+            GSoC Learning journey with OWASP BLT.
+          </p>
+          <div class="flex gap-4">
+            <a
+              href="https://bishaldas.hashnode.dev/gsoc-2024-a-summer-of-learning-coding-and-growth"
+              class="flex-1 hover:text-white bg-[#e74c3c] text-white py-2 px-4 rounded-lg hover:bg-red-700 transition-colors text-center flex items-center justify-center gap-2"
+            >
+              <i class="fas fa-book-open"></i>
+              <span>Read Blog</span>
+            </a>
+            <a
+              href="https://blt.owasp.org/contributors/?contributor=5"
+              class="flex-1 border-2 border-[#e74c3c] text-[#e74c3c] py-2 px-4 rounded-lg hover:bg-[#e74c3c] hover:text-white transition-colors text-center flex items-center justify-center gap-2"
+            >
+              <i class="fas fa-user"></i>
+              <span>Profile</span>
+            </a>
+          </div>
+        </div>
+        <!-- Shubham Palriwala -->
+        <div
+          class="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md border border-gray-100 dark:border-gray-800"
+        >
+          <div class="flex items-center gap-4 mb-6">
+            <div
+              class="w-16 h-16 bg-red-100 rounded-full flex items-center justify-center"
+            >
+              <i class="fas fa-flask text-[#e74c3c] text-2xl"></i>
+            </div>
+            <div>
+              <h3 class="text-2xl font-semibold">Shubham Palriwala</h3>
+              <p class="text-gray-600 dark:text-gray-400">OWASP Juice Shop</p>
+            </div>
+          </div>
+          <p class="text-gray-700 dark:text-gray-300 mb-6 text-lg">
+            OWASP Juice Shop Journey
+          </p>
+          <div class="flex gap-4">
+            <a
+              href="https://medium.com/@shubhampalriwala/google-summer-of-code-journey-with-owasp-juice-shop-c1ca15c8e170"
+              class="flex-1 hover:text-white bg-[#e74c3c] text-white py-2 px-4 rounded-lg hover:bg-red-700 transition-colors text-center flex items-center justify-center gap-2"
+            >
+              <i class="fas fa-book-open"></i>
+              <span>Read Blog</span>
+            </a>
+          </div>
+        </div>
+        <!-- Akshay Behl -->
+        <div
+          class="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md border border-gray-100 dark:border-gray-800"
+        >
+          <div class="flex items-center gap-4 mb-6">
+            <div
+              class="w-16 h-16 bg-red-100 rounded-full flex items-center justify-center"
+            >
+              <i class="fas fa-network-wired text-[#e74c3c] text-2xl"></i>
+            </div>
+            <div>
+              <h3 class="text-2xl font-semibold">Akshay Behl</h3>
+              <p class="text-gray-600 dark:text-gray-400">OWASP Nettacker</p>
+            </div>
+          </div>
+          <p class="text-gray-700 dark:text-gray-300 mb-6 text-lg">
+            OWASP Nettacker Experience
+          </p>
+          <div class="flex gap-4">
+            <a
+              href="https://medium.com/@akshaybehl231/diving-into-open-source-owasp-nettacker-gsoc24-e73114f37a11"
+              class="flex-1 hover:text-white bg-[#e74c3c] text-white py-2 px-4 rounded-lg hover:bg-red-700 transition-colors text-center flex items-center justify-center gap-2"
+            >
+              <i class="fas fa-book-open"></i>
+              <span>Read Blog</span>
+            </a>
+          </div>
+        </div>
+        <!-- Chakshu Gupta -->
+        <div
+          class="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md border border-gray-100 dark:border-gray-800"
+        >
+          <div class="flex items-center gap-4 mb-6">
+            <div
+              class="w-16 h-16 bg-red-100 rounded-full flex items-center justify-center"
+            >
+              <i class="fas fa-shield-alt text-[#e74c3c] text-2xl"></i>
+            </div>
+            <div>
+              <h3 class="text-2xl font-semibold">Chakshu Gupta</h3>
+              <p class="text-gray-600 dark:text-gray-400">
+                OWASP Honeypot Project
+              </p>
+            </div>
+          </div>
+          <p class="text-gray-700 dark:text-gray-300 mb-6 text-lg">
+            OWASP Honeypot Project Journey
+          </p>
+          <div class="flex gap-4">
+            <a
+              href="https://medium.com/@ChGDream/my-google-summer-of-code-2020-journey-with-owasp-b772c3e67c3f"
+              class="flex-1 hover:text-white bg-[#e74c3c] text-white py-2 px-4 rounded-lg hover:bg-red-700 transition-colors text-center flex items-center justify-center gap-2"
+            >
+              <i class="fas fa-book-open"></i>
+              <span>Read Blog</span>
+            </a>
+          </div>
+        </div>
+        <!-- Rishabh Keshan -->
+        <div
+          class="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md border border-gray-100 dark:border-gray-800"
+        >
+          <div class="flex items-center gap-4 mb-6">
+            <div
+              class="w-16 h-16 bg-red-100 rounded-full flex items-center justify-center"
+            >
+              <i class="fas fa-cube text-[#e74c3c] text-2xl"></i>
+            </div>
+            <div>
+              <h3 class="text-2xl font-semibold">Rishabh Keshan</h3>
+              <p class="text-gray-600 dark:text-gray-400">Web3 Juice Shop</p>
+            </div>
+          </div>
+          <p class="text-gray-700 dark:text-gray-300 mb-6 text-lg">
+            Web3 Journey with Juice Shop
+          </p>
+          <div class="flex gap-4">
+            <a
+              href="https://medium.com/@ChGDream/my-google-summer-of-code-2020-journey-with-owasp-b772c3e67c3f"
+              class="flex-1 hover:text-white bg-[#e74c3c] text-white py-2 px-4 rounded-lg hover:bg-red-700 transition-colors text-center flex items-center justify-center gap-2"
+            >
+              <i class="fas fa-book-open"></i>
+              <span>Read Blog</span>
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+    <!-- GSoC 2026 Students Section -->
+    <div class="mb-20">
+      <h2
+        class="text-3xl font-bold text-center text-gray-900 dark:text-gray-100 mb-2"
+      >
+        2026 Contributors
+      </h2>
+      <div class="w-20 h-1 bg-[#e74c3c] mx-auto mb-12 rounded-full"></div>
+      <div class="flex items-start space-x-6 mb-8">
+        <div class="bg-red-100 rounded-full p-3 flex-shrink-0">
+          <i class="fas fa-star text-[#e74c3c] text-xl"></i>
+        </div>
+        <div>
+          <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100 mb-2">
+            Lead Mentor
+          </h3>
+          <p class="text-lg text-gray-800 dark:text-gray-200 font-medium mb-1">
+            Donnie Brown (All years)
+          </p>
+        </div>
+      </div>
+      <div class="space-y-8">
+        <!-- Md Kaif Ansari -->
+        <div
+          class="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-100 dark:border-gray-800 p-8"
+        >
+          <div class="flex items-center gap-6 mb-6">
+            <div
+              class="w-20 h-20 bg-red-100 rounded-full flex items-center justify-center"
+            >
+              <i class="fab fa-github text-[#e74c3c] text-3xl"></i>
+            </div>
+            <div class="flex-1">
+              <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100">
+                Md Kaif Ansari
+              </h3>
+              <p class="text-lg text-gray-600 dark:text-gray-400 mb-2">
+                2026 Contributor
+              </p>
+              <div class="flex gap-4">
+                <a
+                  href="https://github.com/mdkaifansari04"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="inline-flex items-center px-4 py-2 bg-[#e74c3c] text-white rounded-lg hover:bg-red-700 transition-colors"
+                >
+                  <i class="fab fa-github mr-2"></i>
+                  GitHub Profile
+                </a>
+                <a
+                  href="https://mdkaifansari04.github.io/MY-GSOC-TOOL/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="inline-flex items-center px-4 py-2 border-2 border-[#e74c3c] text-[#e74c3c] rounded-lg hover:bg-[#e74c3c] hover:text-white transition-colors"
+                >
+                  <i class="fas fa-tools mr-2"></i>
+                  GSoC-Tool
+                </a>
+              </div>
+            </div>
+          </div>
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <!-- Rinkit Adhana -->
+            <div
+              class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4 border border-gray-200 dark:border-gray-700"
+            >
+              <div class="flex items-center gap-3 mb-3">
+                <div
+                  class="w-10 h-10 bg-red-100 rounded-full flex items-center justify-center"
+                >
+                  <i class="fas fa-code text-[#e74c3c] text-sm"></i>
+                </div>
+                <div>
+                  <h4
+                    class="text-lg font-bold text-gray-900 dark:text-gray-100"
+                  >
+                    Rinkit Adhana
+                  </h4>
+                  <p class="text-sm text-gray-600 dark:text-gray-400">
+                    Full Stack Development
+                  </p>
+                </div>
+              </div>
+              <div class="mentor-description-container">
+                <p
+                  class="text-gray-600 dark:text-gray-400 text-base leading-relaxed mentor-description-text"
+                >
+                  As a full stack engineer and active BLT contributor, I bring
+                  hands-on experience from both sides of the development
+                  process. Having participated in GSoC 2025, I understand the
+                  challenges new contributors face and can guide you through
+                  your open source journey. I specialize in helping developers
+                  build scalable web applications, navigate complex codebases,
+                  and contribute effectively to real-world projects. My goal is
+                  to share practical knowledge and help you grow as a developer
+                  while making meaningful contributions to BLT.
+                </p>
+              </div>
+            </div>
+            <!-- Raj Gupta -->
+            <div
+              class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4 border border-gray-200 dark:border-gray-700"
+            >
+              <div class="flex items-center gap-3 mb-3">
+                <div
+                  class="w-10 h-10 bg-red-100 rounded-full flex items-center justify-center"
+                >
+                  <i class="fas fa-code text-[#e74c3c] text-sm"></i>
+                </div>
+                <div>
+                  <h4
+                    class="text-lg font-bold text-gray-900 dark:text-gray-100"
+                  >
+                    Raj Gupta
+                  </h4>
+                  <p class="text-sm text-gray-600 dark:text-gray-400">
+                    Full Stack Development mentor
+                  </p>
+                </div>
+              </div>
+              <div class="mentor-description-container">
+                <p
+                  class="text-gray-600 dark:text-gray-400 text-base leading-relaxed mentor-description-text"
+                >
+                  I’m a full stack developer with prior Google Summer of Code
+                  (GSoC) experience and a strong passion for open source. Having
+                  worked as a contributor, I understand the challenges of
+                  getting started - from reading large codebases to making
+                  meaningful pull requests. As a mentor, I enjoy guiding
+                  contributors through best practices, code reviews, and
+                  real-world problem solving. I continue to actively contribute
+                  to open source because I believe collaboration and knowledge
+                  sharing are what truly drive impactful software.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+        <!-- Preetham -->
+        <div
+          class="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-100 dark:border-gray-800 p-8"
+        >
+          <div class="flex items-center gap-6 mb-6">
+            <div
+              class="w-20 h-20 bg-red-100 rounded-full flex items-center justify-center"
+            >
+              <i class="fab fa-github text-[#e74c3c] text-3xl"></i>
+            </div>
+            <div class="flex-1">
+              <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100">
+                Preetham
+              </h3>
+              <p class="text-lg text-gray-600 dark:text-gray-400 mb-2">
+                2026 Contributor
+              </p>
+              <div class="flex gap-4">
+                <a
+                  href="https://github.com/Pritz395"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="inline-flex items-center px-4 py-2 bg-[#e74c3c] text-white rounded-lg hover:bg-red-700 transition-colors"
+                >
+                  <i class="fab fa-github mr-2"></i>
+                  GitHub Profile
+                </a>
+                <a
+                  href="https://Pritz395.github.io/MY-GSOC-TOOL/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="inline-flex items-center px-4 py-2 border-2 border-[#e74c3c] text-[#e74c3c] rounded-lg hover:bg-[#e74c3c] hover:text-white transition-colors"
+                >
+                  <i class="fas fa-tools mr-2"></i>
+                  GSoC-Tool
+                </a>
+              </div>
+            </div>
+          </div>
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <!-- Vinamra Vaswani -->
+            <div
+              class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4 border border-gray-200 dark:border-gray-700"
+            >
+              <div class="flex items-center gap-3 mb-3">
+                <div
+                  class="w-10 h-10 bg-red-100 rounded-full flex items-center justify-center"
+                >
+                  <i class="fas fa-code text-[#e74c3c] text-sm"></i>
+                </div>
+                <div>
+                  <h4
+                    class="text-lg font-bold text-gray-900 dark:text-gray-100"
+                  >
+                    Vinamra Vaswani
+                  </h4>
+                  <p class="text-sm text-gray-600 dark:text-gray-400">
+                    Backend Systems
+                  </p>
+                </div>
+              </div>
+              <div class="mentor-description-container">
+                <p
+                  class="text-gray-600 dark:text-gray-400 text-base leading-relaxed mentor-description-text"
+                >
+                  I am a software engineer experienced in building
+                  production-grade backend systems using Python, FastAPI, and
+                  MongoDB, with a focus on clean architecture and real-world
+                  problem solving. Through open-source style projects and
+                  mentorship programs, I have guided juniors in working with
+                  real codebases, collaborative workflows, and maintainable
+                  engineering practices. As a GSoC mentor, my goal is to help
+                  students move from tutorials to confident real-world
+                  contributors, while giving back to open source by supporting
+                  their technical and professional growth in a learning-first
+                  environment.
+                </p>
+              </div>
+            </div>
+            <!-- Carla Voorhees -->
+            <div
+              class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4 border border-gray-200 dark:border-gray-700"
+            >
+              <div class="flex items-center gap-3 mb-3">
+                <div
+                  class="w-10 h-10 bg-red-100 rounded-full flex items-center justify-center"
+                >
+                  <i class="fas fa-code text-[#e74c3c] text-sm"></i>
+                </div>
+                <div>
+                  <h4
+                    class="text-lg font-bold text-gray-900 dark:text-gray-100"
+                  >
+                    Carla Voorhees
+                  </h4>
+                  <p class="text-sm text-gray-600 dark:text-gray-400">
+                    Technical Product Manager
+                  </p>
+                </div>
+              </div>
+              <div class="mentor-description-container">
+                <p
+                  class="text-gray-600 dark:text-gray-400 text-base leading-relaxed mentor-description-text"
+                >
+                  I am a technical product manager with a background in
+                  cybersecurity and data management. I have experience mentoring
+                  students, helping them navigate complex requirements and
+                  understand best practices. I focus on guiding students through
+                  the product development lifecycle, from ideation to
+                  deployment, while fostering a collaborative and inclusive
+                  learning environment. I help them to understand how to take
+                  requirements and designs and turn them into working code. My
+                  goal is to empower students to become confident contributors
+                  to open source communities.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+        <!-- Siddharth Bansal -->
+        <div
+          class="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-100 dark:border-gray-800 p-8"
+        >
+          <div class="flex items-center gap-6 mb-6">
+            <div
+              class="w-20 h-20 bg-red-100 rounded-full flex items-center justify-center"
+            >
+              <i class="fab fa-github text-[#e74c3c] text-3xl"></i>
+            </div>
+            <div class="flex-1">
+              <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100">
+                Siddharth Bansal
+              </h3>
+              <p class="text-lg text-gray-600 dark:text-gray-400 mb-2">
+                2026 Contributor
+              </p>
+              <div class="flex gap-4">
+                <a
+                  href="https://github.com/sidd190"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="inline-flex items-center px-4 py-2 bg-[#e74c3c] text-white rounded-lg hover:bg-red-700 transition-colors"
+                >
+                  <i class="fab fa-github mr-2"></i>
+                  GitHub Profile
+                </a>
+                <a
+                  href="https://sidd190.github.io/MY-GSOC-TOOL/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="inline-flex items-center px-4 py-2 border-2 border-[#e74c3c] text-[#e74c3c] rounded-lg hover:bg-[#e74c3c] hover:text-white transition-colors"
+                >
+                  <i class="fas fa-tools mr-2"></i>
+                  GSoC-Tool
+                </a>
+              </div>
+            </div>
+          </div>
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <!-- Jigyasu Rajput -->
+            <div
+              class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4 border border-gray-200 dark:border-gray-700"
+            >
+              <div class="flex items-center gap-3 mb-3">
+                <div
+                  class="w-10 h-10 bg-red-100 rounded-full flex items-center justify-center"
+                >
+                  <i class="fas fa-code text-[#e74c3c] text-sm"></i>
+                </div>
+                <div>
+                  <h4
+                    class="text-lg font-bold text-gray-900 dark:text-gray-100"
+                  >
+                    Jigyasu Rajput
+                  </h4>
+                  <p class="text-sm text-gray-600 dark:text-gray-400">
+                    Full Stack Development
+                  </p>
+                </div>
+              </div>
+              <div class="mentor-description-container">
+                <p
+                  class="text-gray-600 dark:text-gray-400 text-base leading-relaxed mentor-description-text"
+                >
+                  I'm a full-stack developer with prior GSoC experience and a
+                  deep love for open source. Having been a contributor myself, I
+                  know how overwhelming it can feel at the start — from
+                  understanding huge codebases to shipping your first meaningful
+                  PR. As a mentor, I focus on helping people build confidence
+                  through clean practices, thoughtful code reviews, and
+                  real-world problem solving. I stay active in open source
+                  because collaboration and shared learning are what actually
+                  move great software forward.
+                </p>
+              </div>
+            </div>
+            <!-- Rishab Kumar Jha -->
+            <div
+              class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4 border border-gray-200 dark:border-gray-700"
+            >
+              <div class="flex items-center gap-3 mb-3">
+                <div
+                  class="w-10 h-10 bg-red-100 rounded-full flex items-center justify-center"
+                >
+                  <i class="fas fa-code text-[#e74c3c] text-sm"></i>
+                </div>
+                <div>
+                  <h4
+                    class="text-lg font-bold text-gray-900 dark:text-gray-100"
+                  >
+                    Rishab Kumar Jha
+                  </h4>
+                  <p class="text-sm text-gray-600 dark:text-gray-400">
+                    Full Stack/Blockchain
+                  </p>
+                </div>
+              </div>
+              <div class="mentor-description-container">
+                <p
+                  class="text-gray-600 dark:text-gray-400 text-base leading-relaxed mentor-description-text"
+                >
+                  I'm a software developer interested in distributed systems,
+                  web3, cloud native technologies & deep-tech. As a past GSoC
+                  and LFX alumnus myself, I understand the pain points of new
+                  contributors. Happy to mentor and help mentees navigate
+                  open-source effectively.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Manahil Afzal -->
+        <div
+          class="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-100 dark:border-gray-800 p-8"
+        >
+          <div class="flex items-center gap-6 mb-6">
+            <div
+              class="w-20 h-20 bg-red-100 rounded-full flex items-center justify-center"
+            >
+              <i class="fab fa-github text-[#e74c3c] text-3xl"></i>
+            </div>
+            <div class="flex-1">
+              <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100">
+                Manahil Afzal 
+              </h3>
+              <p class="text-lg text-gray-600 dark:text-gray-400 mb-2">
+                MERN Stack Engineer / 2026 Contributor
+              </p>
+              <p class="text-gray-600 dark:text-gray-400 mb-4 text-sm">
+                Passionate about building meaningful web applications. Exploring
+                cloud, AI, and open source programs like GSoC & Outreachy.
+                Interested in contributing to organizations like OWASP
+                Foundation & Apache.
+              </p>
+              <div class="flex gap-4">
+                <a
+                  href="https://github.com/Manahil-Afzal"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="inline-flex items-center px-4 py-2 bg-[#e74c3c] text-white rounded-lg hover:bg-red-700 transition-colors"
+                >
+                  <i class="fab fa-github mr-2"></i>
+                  GitHub Profile
+                </a>
+                <a
+                  href="https://manahil-afzal.github.io/MY-GSOC-TOOL/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="inline-flex items-center px-4 py-2 border-2 border-[#e74c3c] text-[#e74c3c] rounded-lg hover:bg-[#e74c3c] hover:text-white transition-colors"
+                >
+                  <i class="fas fa-tools mr-2"></i>
+                  GSoC-Tool
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Sakshee Suman -->
+        <div
+          class="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-100 dark:border-gray-800 p-8"
+        >
+          <div class="flex items-center gap-6 mb-6">
+            <div
+              class="w-20 h-20 bg-red-100 rounded-full flex items-center justify-center"
+            >
+              <i class="fab fa-github text-[#e74c3c] text-3xl"></i>
+            </div>
+            <div class="flex-1">
+              <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100">
+                Sakshee Suman
+              </h3>
+              <p class="text-lg text-gray-600 dark:text-gray-400 mb-2">
+                2026 Contributor
+              </p>
+              <div class="flex gap-4">
+                <a
+                  href="https://github.com/e-esakman"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="inline-flex items-center px-4 py-2 bg-[#e74c3c] text-white rounded-lg hover:bg-red-700 transition-colors"
+                >
+                  <i class="fab fa-github mr-2"></i>
+                  GitHub Profile
+                </a>
+                <a
+                  href="https://e-esakman.github.io/MY-GSOC-TOOL/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="inline-flex items-center px-4 py-2 border-2 border-[#e74c3c] text-[#e74c3c] rounded-lg hover:bg-[#e74c3c] hover:text-white transition-colors"
+                >
+                  <i class="fas fa-tools mr-2"></i>
+                  GSoC-Tool
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <!-- Arnav Kirti -->
+        <div
+          class="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-100 dark:border-gray-800 p-8"
+        >
+          <div class="flex items-center gap-6 mb-6">
+            <div
+              class="w-20 h-20 bg-red-100 rounded-full flex items-center justify-center"
+            >
+              <i class="fab fa-github text-[#e74c3c] text-3xl"></i>
+            </div>
+            <div class="flex-1">
+              <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100">
+                Arnav Kirti
+              </h3>
+              <p class="text-lg text-gray-600 dark:text-gray-400 mb-2">
+                2026 Contributor
+              </p>
+              <div class="flex gap-4">
+                <a
+                  href="https://github.com/arnavkirti"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="inline-flex items-center px-4 py-2 bg-[#e74c3c] text-white rounded-lg hover:bg-red-700 transition-colors"
+                >
+                  <i class="fab fa-github mr-2"></i>
+                  GitHub Profile
+                </a>
+                <a
+                  href="https://arnavkirti.github.io/MY-GSOC-TOOL/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="inline-flex items-center px-4 py-2 border-2 border-[#e74c3c] text-[#e74c3c] rounded-lg hover:bg-[#e74c3c] hover:text-white transition-colors"
+                >
+                  <i class="fas fa-tools mr-2"></i>
+                  GSoC-Tool
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <!-- Savio D'souza -->
+        <div
+          class="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-100 dark:border-gray-800 p-8"
+        >
+          <div class="flex items-center gap-6 mb-6">
+            <div
+              class="w-20 h-20 bg-red-100 rounded-full flex items-center justify-center"
+            >
+              <i class="fab fa-github text-[#e74c3c] text-3xl"></i>
+            </div>
+            <div class="flex-1">
+              <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100">
+                Savio D'souza
+              </h3>
+              <p class="text-lg text-gray-600 dark:text-gray-400 mb-2">
+                2026 Contributor
+              </p>
+              <div class="flex gap-4">
+                <a
+                  href="https://github.com/S3DFX-CYBER"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="inline-flex items-center px-4 py-2 bg-[#e74c3c] text-white rounded-lg hover:bg-red-700 transition-colors"
+                >
+                  <i class="fab fa-github mr-2"></i>
+                  GitHub Profile
+                </a>
+                <a
+                  href="https://S3DFX-CYBER.github.io/MY-GSOC-TOOL/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="inline-flex items-center px-4 py-2 border-2 border-[#e74c3c] text-[#e74c3c] rounded-lg hover:bg-[#e74c3c] hover:text-white transition-colors"
+                >
+                  <i class="fas fa-tools mr-2"></i>
+                  GSoC-Tool
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <!-- Jayant Malvi -->
+        <div
+          class="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-100 dark:border-gray-800 p-8"
+        >
+          <div class="flex items-center gap-6 mb-6">
+            <div
+              class="w-20 h-20 bg-red-100 rounded-full flex items-center justify-center"
+            >
+              <i class="fab fa-github text-[#e74c3c] text-3xl"></i>
+            </div>
+            <div class="flex-1">
+              <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100">
+                Jayant Malvi
+              </h3>
+              <p class="text-lg text-gray-600 dark:text-gray-400 mb-2">
+                2026 Contributor
+              </p>
+              <div class="flex gap-4">
+                <a
+                  href="https://github.com/Jayant2908"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="inline-flex items-center px-4 py-2 bg-[#e74c3c] text-white rounded-lg hover:bg-red-700 transition-colors"
+                >
+                  <i class="fab fa-github mr-2"></i>
+                  GitHub Profile
+                </a>
+                <a
+                  href="https://Jayant2908.github.io/MY-GSOC-TOOL/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="inline-flex items-center px-4 py-2 border-2 border-[#e74c3c] text-[#e74c3c] rounded-lg hover:bg-[#e74c3c] hover:text-white transition-colors"
+                >
+                  <i class="fas fa-tools mr-2"></i>
+                  GSoC-Tool
+                </a>
+              </div>
+            </div>
+          </div>
+          <!-- Mentors grid -->
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <!-- Manikandan Chandran -->
+            <div
+              class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4 border border-gray-200 dark:border-gray-700"
+            >
+              <div class="flex items-center gap-3 mb-3">
+                <div
+                  class="w-10 h-10 bg-red-100 rounded-full flex items-center justify-center"
+                >
+                  <i class="fas fa-code text-[#e74c3c] text-sm"></i>
+                </div>
+                <div>
+                  <h4
+                    class="text-lg font-bold text-gray-900 dark:text-gray-100"
+                  >
+                    Manikandan Chandran
+                  </h4>
+                  <p class="text-sm text-gray-600 dark:text-gray-400">
+                    React/OAuth/REST API
+                  </p>
+                </div>
+              </div>
+              <div class="mentor-description-container">
+                <p
+                  class="text-gray-600 dark:text-gray-400 text-base leading-relaxed mentor-description-text"
+                >
+                  Mentors teams on building secure React apps with real-world
+                  OAuth flows and robust REST APIs.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <!-- Available Mentors Section -->
+      <div
+        class="mt-16 bg-gray-50 dark:bg-gray-900 rounded-xl p-8 border border-gray-200 dark:border-gray-700"
+      >
+        <h3
+          class="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-6 text-center"
+        >
+          Available Mentors for Future Students
+        </h3>
+        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          <!-- Manikandan Chandran -->
+          <div
+            class="bg-white dark:bg-gray-800 rounded-lg p-6 border border-gray-200 dark:border-gray-700"
+          >
+            <div class="flex items-center gap-3 mb-3">
+              <div
+                class="w-12 h-12 bg-red-100 rounded-full flex items-center justify-center"
+              >
+                <i class="fas fa-chalkboard-teacher text-[#e74c3c] text-lg"></i>
+              </div>
+              <div>
+                <h4 class="text-lg font-bold text-gray-900 dark:text-gray-100">
+                  Manikandan Chandran
+                </h4>
+                <p class="text-sm text-gray-600 dark:text-gray-400">
+                  React/OAuth/REST API
+                </p>
+              </div>
+            </div>
+            <p class="text-gray-600 dark:text-gray-400 text-sm">
+              Mentors teams on building secure React apps with real-world OAuth
+              flows and robust REST APIs.
+            </p>
+          </div>
+          <!-- Ahmed ElSheikh -->
+          <div
+            class="bg-white dark:bg-gray-800 rounded-lg p-6 border border-gray-200 dark:border-gray-700"
+          >
+            <div class="flex items-center gap-3 mb-3">
+              <div
+                class="w-12 h-12 bg-red-100 rounded-full flex items-center justify-center"
+              >
+                <i class="fas fa-chalkboard-teacher text-[#e74c3c] text-lg"></i>
+              </div>
+              <div>
+                <h4 class="text-lg font-bold text-gray-900 dark:text-gray-100">
+                  Ahmed ElSheikh
+                </h4>
+                <p class="text-sm text-gray-600 dark:text-gray-400">
+                  React/OAuth/REST API
+                </p>
+              </div>
+            </div>
+            <p class="text-gray-600 dark:text-gray-400 text-sm">
+              Cybersecurity analyst and AI security engineer specializing in
+              secure system design.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+    <!-- Past Mentors Section -->
+    <div
+      class="bg-white dark:bg-gray-800 rounded-xl shadow-lg transition-all duration-300 p-8 mb-20 border border-gray-100 dark:border-gray-800"
+    >
+      <h2
+        class="text-3xl font-bold text-gray-900 dark:text-gray-100 text-center mb-2"
+      >
+        Past GSoC Mentors
+      </h2>
+      <div class="w-20 h-1 bg-[#e74c3c] mx-auto mb-8 rounded-full"></div>
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
+        <div
+          class="bg-gray-50 dark:bg-gray-900 rounded-lg p-6 border border-gray-200 dark:border-gray-700"
+        >
+          <h4
+            class="text-lg font-bold text-gray-900 dark:text-gray-100 mb-3 flex items-center"
+          >
+            <i
+              aria-hidden="true"
+              class="fas fa-calendar-alt text-[#e74c3c] mr-2"
+            ></i
+            >2025
+          </h4>
+          <ul class="space-y-2 text-gray-700 dark:text-gray-300">
+            <li class="flex items-start">
+              <i class="fas fa-user-tie text-[#e74c3c] mt-1 mr-2"></i>
+              <span
+                >Rahul Negi
+                <span class="text-gray-500 dark:text-gray-500"
+                  >(Python/Django Mentor)</span
+                ></span
+              >
+            </li>
+            <li class="flex items-start">
+              <i class="fas fa-user-tie text-[#e74c3c] mt-1 mr-2"></i>
+              <span
+                >Bishal Das
+                <span class="text-gray-500 dark:text-gray-500"
+                  >(Django & UI/UX Mentor)</span
+                ></span
+              >
+            </li>
+            <li class="flex items-start">
+              <i class="fas fa-user-tie text-[#e74c3c] mt-1 mr-2"></i>
+              <span
+                >Sudhir Palavalasa
+                <span class="text-gray-500 dark:text-gray-500"
+                  >(Backend and OAuth mentor)</span
+                ></span
+              >
+            </li>
+          </ul>
+        </div>
+        <div
+          class="bg-gray-50 dark:bg-gray-900 rounded-lg p-6 border border-gray-200 dark:border-gray-700"
+        >
+          <h4
+            class="text-lg font-bold text-gray-900 dark:text-gray-100 mb-3 flex items-center"
+          >
+            <i
+              aria-hidden="true"
+              class="fas fa-calendar-alt text-[#e74c3c] mr-2"
+            ></i
+            >2024
+          </h4>
+          <ul class="space-y-2 text-gray-700 dark:text-gray-300">
+            <li class="flex items-start">
+              <i class="fas fa-user-tie text-[#e74c3c] mt-1 mr-2"></i>
+              <span
+                >Swapnil Shinde
+                <span class="text-gray-500 dark:text-gray-500"
+                  >(Django and blockchain mentor)</span
+                ></span
+              >
+            </li>
+            <li class="flex items-start">
+              <i class="fas fa-user-tie text-[#e74c3c] mt-1 mr-2"></i>
+              <span
+                >Arkadii Yakovets
+                <span class="text-gray-500 dark:text-gray-500"
+                  >(Python/Django mentor)</span
+                ></span
+              >
+            </li>
+          </ul>
+        </div>
+        <div
+          class="bg-gray-50 dark:bg-gray-900 rounded-lg p-6 border border-gray-200 dark:border-gray-700"
+        >
+          <h4
+            class="text-lg font-bold text-gray-900 dark:text-gray-100 mb-3 flex items-center"
+          >
+            <i
+              aria-hidden="true"
+              class="fas fa-calendar-alt text-[#e74c3c] mr-2"
+            ></i
+            >2023
+          </h4>
+          <ul class="space-y-2 text-gray-700 dark:text-gray-300">
+            <li class="flex items-start">
+              <i class="fas fa-user-tie text-[#e74c3c] mt-1 mr-2"></i>
+              <span
+                >Aryan Ranjan
+                <span class="text-gray-500 dark:text-gray-500"
+                  >(Flutter and Django Mentor)</span
+                ></span
+              >
+            </li>
+          </ul>
+        </div>
+        <div
+          class="bg-gray-50 dark:bg-gray-900 rounded-lg p-6 border border-gray-200 dark:border-gray-700"
+        >
+          <h4
+            class="text-lg font-bold text-gray-900 dark:text-gray-100 mb-3 flex items-center"
+          >
+            <i
+              aria-hidden="true"
+              class="fas fa-calendar-alt text-[#e74c3c] mr-2"
+            ></i
+            >2022
+          </h4>
+          <ul class="space-y-2 text-gray-700 dark:text-gray-300">
+            <li class="flex items-start">
+              <i class="fas fa-user-tie text-[#e74c3c] mt-1 mr-2"></i>
+              <span
+                >Sourav Badami
+                <span class="text-gray-500 dark:text-gray-500"
+                  >(Django Mentor)</span
+                ></span
+              >
+            </li>
+            <li class="flex items-start">
+              <i class="fas fa-user-tie text-[#e74c3c] mt-1 mr-2"></i>
+              <span
+                >Rahul Badami
+                <span class="text-gray-500 dark:text-gray-500"
+                  >(Payments Mentor)</span
+                ></span
+              >
+            </li>
+            <li class="flex items-start">
+              <i class="fas fa-user-tie text-[#e74c3c] mt-1 mr-2"></i>
+              <span
+                >Ankit Choudhary
+                <span class="text-gray-500 dark:text-gray-500"
+                  >(Flutter Mentor)</span
+                ></span
+              >
+            </li>
+            <li class="flex items-start">
+              <i class="fas fa-user-tie text-[#e74c3c] mt-1 mr-2"></i>
+              <span
+                >Sparsh Agrawal
+                <span class="text-gray-500 dark:text-gray-500"
+                  >(Flutter Mentor)</span
+                ></span
+              >
+            </li>
+          </ul>
+        </div>
+        <div
+          class="bg-gray-50 dark:bg-gray-900 rounded-lg p-6 border border-gray-200 dark:border-gray-700"
+        >
+          <h4
+            class="text-lg font-bold text-gray-900 dark:text-gray-100 mb-3 flex items-center"
+          >
+            <i
+              aria-hidden="true"
+              class="fas fa-calendar-alt text-[#e74c3c] mr-2"
+            ></i
+            >2020-2021
+          </h4>
+          <ul class="space-y-2 text-gray-700 dark:text-gray-300">
+            <li class="flex items-start">
+              <i class="fas fa-user-tie text-[#e74c3c] mt-1 mr-2"></i>
+              <span
+                >Sourav Badami
+                <span class="text-gray-500 dark:text-gray-500"
+                  >(Django Mentor)</span
+                ></span
+              >
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock content %}

--- a/website/templates/gsoc.html
+++ b/website/templates/gsoc.html
@@ -898,6 +898,39 @@
                             </div>
                         </div>
                     </div>
+
+                    <!-- Manahil Afzal -->
+<div class="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-100 dark:border-gray-800 p-8">
+    <div class="flex items-center gap-6 mb-6">
+        <div class="w-20 h-20 bg-red-100 rounded-full flex items-center justify-center">
+            <i class="fab fa-github text-[#e74c3c] text-3xl"></i>
+        </div>
+        <div class="flex-1">
+            <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100">Manahil Afzal</h3>
+            <p class="text-lg text-gray-600 dark:text-gray-400 mb-2">MERN Stack Engineer / 2026 Contributor</p>
+            <p class="text-gray-600 dark:text-gray-400 mb-4 text-sm">
+                Passionate about building meaningful web applications. Exploring cloud, AI, and open source programs like GSoC & Outreachy. Interested in contributing to organizations like OWASP Foundation & Apache.
+            </p>
+            <div class="flex gap-4">
+                <a href="https://github.com/Manahil-Afzal"
+                   target="_blank"
+                   rel="noopener noreferrer"
+                   class="inline-flex items-center px-4 py-2 bg-[#e74c3c] text-white rounded-lg hover:bg-red-700 transition-colors">
+                    <i class="fab fa-github mr-2"></i>
+                    GitHub Profile
+                </a>
+                <a href="https://manahil-afzal.github.io/MY-GSOC-TOOL/"
+                   target="_blank"
+                   rel="noopener noreferrer"
+                   class="inline-flex items-center px-4 py-2 border-2 border-[#e74c3c] text-[#e74c3c] rounded-lg hover:bg-[#e74c3c] hover:text-white transition-colors">
+                    <i class="fas fa-tools mr-2"></i>
+                    GSoC Tool
+                </a>
+            </div>
+        </div>
+    </div>
+</div>
+
                     <!-- Sakshee Suman -->
                     <div class="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-100 dark:border-gray-800 p-8">
                         <div class="flex items-center gap-6 mb-6">

--- a/website/templates/gsoc.html
+++ b/website/templates/gsoc.html
@@ -899,7 +899,7 @@
                         </div>
                     </div>
                     <!-- Manahil Afzal -->
-                      <div class="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-100 dark:border-gray-800 p-8">
+                  <div class="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-100 dark:border-gray-800 p-8">
                         <div class="flex items-center gap-6 mb-6">
                             <div class="w-20 h-20 bg-red-100 rounded-full flex items-center justify-center">
                                 <i class="fab fa-github text-[#e74c3c] text-3xl"></i>
@@ -928,7 +928,7 @@
                                 </div>
                             </div>
                         </div>
-                    </div>
+                      </div>
                     <!-- Sakshee Suman -->
                     <div class="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-100 dark:border-gray-800 p-8">
                         <div class="flex items-center gap-6 mb-6">

--- a/website/templates/gsoc.html
+++ b/website/templates/gsoc.html
@@ -1,1801 +1,1205 @@
-{% extends "base.html" %} {% load static %} {% load custom_tags %} {% block
-title %} Google Summer of Code with OWASP {% endblock title %} {% block
-description %} Join the Google Summer of Code program with OWASP and contribute
-to open source security projects. {% endblock description %} {% block keywords
-%} GSoC, Google Summer of Code, OWASP, Open Source, Student Program, Mentorship
-{% endblock keywords %} {% block og_title %} Google Summer of Code with OWASP {%
-endblock og_title %} {% block og_description %} Learn about the Google Summer of
-Code (GSoC) program, its benefits, and its partnership with OWASP {% env
-'PROJECT_NAME' %}. {% endblock og_description %} {% block extra_head %}
-<style>
-  .mentor-description-container {
+{% extends "base.html" %}
+{% load static %}
+{% load custom_tags %}
+{% block title %}
+    Google Summer of Code with OWASP
+{% endblock title %}
+{% block description %}
+    Join the Google Summer of Code program with OWASP and contribute to open source security projects.
+{% endblock description %}
+{% block keywords %}
+    GSoC, Google Summer of Code, OWASP, Open Source, Student Program, Mentorship
+{% endblock keywords %}
+{% block og_title %}
+    Google Summer of Code with OWASP
+{% endblock og_title %}
+{% block og_description %}
+    Learn about the Google Summer of Code (GSoC) program, its benefits, and its partnership with OWASP {% env 'PROJECT_NAME' %}.
+{% endblock og_description %}
+{% block extra_head %}
+    <style>
+.mentor-description-container {
     max-height: 8rem;
     overflow-y: auto;
     scrollbar-width: none;
     -ms-overflow-style: none;
-  }
-  .mentor-description-container::-webkit-scrollbar {
+}
+.mentor-description-container::-webkit-scrollbar {
     display: none;
-  }
-  .mentor-description-text {
+}
+.mentor-description-text {
     scrollbar-width: none;
     -ms-overflow-style: none;
-  }
-  .mentor-description-text::-webkit-scrollbar {
+}
+.mentor-description-text::-webkit-scrollbar {
     display: none;
-  }
-</style>
-{% endblock extra_head %} {% block content %} {% include "includes/sidenav.html"
-%}
-<!-- Hero Section -->
-<div class="mt-[100px] bg-zinc-100 py-16">
-  <div class="w-[85%] mx-auto">
-    <div class="flex flex-col md:flex-row items-center gap-8">
-      <div class="md:w-1/3 flex justify-center">
-        <div class="relative">
-          <div
-            class="absolute -inset-4 bg-[#e74c3c] rounded-full blur-md opacity-30 animate-pulse"
-          ></div>
-          <img
-            src="{% static 'images/gsoc.png' %}"
-            alt="Google Summer of Code Logo"
-            class="w-[160px] h-auto object-contain relative"
-            width="200"
-            height="200"
-          />
+}
+    </style>
+{% endblock extra_head %}
+{% block content %}
+    {% include "includes/sidenav.html" %}
+    <!-- Hero Section -->
+    <div class="mt-[100px] bg-zinc-100 py-16">
+        <div class="w-[85%] mx-auto">
+            <div class="flex flex-col md:flex-row items-center gap-8">
+                <div class="md:w-1/3 flex justify-center">
+                    <div class="relative">
+                        <div class="absolute -inset-4 bg-[#e74c3c] rounded-full blur-md opacity-30 animate-pulse"></div>
+                        <img src="{% static 'images/gsoc.png' %}"
+                             alt="Google Summer of Code Logo"
+                             class="w-[160px] h-auto object-contain relative"
+                             width="200"
+                             height="200" />
+                    </div>
+                </div>
+                <div class="md:w-2/3">
+                    <h1 class="text-4xl md:text-5xl font-bold text-gray-900 dark:text-gray-100 mb-4">Google Summer of Code</h1>
+                    <h2 class="text-xl md:text-2xl font-medium text-red-500 mb-6">
+                        with Open Worldwide Application Security Project (OWASP) Foundation
+                    </h2>
+                    <p class="text-xl text-gray-700 dark:text-gray-300 leading-relaxed mb-2">
+                        The
+                        <a href="https://summerofcode.withgoogle.com/"
+                           class="text-[#e74c3c] hover:text-red-700 hover:underline transition-colors font-medium">Google Summer of Code program</a>
+                        (GSoC) is designed to encourage student participation in open source
+                        development. Through GSoC, accepted student applicants will be paired
+                        with OWASP mentors that will guide them through their coding tasks.
+                    </p>
+                    <p class="text-gray-700 dark:text-gray-300 leading-relaxed mb-6">
+                        <i class="fas fa-info-circle mr-2"></i> This program is done
+                        completely online. Students and mentors from more than 100 countries
+                        have participated in past years.
+                    </p>
+                    <div class="flex flex-wrap gap-4">
+                        <a href="https://owasp.org/www-community/initiatives/gsoc/"
+                           class="inline-flex items-center px-6 py-3 bg-red-500 shadow-md hover:bg-red-600 hover:text-white text-white font-medium rounded-lg transition-colors duration-200">
+                            <i class="fas fa-code-branch mr-2"></i> Browse Projects
+                        </a>
+                        <a href="https://summerofcode.withgoogle.com/"
+                           class="inline-flex items-center px-6 py-3 bg-white dark:bg-gray-800 shadow-md hover:bg-gray-100 hover:text-gray-800 text-gray-800 dark:text-gray-200 font-medium rounded-lg transition-colors border border-gray-300 dark:border-gray-600 duration-200">
+                            <i class="fas fa-external-link-alt mr-2"></i> Official GSoC Site
+                        </a>
+                    </div>
+                </div>
+            </div>
         </div>
-      </div>
-      <div class="md:w-2/3">
-        <h1
-          class="text-4xl md:text-5xl font-bold text-gray-900 dark:text-gray-100 mb-4"
-        >
-          Google Summer of Code
-        </h1>
-        <h2 class="text-xl md:text-2xl font-medium text-red-500 mb-6">
-          with Open Worldwide Application Security Project (OWASP) Foundation
-        </h2>
-        <p
-          class="text-xl text-gray-700 dark:text-gray-300 leading-relaxed mb-2"
-        >
-          The
-          <a
-            href="https://summerofcode.withgoogle.com/"
-            class="text-[#e74c3c] hover:text-red-700 hover:underline transition-colors font-medium"
-            >Google Summer of Code program</a
-          >
-          (GSoC) is designed to encourage student participation in open source
-          development. Through GSoC, accepted student applicants will be paired
-          with OWASP mentors that will guide them through their coding tasks.
-        </p>
-        <p class="text-gray-700 dark:text-gray-300 leading-relaxed mb-6">
-          <i class="fas fa-info-circle mr-2"></i> This program is done
-          completely online. Students and mentors from more than 100 countries
-          have participated in past years.
-        </p>
-        <div class="flex flex-wrap gap-4">
-          <a
-            href="https://owasp.org/www-community/initiatives/gsoc/"
-            class="inline-flex items-center px-6 py-3 bg-red-500 shadow-md hover:bg-red-600 hover:text-white text-white font-medium rounded-lg transition-colors duration-200"
-          >
-            <i class="fas fa-code-branch mr-2"></i> Browse Projects
-          </a>
-          <a
-            href="https://summerofcode.withgoogle.com/"
-            class="inline-flex items-center px-6 py-3 bg-white dark:bg-gray-800 shadow-md hover:bg-gray-100 hover:text-gray-800 text-gray-800 dark:text-gray-200 font-medium rounded-lg transition-colors border border-gray-300 dark:border-gray-600 duration-200"
-          >
-            <i class="fas fa-external-link-alt mr-2"></i> Official GSoC Site
-          </a>
-        </div>
-      </div>
     </div>
-  </div>
-</div>
-<!-- Main Content -->
-<div class="py-16 px-4 sm:px-6 lg:px-8 bg-white dark:bg-gray-800">
-  <div class="w-[85%] mx-auto">
-    <!-- Stats Section -->
-    <div class="mb-16">
-      <div class="grid grid-cols-1 sm:grid-cols-3 gap-6">
-        <div
-          class="bg-white dark:bg-gray-800 shadow-lg rounded-xl overflow-hidden transform"
-        >
-          <div class="p-2 bg-[#e74c3c]"></div>
-          <div class="p-6 text-center">
-            <div class="text-5xl font-bold mb-2 text-[#e74c3c]">100+</div>
-            <div class="text-gray-700 dark:text-gray-300 font-medium">
-              Countries Participated
-            </div>
-          </div>
-        </div>
-        <div
-          class="bg-white dark:bg-gray-800 shadow-lg rounded-xl overflow-hidden transform"
-        >
-          <div class="p-2 bg-[#e74c3c]"></div>
-          <div class="p-6 text-center">
-            <div class="text-5xl font-bold mb-2 text-[#e74c3c]">7</div>
-            <div class="text-gray-700 dark:text-gray-300 font-medium">
-              Years with OWASP BLT
-            </div>
-          </div>
-        </div>
-        <div
-          class="bg-white dark:bg-gray-800 shadow-lg rounded-xl overflow-hidden transform"
-        >
-          <div class="p-2 bg-[#e74c3c]"></div>
-          <div class="p-6 text-center">
-            <div class="text-5xl font-bold mb-2 text-[#e74c3c]">20+</div>
-            <div class="text-gray-700 dark:text-gray-300 font-medium">
-              Successful Projects
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <!-- Benefits Section -->
-    <div class="mb-20">
-      <h2
-        class="text-3xl font-bold text-center text-gray-900 dark:text-gray-100 mb-2"
-      >
-        Program Benefits
-      </h2>
-      <div class="w-20 h-1 bg-[#e74c3c] mx-auto mb-12 rounded-full"></div>
-      <div class="grid grid-cols-1 lg:grid-cols-2 gap-10">
-        <!-- Student Benefits -->
-        <div
-          class="bg-white dark:bg-gray-800 rounded-xl shadow-lg transition-all duration-300 p-8 border border-gray-100 dark:border-gray-800"
-        >
-          <div class="flex items-center mb-6">
-            <div
-              class="w-12 h-12 flex items-center justify-center bg-red-100 text-[#e74c3c] rounded-full mr-4"
-            >
-              <i class="fas fa-user-graduate text-xl" aria-hidden="true"></i>
-            </div>
-            <h3 class="text-2xl font-bold text-gray-900 dark:text-gray-100">
-              For Students
-            </h3>
-          </div>
-          <ul class="space-y-4">
-            <li class="flex items-start">
-              <i
-                class="fas fa-check-circle text-[#e74c3c] mt-1 mr-3"
-                aria-hidden="true"
-              ></i>
-              <p class="text-gray-700 dark:text-gray-300">
-                Gaining exposure to real-world software development scenarios
-              </p>
-            </li>
-            <li class="flex items-start">
-              <i
-                class="fas fa-check-circle text-[#e74c3c] mt-1 mr-3"
-                aria-hidden="true"
-              ></i>
-              <p class="text-gray-700 dark:text-gray-300">
-                An opportunity for employment in areas related to their academic
-                pursuits
-              </p>
-            </li>
-            <li class="flex items-start">
-              <i
-                class="fas fa-check-circle text-[#e74c3c] mt-1 mr-3"
-                aria-hidden="true"
-              ></i>
-              <p class="text-gray-700 dark:text-gray-300">
-                Google will be offering successful student contributors a
-                stipend
-              </p>
-            </li>
-            <li class="flex items-start">
-              <i
-                class="fas fa-check-circle text-[#e74c3c] mt-1 mr-3"
-                aria-hidden="true"
-              ></i>
-              <p class="text-gray-700 dark:text-gray-300">
-                Build your professional network
-              </p>
-            </li>
-            <li class="flex items-start">
-              <i
-                class="fas fa-check-circle text-[#e74c3c] mt-1 mr-3"
-                aria-hidden="true"
-              ></i>
-              <p class="text-gray-700 dark:text-gray-300">
-                Gain valuable experience in cybersecurity
-              </p>
-            </li>
-            <li class="flex items-start">
-              <i
-                class="fas fa-check-circle text-[#e74c3c] mt-1 mr-3"
-                aria-hidden="true"
-              ></i>
-              <p class="text-gray-700 dark:text-gray-300">
-                Receive a certificate upon completion
-              </p>
-            </li>
-          </ul>
-        </div>
-        <!-- Mentor Benefits -->
-        <div
-          class="bg-white dark:bg-gray-800 rounded-xl shadow-lg transition-all duration-300 p-8 border border-gray-100 dark:border-gray-800"
-        >
-          <div class="flex items-center mb-6">
-            <div
-              class="w-12 h-12 flex items-center justify-center bg-red-100 text-[#e74c3c] rounded-full mr-4"
-            >
-              <i
-                class="fas fa-chalkboard-teacher text-xl"
-                aria-hidden="true"
-              ></i>
-            </div>
-            <h3 class="text-2xl font-bold text-gray-900 dark:text-gray-100">
-              For Mentors
-            </h3>
-          </div>
-          <ul class="space-y-4">
-            <li class="flex items-start">
-              <i
-                class="fas fa-check-circle text-[#e74c3c] mt-1 mr-3"
-                aria-hidden="true"
-              ></i>
-              <p class="text-gray-700 dark:text-gray-300">
-                Shape the next generation of open-source developers
-              </p>
-            </li>
-            <li class="flex items-start">
-              <i
-                class="fas fa-check-circle text-[#e74c3c] mt-1 mr-3"
-                aria-hidden="true"
-              ></i>
-              <p class="text-gray-700 dark:text-gray-300">
-                Enhance project visibility and community engagement
-              </p>
-            </li>
-            <li class="flex items-start">
-              <i
-                class="fas fa-check-circle text-[#e74c3c] mt-1 mr-3"
-                aria-hidden="true"
-              ></i>
-              <p class="text-gray-700 dark:text-gray-300">
-                Develop leadership and mentoring skills
-              </p>
-            </li>
-            <li class="flex items-start">
-              <i
-                class="fas fa-check-circle text-[#e74c3c] mt-1 mr-3"
-                aria-hidden="true"
-              ></i>
-              <p class="text-gray-700 dark:text-gray-300">
-                Expand your professional network within OWASP
-              </p>
-            </li>
-            <li class="flex items-start">
-              <i
-                class="fas fa-check-circle text-[#e74c3c] mt-1 mr-3"
-                aria-hidden="true"
-              ></i>
-              <p class="text-gray-700 dark:text-gray-300">
-                Recognition in the global security community
-              </p>
-            </li>
-            <li class="flex items-start">
-              <i
-                class="fas fa-check-circle text-[#e74c3c] mt-1 mr-3"
-                aria-hidden="true"
-              ></i>
-              <p class="text-gray-700 dark:text-gray-300">
-                Contribute to the growth of open-source security projects
-              </p>
-            </li>
-          </ul>
-        </div>
-      </div>
-    </div>
-    <!-- OWASP Partnership Card -->
-    <div
-      class="bg-white rounded-xl shadow-lg transition-all duration-300 p-8 mb-20 border border-gray-100"
-    >
-      <h2 class="text-3xl font-bold text-gray-900 mb-6">
-        OWASP BLT & GSOC Partnership
-      </h2>
-      <div class="space-y-6 text-gray-700">
-        <p class="leading-relaxed">
-          OWASP is an open community dedicated to enabling organizations to
-          conceive, develop, acquire, operate, and maintain applications that
-          can be trusted. OWASP has been an active participant in the Google
-          Summer of Code program, providing students with the opportunity to
-          contribute to various OWASP projects.
-        </p>
-        <p class="leading-relaxed">
-          OWASP BLT (Bug Logging Tool) has been participating in the Google
-          Summer of Code program for the past 5 consecutive years, from 2020 to
-          2024. OWASP BLT is an open-source platform dedicated to making the
-          internet safer through community-driven bug reporting and
-          collaboration.
-        </p>
-        <p class="leading-relaxed">
-          All students currently enrolled in an accredited institution are
-          welcome to participate in the Google Summer of Code program, hopefully
-          along with the OWASP Foundation.
-        </p>
-      </div>
-    </div>
-    <!-- Project Ideas Section -->
-    <div class="mb-20">
-      <h2
-        class="text-3xl font-bold text-center text-gray-900 dark:text-gray-100 mb-2"
-      >
-        Project Ideas
-      </h2>
-      <div class="w-20 h-1 bg-[#e74c3c] mx-auto mb-12 rounded-full"></div>
-      <!-- OWASP BLT Projects (Highlighted) -->
-      <div class="mb-12">
-        <a
-          href="https://github.com/OWASP-BLT/BLT/milestones"
-          rel="noopener noreferrer"
-          target="_blank"
-          class="block p-8 bg-gradient-to-br from-red-50 to-red-100 border-2 border-red-200 rounded-xl transition-all"
-        >
-          <div class="flex flex-col md:flex-row items-center justify-between">
-            <div class="mb-6 md:mb-0">
-              <h3 class="text-2xl font-bold text-red-700 mb-3">
-                OWASP BLT Project Ideas
-              </h3>
-              <p class="text-red-600 text-lg mb-4">
-                Explore exciting project opportunities with OWASP Bug Logging
-                Tool
-              </p>
-              <span
-                class="inline-block px-4 py-2 bg-white dark:bg-gray-800 text-[#e74c3c] rounded-full font-medium"
-                >Featured Projects</span
-              >
-            </div>
-            <div class="text-center">
-              <div
-                class="w-24 h-24 flex items-center justify-center bg-white dark:bg-gray-800 rounded-full mb-4 shadow-md mx-auto"
-              >
-                <i class="fa-solid fa-lightbulb text-[#e74c3c] text-4xl"></i>
-              </div>
-              <span class="inline-flex items-center text-[#e74c3c] font-medium">
-                Browse Now <i class="fa-solid fa-arrow-right ml-2"></i>
-              </span>
-            </div>
-          </div>
-        </a>
-      </div>
-      <!-- Past Ideas Grid -->
-      <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
-        <a
-          href="https://owasp.org/www-community/initiatives/gsoc/gsoc2025ideas"
-          target="_blank"
-          rel="noopener noreferrer"
-          class="group block p-5 bg-white dark:bg-gray-800 shadow-md rounded-lg border border-gray-100 dark:border-gray-800 transition-all"
-        >
-          <div class="flex items-center">
-            <span
-              class="font-semibold text-gray-900 dark:text-gray-100 group-hover:text-[#e74c3c] transition-colors"
-              >GSOC Project Ideas 2025</span
-            >
-            <i
-              class="fa-solid fa-link ml-auto text-gray-400 dark:text-gray-600 group-hover:text-[#e74c3c]"
-            ></i>
-          </div>
-        </a>
-        <a
-          href="https://owasp.org/www-community/initiatives/gsoc/gsoc2024ideas"
-          target="_blank"
-          rel="noopener noreferrer"
-          class="group block p-5 bg-white dark:bg-gray-800 shadow-md rounded-lg border border-gray-100 dark:border-gray-800 transition-all"
-        >
-          <div class="flex items-center">
-            <span
-              class="font-semibold text-gray-900 dark:text-gray-100 group-hover:text-[#e74c3c] transition-colors"
-              >GSOC Project Ideas 2024</span
-            >
-            <i
-              class="fa-solid fa-link ml-auto text-gray-400 dark:text-gray-600 group-hover:text-[#e74c3c]"
-            ></i>
-          </div>
-        </a>
-        <a
-          href="https://owasp.org/www-community/initiatives/gsoc/gsoc2023ideas"
-          target="_blank"
-          rel="noopener noreferrer"
-          class="group block p-5 bg-white dark:bg-gray-800 shadow-md rounded-lg border border-gray-100 dark:border-gray-800 transition-all"
-        >
-          <div class="flex items-center">
-            <span
-              class="font-semibold text-gray-900 dark:text-gray-100 group-hover:text-[#e74c3c] transition-colors"
-              >GSOC Project Ideas 2023</span
-            >
-            <i
-              class="fa-solid fa-link ml-auto text-gray-400 dark:text-gray-600 group-hover:text-[#e74c3c]"
-            ></i>
-          </div>
-        </a>
-        <a
-          href="https://owasp.org/www-community/initiatives/gsoc/gsoc2022ideas"
-          target="_blank"
-          rel="noopener noreferrer"
-          class="group block p-5 bg-white dark:bg-gray-800 shadow-md rounded-lg border border-gray-100 dark:border-gray-800 transition-all"
-        >
-          <div class="flex items-center">
-            <span
-              class="font-semibold text-gray-900 dark:text-gray-100 group-hover:text-[#e74c3c] transition-colors"
-              >GSOC Project Ideas 2022</span
-            >
-            <i
-              class="fa-solid fa-link ml-auto text-gray-400 dark:text-gray-600 group-hover:text-[#e74c3c]"
-            ></i>
-          </div>
-        </a>
-        <a
-          href="https://owasp.org/www-community/initiatives/gsoc/gsoc2021ideas"
-          target="_blank"
-          rel="noopener noreferrer"
-          class="group block p-5 bg-white dark:bg-gray-800 shadow-md rounded-lg border border-gray-100 dark:border-gray-800 transition-all"
-        >
-          <div class="flex items-center">
-            <span
-              class="font-semibold text-gray-900 dark:text-gray-100 group-hover:text-[#e74c3c] transition-colors"
-              >GSOC Project Ideas 2021</span
-            >
-            <i
-              class="fa-solid fa-link ml-auto text-gray-400 dark:text-gray-600 group-hover:text-[#e74c3c]"
-            ></i>
-          </div>
-        </a>
-        <a
-          href="https://owasp.org/www-community/initiatives/gsoc/gsoc2020ideas"
-          target="_blank"
-          rel="noopener noreferrer"
-          class="group block p-5 bg-white dark:bg-gray-800 shadow-md rounded-lg border border-gray-100 dark:border-gray-800 transition-all"
-        >
-          <div class="flex items-center">
-            <span
-              class="font-semibold text-gray-900 dark:text-gray-100 group-hover:text-[#e74c3c] transition-colors"
-              >GSOC Project Ideas 2020</span
-            >
-            <i
-              class="fa-solid fa-link ml-auto text-gray-400 dark:text-gray-600 group-hover:text-[#e74c3c]"
-            ></i>
-          </div>
-        </a>
-        <a
-          href="https://owasp.org/www-community/initiatives/gsoc/gsoc2019ideas"
-          target="_blank"
-          rel="noopener noreferrer"
-          class="group block p-5 bg-white dark:bg-gray-800 shadow-md rounded-lg border border-gray-100 dark:border-gray-800 transition-all"
-        >
-          <div class="flex items-center">
-            <span
-              class="font-semibold text-gray-900 dark:text-gray-100 group-hover:text-[#e74c3c] transition-colors"
-              >GSOC Project Ideas 2019</span
-            >
-            <i
-              class="fa-solid fa-link ml-auto text-gray-400 dark:text-gray-600 group-hover:text-[#e74c3c]"
-            ></i>
-          </div>
-        </a>
-        <a
-          href="https://owasp.org/www-community/initiatives/gsoc/gsoc2018ideas"
-          target="_blank"
-          rel="noopener noreferrer"
-          class="group block p-5 bg-white dark:bg-gray-800 shadow-md rounded-lg border border-gray-100 dark:border-gray-800 transition-all"
-        >
-          <div class="flex items-center">
-            <span
-              class="font-semibold text-gray-900 dark:text-gray-100 group-hover:text-[#e74c3c] transition-colors"
-              >GSOC Project Ideas 2018</span
-            >
-            <i
-              class="fa-solid fa-link ml-auto text-gray-400 dark:text-gray-600 group-hover:text-[#e74c3c]"
-            ></i>
-          </div>
-        </a>
-        <a
-          href="https://owasp.org/www-community/initiatives/gsoc/gsoc2017ideas"
-          target="_blank"
-          rel="noopener noreferrer"
-          class="group block p-5 bg-white dark:bg-gray-800 shadow-md rounded-lg border border-gray-100 dark:border-gray-800 transition-all"
-        >
-          <div class="flex items-center">
-            <span
-              class="font-semibold text-gray-900 dark:text-gray-100 group-hover:text-[#e74c3c] transition-colors"
-              >GSOC Project Ideas 2017</span
-            >
-            <i
-              class="fa-solid fa-link ml-auto text-gray-400 dark:text-gray-600 group-hover:text-[#e74c3c]"
-            ></i>
-          </div>
-        </a>
-      </div>
-    </div>
-    <!-- Past Events -->
-    <div
-      class="bg-white dark:bg-gray-800 rounded-xl shadow-lg transition-all duration-300 p-8 mb-20 border border-gray-100 dark:border-gray-800"
-    >
-      <h2 class="text-3xl font-bold text-gray-900 dark:text-gray-100 mb-6">
-        Past GSOC Events
-      </h2>
-      <div class="grid grid-cols-1 lg:grid-cols-2 gap-8">
-        <!-- 2023 -->
-        <div
-          class="bg-white dark:bg-gray-800 rounded-lg shadow-md transition-all border border-gray-200 dark:border-gray-700 overflow-hidden"
-        >
-          <div class="p-2 bg-[#e74c3c]"></div>
-          <div class="p-6">
-            <a
-              href="https://summerofcode.withgoogle.com/archive/2023/organizations/owasp-foundation"
-              target="_blank"
-              rel="noopener noreferrer"
-              class="text-xl font-bold text-gray-900 dark:text-gray-100 hover:text-[#e74c3c] transition-colors flex items-center mb-4"
-            >
-              <i
-                aria-hidden="true"
-                class="fas fa-calendar-alt mr-2 text-[#e74c3c]"
-              ></i>
-              2023 GSOC Archive
-            </a>
-            <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4">
-              <h4
-                class="text-lg font-semibold text-gray-800 dark:text-gray-200 mb-2 flex items-center"
-              >
-                <i
-                  aria-hidden="true"
-                  class="fas fa-users mr-2 text-[#e74c3c]"
-                ></i>
-                Mentors
-              </h4>
-              <p class="text-gray-700 dark:text-gray-300 leading-relaxed">
-                Abraham Aranguren, Aryan Prasad, Aryan Ranjan, Ben de Haan,
-                Björn Kimminich, Christian Folini, DonnieBLT, fzipitria, Jannik
-                Hollenbach, José Carlos Chávez, Mrigank Anand, Rick M,
-                ShubhamPalriwala, Simon Bennetts, thc202, Timo Pagel, Viyat
-              </p>
-            </div>
-          </div>
-        </div>
-        <!-- 2022 -->
-        <div
-          class="bg-white dark:bg-gray-800 rounded-lg shadow-md transition-all border border-gray-200 dark:border-gray-700 overflow-hidden"
-        >
-          <div class="p-2 bg-[#e74c3c]"></div>
-          <div class="p-6">
-            <a
-              href="https://summerofcode.withgoogle.com/archive/2022/organizations/owasp-foundation"
-              target="_blank"
-              rel="noopener noreferrer"
-              class="text-xl font-bold text-gray-900 dark:text-gray-100 hover:text-[#e74c3c] transition-colors flex items-center mb-4"
-            >
-              <i
-                aria-hidden="true"
-                class="fas fa-calendar-alt mr-2 text-[#e74c3c]"
-              ></i>
-              2022 GSOC Archive
-            </a>
-            <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4">
-              <h4
-                class="text-lg font-semibold text-gray-800 dark:text-gray-200 mb-2 flex items-center"
-              >
-                <i
-                  aria-hidden="true"
-                  class="fas fa-users mr-2 text-[#e74c3c]"
-                ></i>
-                Mentors
-              </h4>
-              <p class="text-gray-700 dark:text-gray-300 leading-relaxed">
-                Abraham Aranguren, Ade Yoseman Putra, Ankit Choudhary, Björn
-                Kimminich, Dhiren Serai, Franziska, fzipitria, Glenn Ten Cate,
-                Jannik Hollenbach, Rejah Rehim, Rick M, Saeed Dehqan, Sam
-                Stepanyan, Sparsh Agrawal, thc202, Timo Pagel, Viyat
-              </p>
-            </div>
-          </div>
-        </div>
-        <!-- 2021 -->
-        <div
-          class="bg-white dark:bg-gray-800 rounded-lg shadow-md transition-all border border-gray-200 dark:border-gray-700 overflow-hidden"
-        >
-          <div class="p-2 bg-[#e74c3c]"></div>
-          <div class="p-6">
-            <a
-              href="https://summerofcode.withgoogle.com/archive/2021/organizations/owasp-foundation"
-              target="_blank"
-              rel="noopener noreferrer"
-              class="text-xl font-bold text-gray-900 dark:text-gray-100 hover:text-[#e74c3c] transition-colors flex items-center mb-4"
-            >
-              <i
-                aria-hidden="true"
-                class="fas fa-calendar-alt mr-2 text-[#e74c3c]"
-              ></i>
-              2021 GSOC Archive
-            </a>
-            <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4">
-              <h4
-                class="text-lg font-semibold text-gray-800 dark:text-gray-200 mb-2 flex items-center"
-              >
-                <i
-                  aria-hidden="true"
-                  class="fas fa-users mr-2 text-[#e74c3c]"
-                ></i>
-                Mentors
-              </h4>
-              <p class="text-gray-700 dark:text-gray-300 leading-relaxed">
-                8f040, Abe, Abraham Aranguren, Ade Yoseman Putra, Ali Razmjoo
-                Qalaei, Anshul Singhal, Ashrith N Shetty, Björn Kimminich,
-                Damien Carol, Dhiren Devinder Serai, Glenn ten Cate, Jannik
-                Hollenbach, madchap, Mohit Sharma-2, Rejah Rehim, Riccardo Cate,
-                Rick M, Saeed Dehqan-1, Sam Stepanyan, Simon Bennetts, Sourav
-                Badami, thc202
-              </p>
-            </div>
-          </div>
-        </div>
-        <!-- 2020 -->
-        <div
-          class="bg-white dark:bg-gray-800 rounded-lg shadow-md transition-all border border-gray-200 dark:border-gray-700 overflow-hidden"
-        >
-          <div class="p-2 bg-[#e74c3c]"></div>
-          <div class="p-6">
-            <a
-              href="https://summerofcode.withgoogle.com/archive/2020/organizations/owasp-foundation"
-              target="_blank"
-              rel="noopener noreferrer"
-              class="text-xl font-bold text-gray-900 dark:text-gray-100 hover:text-[#e74c3c] transition-colors flex items-center mb-4"
-            >
-              <i
-                aria-hidden="true"
-                class="fas fa-calendar-alt mr-2 text-[#e74c3c]"
-              ></i>
-              2020 GSOC Archive
-            </a>
-            <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4">
-              <h4
-                class="text-lg font-semibold text-gray-800 dark:text-gray-200 mb-2 flex items-center"
-              >
-                <i
-                  aria-hidden="true"
-                  class="fas fa-users mr-2 text-[#e74c3c]"
-                ></i>
-                Mentors
-              </h4>
-              <p class="text-gray-700 dark:text-gray-300 leading-relaxed">
-                Abe, Abraham Aranguren, Ade Yoseman Putra, Adrian Winckles, Ali
-                Razmjoo Qalaei, Björn Kimminich, Felipe Zipitria, Glenn ten
-                Cate, Jannik Hollenbach, Mohit Sharma, Rejah Rehim A A, Rejah
-                Rehim, Ricardo Pereira, Riccardo ten Cate, Rick M, S,
-                securestep9, Simon Bennetts, Soham Marik, souravbadami, spyros,
-                Sri Harsha G, Timo Pagel, Viyat Bhalodia
-              </p>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <!-- Success Stories -->
-    <div
-      class="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-100 dark:border-gray-800 p-8 mb-12"
-    >
-      <h2
-        class="text-3xl font-bold text-gray-900 dark:text-gray-100 mb-2 text-center"
-      >
-        Success Stories
-      </h2>
-      <div class="w-20 h-1 bg-[#e74c3c] mx-auto mb-8 rounded-full"></div>
-      <div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
-        <!-- Shirish Jain -->
-        <div
-          class="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md border border-gray-100 dark:border-gray-800"
-        >
-          <div class="flex items-center gap-4 mb-6">
-            <div
-              class="w-16 h-16 bg-red-100 rounded-full flex items-center justify-center"
-            >
-              <i class="fas fa-code text-[#e74c3c] text-2xl"></i>
-            </div>
-            <div>
-              <h3 class="text-2xl font-semibold">Shirish Jain</h3>
-              <p class="text-gray-600 dark:text-gray-400">GSoC 2023</p>
-            </div>
-          </div>
-          <p class="text-gray-700 dark:text-gray-300 mb-6 text-lg">
-            Successfully implemented the Sizzle Time Tracking feature during
-            GSoC 2023.
-          </p>
-          <div class="flex gap-4">
-            <a
-              href="https://medium.com/@shirishjain.2001/gsoc-2023-final-report-owasp-bug-logging-tool-f70d6368f9f5"
-              class="flex-1 hover:text-white bg-[#e74c3c] text-white py-2 px-4 rounded-lg hover:bg-red-700 transition-colors text-center flex items-center justify-center gap-2"
-            >
-              <i class="fas fa-book-open"></i>
-              <span>Read Blog</span>
-            </a>
-            <a
-              href="https://blt.owasp.org/contributors/?contributor=37"
-              class="flex-1 border-2 border-[#e74c3c] text-[#e74c3c] py-2 px-4 rounded-lg hover:bg-[#e74c3c] hover:text-white transition-colors text-center flex items-center justify-center gap-2"
-            >
-              <i class="fas fa-user"></i>
-              <span>Profile</span>
-            </a>
-          </div>
-        </div>
-        <!-- Aryan Ranjan -->
-        <div
-          class="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md border border-gray-100 dark:border-gray-800"
-        >
-          <div class="flex items-center gap-4 mb-6">
-            <div
-              class="w-16 h-16 bg-red-100 rounded-full flex items-center justify-center"
-            >
-              <i class="fas fa-comments text-[#e74c3c] text-2xl"></i>
-            </div>
-            <div>
-              <h3 class="text-2xl font-semibold">Aryan Ranjan</h3>
-              <p class="text-gray-600 dark:text-gray-400">GSoC 2023</p>
-            </div>
-          </div>
-          <p class="text-gray-700 dark:text-gray-300 mb-6 text-lg">
-            Developed the Discussion Room feature during GSoC 2023.
-          </p>
-          <div class="flex gap-4">
-            <a
-              href="https://medium.com/@justary27/my-gsoc22-voyage-beginning-4296df5af625"
-              class="flex-1 hover:text-white bg-[#e74c3c] text-white py-2 px-4 rounded-lg hover:bg-red-700 transition-colors text-center flex items-center justify-center gap-2"
-            >
-              <i class="fas fa-book-open"></i>
-              <span>Read Blog</span>
-            </a>
-            <a
-              href="https://blt.owasp.org/contributors/?contributor=1"
-              class="flex-1 border-2 border-[#e74c3c] text-[#e74c3c] py-2 px-4 rounded-lg hover:bg-[#e74c3c] hover:text-white transition-colors text-center flex items-center justify-center gap-2"
-            >
-              <i class="fas fa-user"></i>
-              <span>Profile</span>
-            </a>
-          </div>
-        </div>
-        <!-- Swapnil Shinde -->
-        <div
-          class="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md border border-gray-100 dark:border-gray-800"
-        >
-          <div class="flex items-center gap-4 mb-6">
-            <div
-              class="w-16 h-16 bg-red-100 rounded-full flex items-center justify-center"
-            >
-              <i class="fas fa-bug text-[#e74c3c] text-2xl"></i>
-            </div>
-            <div>
-              <h3 class="text-2xl font-semibold">Swapnil Shinde</h3>
-              <p class="text-gray-600 dark:text-gray-400">GSoC 2022</p>
-            </div>
-          </div>
-          <p class="text-gray-700 dark:text-gray-300 mb-6 text-lg">
-            Contributed to OWASP BLT development.
-          </p>
-          <div class="flex gap-4">
-            <a
-              href="https://gist.github.com/AtmegaBuzz/512a85827b5cc993e35c274dcbada669"
-              class="flex-1 hover:text-white bg-[#e74c3c] text-white py-2 px-4 rounded-lg hover:bg-red-700 transition-colors text-center flex items-center justify-center gap-2"
-            >
-              <i class="fas fa-file-alt"></i>
-              <span>Report</span>
-            </a>
-            <a
-              href="https://blt.owasp.org/contributors/?contributor=3"
-              class="flex-1 border-2 border-[#e74c3c] text-[#e74c3c] py-2 px-4 rounded-lg hover:bg-[#e74c3c] hover:text-white transition-colors text-center flex items-center justify-center gap-2"
-            >
-              <i class="fas fa-user"></i>
-              <span>Profile</span>
-            </a>
-          </div>
-        </div>
-        <!-- Bishal Das -->
-        <div
-          class="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md border border-gray-100 dark:border-gray-800"
-        >
-          <div class="flex items-center gap-4 mb-6">
-            <div
-              class="w-16 h-16 bg-red-100 rounded-full flex items-center justify-center"
-            >
-              <i class="fas fa-graduation-cap text-[#e74c3c] text-2xl"></i>
-            </div>
-            <div>
-              <h3 class="text-2xl font-semibold">Bishal Das</h3>
-              <p class="text-gray-600 dark:text-gray-400">GSoC 2024</p>
-            </div>
-          </div>
-          <p class="text-gray-700 dark:text-gray-300 mb-6 text-lg">
-            GSoC Learning journey with OWASP BLT.
-          </p>
-          <div class="flex gap-4">
-            <a
-              href="https://bishaldas.hashnode.dev/gsoc-2024-a-summer-of-learning-coding-and-growth"
-              class="flex-1 hover:text-white bg-[#e74c3c] text-white py-2 px-4 rounded-lg hover:bg-red-700 transition-colors text-center flex items-center justify-center gap-2"
-            >
-              <i class="fas fa-book-open"></i>
-              <span>Read Blog</span>
-            </a>
-            <a
-              href="https://blt.owasp.org/contributors/?contributor=5"
-              class="flex-1 border-2 border-[#e74c3c] text-[#e74c3c] py-2 px-4 rounded-lg hover:bg-[#e74c3c] hover:text-white transition-colors text-center flex items-center justify-center gap-2"
-            >
-              <i class="fas fa-user"></i>
-              <span>Profile</span>
-            </a>
-          </div>
-        </div>
-        <!-- Shubham Palriwala -->
-        <div
-          class="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md border border-gray-100 dark:border-gray-800"
-        >
-          <div class="flex items-center gap-4 mb-6">
-            <div
-              class="w-16 h-16 bg-red-100 rounded-full flex items-center justify-center"
-            >
-              <i class="fas fa-flask text-[#e74c3c] text-2xl"></i>
-            </div>
-            <div>
-              <h3 class="text-2xl font-semibold">Shubham Palriwala</h3>
-              <p class="text-gray-600 dark:text-gray-400">OWASP Juice Shop</p>
-            </div>
-          </div>
-          <p class="text-gray-700 dark:text-gray-300 mb-6 text-lg">
-            OWASP Juice Shop Journey
-          </p>
-          <div class="flex gap-4">
-            <a
-              href="https://medium.com/@shubhampalriwala/google-summer-of-code-journey-with-owasp-juice-shop-c1ca15c8e170"
-              class="flex-1 hover:text-white bg-[#e74c3c] text-white py-2 px-4 rounded-lg hover:bg-red-700 transition-colors text-center flex items-center justify-center gap-2"
-            >
-              <i class="fas fa-book-open"></i>
-              <span>Read Blog</span>
-            </a>
-          </div>
-        </div>
-        <!-- Akshay Behl -->
-        <div
-          class="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md border border-gray-100 dark:border-gray-800"
-        >
-          <div class="flex items-center gap-4 mb-6">
-            <div
-              class="w-16 h-16 bg-red-100 rounded-full flex items-center justify-center"
-            >
-              <i class="fas fa-network-wired text-[#e74c3c] text-2xl"></i>
-            </div>
-            <div>
-              <h3 class="text-2xl font-semibold">Akshay Behl</h3>
-              <p class="text-gray-600 dark:text-gray-400">OWASP Nettacker</p>
-            </div>
-          </div>
-          <p class="text-gray-700 dark:text-gray-300 mb-6 text-lg">
-            OWASP Nettacker Experience
-          </p>
-          <div class="flex gap-4">
-            <a
-              href="https://medium.com/@akshaybehl231/diving-into-open-source-owasp-nettacker-gsoc24-e73114f37a11"
-              class="flex-1 hover:text-white bg-[#e74c3c] text-white py-2 px-4 rounded-lg hover:bg-red-700 transition-colors text-center flex items-center justify-center gap-2"
-            >
-              <i class="fas fa-book-open"></i>
-              <span>Read Blog</span>
-            </a>
-          </div>
-        </div>
-        <!-- Chakshu Gupta -->
-        <div
-          class="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md border border-gray-100 dark:border-gray-800"
-        >
-          <div class="flex items-center gap-4 mb-6">
-            <div
-              class="w-16 h-16 bg-red-100 rounded-full flex items-center justify-center"
-            >
-              <i class="fas fa-shield-alt text-[#e74c3c] text-2xl"></i>
-            </div>
-            <div>
-              <h3 class="text-2xl font-semibold">Chakshu Gupta</h3>
-              <p class="text-gray-600 dark:text-gray-400">
-                OWASP Honeypot Project
-              </p>
-            </div>
-          </div>
-          <p class="text-gray-700 dark:text-gray-300 mb-6 text-lg">
-            OWASP Honeypot Project Journey
-          </p>
-          <div class="flex gap-4">
-            <a
-              href="https://medium.com/@ChGDream/my-google-summer-of-code-2020-journey-with-owasp-b772c3e67c3f"
-              class="flex-1 hover:text-white bg-[#e74c3c] text-white py-2 px-4 rounded-lg hover:bg-red-700 transition-colors text-center flex items-center justify-center gap-2"
-            >
-              <i class="fas fa-book-open"></i>
-              <span>Read Blog</span>
-            </a>
-          </div>
-        </div>
-        <!-- Rishabh Keshan -->
-        <div
-          class="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md border border-gray-100 dark:border-gray-800"
-        >
-          <div class="flex items-center gap-4 mb-6">
-            <div
-              class="w-16 h-16 bg-red-100 rounded-full flex items-center justify-center"
-            >
-              <i class="fas fa-cube text-[#e74c3c] text-2xl"></i>
-            </div>
-            <div>
-              <h3 class="text-2xl font-semibold">Rishabh Keshan</h3>
-              <p class="text-gray-600 dark:text-gray-400">Web3 Juice Shop</p>
-            </div>
-          </div>
-          <p class="text-gray-700 dark:text-gray-300 mb-6 text-lg">
-            Web3 Journey with Juice Shop
-          </p>
-          <div class="flex gap-4">
-            <a
-              href="https://medium.com/@ChGDream/my-google-summer-of-code-2020-journey-with-owasp-b772c3e67c3f"
-              class="flex-1 hover:text-white bg-[#e74c3c] text-white py-2 px-4 rounded-lg hover:bg-red-700 transition-colors text-center flex items-center justify-center gap-2"
-            >
-              <i class="fas fa-book-open"></i>
-              <span>Read Blog</span>
-            </a>
-          </div>
-        </div>
-      </div>
-    </div>
-    <!-- GSoC 2026 Students Section -->
-    <div class="mb-20">
-      <h2
-        class="text-3xl font-bold text-center text-gray-900 dark:text-gray-100 mb-2"
-      >
-        2026 Contributors
-      </h2>
-      <div class="w-20 h-1 bg-[#e74c3c] mx-auto mb-12 rounded-full"></div>
-      <div class="flex items-start space-x-6 mb-8">
-        <div class="bg-red-100 rounded-full p-3 flex-shrink-0">
-          <i class="fas fa-star text-[#e74c3c] text-xl"></i>
-        </div>
-        <div>
-          <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100 mb-2">
-            Lead Mentor
-          </h3>
-          <p class="text-lg text-gray-800 dark:text-gray-200 font-medium mb-1">
-            Donnie Brown (All years)
-          </p>
-        </div>
-      </div>
-      <div class="space-y-8">
-        <!-- Md Kaif Ansari -->
-        <div
-          class="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-100 dark:border-gray-800 p-8"
-        >
-          <div class="flex items-center gap-6 mb-6">
-            <div
-              class="w-20 h-20 bg-red-100 rounded-full flex items-center justify-center"
-            >
-              <i class="fab fa-github text-[#e74c3c] text-3xl"></i>
-            </div>
-            <div class="flex-1">
-              <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100">
-                Md Kaif Ansari
-              </h3>
-              <p class="text-lg text-gray-600 dark:text-gray-400 mb-2">
-                2026 Contributor
-              </p>
-              <div class="flex gap-4">
-                <a
-                  href="https://github.com/mdkaifansari04"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  class="inline-flex items-center px-4 py-2 bg-[#e74c3c] text-white rounded-lg hover:bg-red-700 transition-colors"
-                >
-                  <i class="fab fa-github mr-2"></i>
-                  GitHub Profile
-                </a>
-                <a
-                  href="https://mdkaifansari04.github.io/MY-GSOC-TOOL/"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  class="inline-flex items-center px-4 py-2 border-2 border-[#e74c3c] text-[#e74c3c] rounded-lg hover:bg-[#e74c3c] hover:text-white transition-colors"
-                >
-                  <i class="fas fa-tools mr-2"></i>
-                  GSoC-Tool
-                </a>
-              </div>
-            </div>
-          </div>
-          <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-            <!-- Rinkit Adhana -->
-            <div
-              class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4 border border-gray-200 dark:border-gray-700"
-            >
-              <div class="flex items-center gap-3 mb-3">
-                <div
-                  class="w-10 h-10 bg-red-100 rounded-full flex items-center justify-center"
-                >
-                  <i class="fas fa-code text-[#e74c3c] text-sm"></i>
+    <!-- Main Content -->
+    <div class="py-16 px-4 sm:px-6 lg:px-8 bg-white dark:bg-gray-800">
+        <div class="w-[85%] mx-auto">
+            <!-- Stats Section -->
+            <div class="mb-16">
+                <div class="grid grid-cols-1 sm:grid-cols-3 gap-6">
+                    <div class="bg-white dark:bg-gray-800 shadow-lg rounded-xl overflow-hidden transform">
+                        <div class="p-2 bg-[#e74c3c]"></div>
+                        <div class="p-6 text-center">
+                            <div class="text-5xl font-bold mb-2 text-[#e74c3c]">100+</div>
+                            <div class="text-gray-700 dark:text-gray-300 font-medium">Countries Participated</div>
+                        </div>
+                    </div>
+                    <div class="bg-white dark:bg-gray-800 shadow-lg rounded-xl overflow-hidden transform">
+                        <div class="p-2 bg-[#e74c3c]"></div>
+                        <div class="p-6 text-center">
+                            <div class="text-5xl font-bold mb-2 text-[#e74c3c]">7</div>
+                            <div class="text-gray-700 dark:text-gray-300 font-medium">Years with OWASP BLT</div>
+                        </div>
+                    </div>
+                    <div class="bg-white dark:bg-gray-800 shadow-lg rounded-xl overflow-hidden transform">
+                        <div class="p-2 bg-[#e74c3c]"></div>
+                        <div class="p-6 text-center">
+                            <div class="text-5xl font-bold mb-2 text-[#e74c3c]">20+</div>
+                            <div class="text-gray-700 dark:text-gray-300 font-medium">Successful Projects</div>
+                        </div>
+                    </div>
                 </div>
-                <div>
-                  <h4
-                    class="text-lg font-bold text-gray-900 dark:text-gray-100"
-                  >
-                    Rinkit Adhana
-                  </h4>
-                  <p class="text-sm text-gray-600 dark:text-gray-400">
-                    Full Stack Development
-                  </p>
+            </div>
+            <!-- Benefits Section -->
+            <div class="mb-20">
+                <h2 class="text-3xl font-bold text-center text-gray-900 dark:text-gray-100 mb-2">Program Benefits</h2>
+                <div class="w-20 h-1 bg-[#e74c3c] mx-auto mb-12 rounded-full"></div>
+                <div class="grid grid-cols-1 lg:grid-cols-2 gap-10">
+                    <!-- Student Benefits -->
+                    <div class="bg-white dark:bg-gray-800 rounded-xl shadow-lg transition-all duration-300 p-8 border border-gray-100 dark:border-gray-800">
+                        <div class="flex items-center mb-6">
+                            <div class="w-12 h-12 flex items-center justify-center bg-red-100 text-[#e74c3c] rounded-full mr-4">
+                                <i class="fas fa-user-graduate text-xl" aria-hidden="true"></i>
+                            </div>
+                            <h3 class="text-2xl font-bold text-gray-900 dark:text-gray-100">For Students</h3>
+                        </div>
+                        <ul class="space-y-4">
+                            <li class="flex items-start">
+                                <i class="fas fa-check-circle text-[#e74c3c] mt-1 mr-3"
+                                   aria-hidden="true"></i>
+                                <p class="text-gray-700 dark:text-gray-300">Gaining exposure to real-world software development scenarios</p>
+                            </li>
+                            <li class="flex items-start">
+                                <i class="fas fa-check-circle text-[#e74c3c] mt-1 mr-3"
+                                   aria-hidden="true"></i>
+                                <p class="text-gray-700 dark:text-gray-300">
+                                    An opportunity for employment in areas related to their academic
+                                    pursuits
+                                </p>
+                            </li>
+                            <li class="flex items-start">
+                                <i class="fas fa-check-circle text-[#e74c3c] mt-1 mr-3"
+                                   aria-hidden="true"></i>
+                                <p class="text-gray-700 dark:text-gray-300">
+                                    Google will be offering successful student contributors a
+                                    stipend
+                                </p>
+                            </li>
+                            <li class="flex items-start">
+                                <i class="fas fa-check-circle text-[#e74c3c] mt-1 mr-3"
+                                   aria-hidden="true"></i>
+                                <p class="text-gray-700 dark:text-gray-300">Build your professional network</p>
+                            </li>
+                            <li class="flex items-start">
+                                <i class="fas fa-check-circle text-[#e74c3c] mt-1 mr-3"
+                                   aria-hidden="true"></i>
+                                <p class="text-gray-700 dark:text-gray-300">Gain valuable experience in cybersecurity</p>
+                            </li>
+                            <li class="flex items-start">
+                                <i class="fas fa-check-circle text-[#e74c3c] mt-1 mr-3"
+                                   aria-hidden="true"></i>
+                                <p class="text-gray-700 dark:text-gray-300">Receive a certificate upon completion</p>
+                            </li>
+                        </ul>
+                    </div>
+                    <!-- Mentor Benefits -->
+                    <div class="bg-white dark:bg-gray-800 rounded-xl shadow-lg transition-all duration-300 p-8 border border-gray-100 dark:border-gray-800">
+                        <div class="flex items-center mb-6">
+                            <div class="w-12 h-12 flex items-center justify-center bg-red-100 text-[#e74c3c] rounded-full mr-4">
+                                <i class="fas fa-chalkboard-teacher text-xl" aria-hidden="true"></i>
+                            </div>
+                            <h3 class="text-2xl font-bold text-gray-900 dark:text-gray-100">For Mentors</h3>
+                        </div>
+                        <ul class="space-y-4">
+                            <li class="flex items-start">
+                                <i class="fas fa-check-circle text-[#e74c3c] mt-1 mr-3"
+                                   aria-hidden="true"></i>
+                                <p class="text-gray-700 dark:text-gray-300">Shape the next generation of open-source developers</p>
+                            </li>
+                            <li class="flex items-start">
+                                <i class="fas fa-check-circle text-[#e74c3c] mt-1 mr-3"
+                                   aria-hidden="true"></i>
+                                <p class="text-gray-700 dark:text-gray-300">Enhance project visibility and community engagement</p>
+                            </li>
+                            <li class="flex items-start">
+                                <i class="fas fa-check-circle text-[#e74c3c] mt-1 mr-3"
+                                   aria-hidden="true"></i>
+                                <p class="text-gray-700 dark:text-gray-300">Develop leadership and mentoring skills</p>
+                            </li>
+                            <li class="flex items-start">
+                                <i class="fas fa-check-circle text-[#e74c3c] mt-1 mr-3"
+                                   aria-hidden="true"></i>
+                                <p class="text-gray-700 dark:text-gray-300">Expand your professional network within OWASP</p>
+                            </li>
+                            <li class="flex items-start">
+                                <i class="fas fa-check-circle text-[#e74c3c] mt-1 mr-3"
+                                   aria-hidden="true"></i>
+                                <p class="text-gray-700 dark:text-gray-300">Recognition in the global security community</p>
+                            </li>
+                            <li class="flex items-start">
+                                <i class="fas fa-check-circle text-[#e74c3c] mt-1 mr-3"
+                                   aria-hidden="true"></i>
+                                <p class="text-gray-700 dark:text-gray-300">Contribute to the growth of open-source security projects</p>
+                            </li>
+                        </ul>
+                    </div>
                 </div>
-              </div>
-              <div class="mentor-description-container">
-                <p
-                  class="text-gray-600 dark:text-gray-400 text-base leading-relaxed mentor-description-text"
-                >
-                  As a full stack engineer and active BLT contributor, I bring
-                  hands-on experience from both sides of the development
-                  process. Having participated in GSoC 2025, I understand the
-                  challenges new contributors face and can guide you through
-                  your open source journey. I specialize in helping developers
-                  build scalable web applications, navigate complex codebases,
-                  and contribute effectively to real-world projects. My goal is
-                  to share practical knowledge and help you grow as a developer
-                  while making meaningful contributions to BLT.
-                </p>
-              </div>
             </div>
-            <!-- Raj Gupta -->
-            <div
-              class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4 border border-gray-200 dark:border-gray-700"
-            >
-              <div class="flex items-center gap-3 mb-3">
-                <div
-                  class="w-10 h-10 bg-red-100 rounded-full flex items-center justify-center"
-                >
-                  <i class="fas fa-code text-[#e74c3c] text-sm"></i>
+            <!-- OWASP Partnership Card -->
+            <div class="bg-white rounded-xl shadow-lg transition-all duration-300 p-8 mb-20 border border-gray-100">
+                <h2 class="text-3xl font-bold text-gray-900 mb-6">OWASP BLT & GSOC Partnership</h2>
+                <div class="space-y-6 text-gray-700">
+                    <p class="leading-relaxed">
+                        OWASP is an open community dedicated to enabling organizations to
+                        conceive, develop, acquire, operate, and maintain applications that
+                        can be trusted. OWASP has been an active participant in the Google
+                        Summer of Code program, providing students with the opportunity to
+                        contribute to various OWASP projects.
+                    </p>
+                    <p class="leading-relaxed">
+                        OWASP BLT (Bug Logging Tool) has been participating in the Google
+                        Summer of Code program for the past 5 consecutive years, from 2020 to
+                        2024. OWASP BLT is an open-source platform dedicated to making the
+                        internet safer through community-driven bug reporting and
+                        collaboration.
+                    </p>
+                    <p class="leading-relaxed">
+                        All students currently enrolled in an accredited institution are
+                        welcome to participate in the Google Summer of Code program, hopefully
+                        along with the OWASP Foundation.
+                    </p>
                 </div>
-                <div>
-                  <h4
-                    class="text-lg font-bold text-gray-900 dark:text-gray-100"
-                  >
-                    Raj Gupta
-                  </h4>
-                  <p class="text-sm text-gray-600 dark:text-gray-400">
-                    Full Stack Development mentor
-                  </p>
+            </div>
+            <!-- Project Ideas Section -->
+            <div class="mb-20">
+                <h2 class="text-3xl font-bold text-center text-gray-900 dark:text-gray-100 mb-2">Project Ideas</h2>
+                <div class="w-20 h-1 bg-[#e74c3c] mx-auto mb-12 rounded-full"></div>
+                <!-- OWASP BLT Projects (Highlighted) -->
+                <div class="mb-12">
+                    <a href="https://github.com/OWASP-BLT/BLT/milestones"
+                       rel="noopener noreferrer"
+                       target="_blank"
+                       class="block p-8 bg-gradient-to-br from-red-50 to-red-100 border-2 border-red-200 rounded-xl transition-all">
+                        <div class="flex flex-col md:flex-row items-center justify-between">
+                            <div class="mb-6 md:mb-0">
+                                <h3 class="text-2xl font-bold text-red-700 mb-3">OWASP BLT Project Ideas</h3>
+                                <p class="text-red-600 text-lg mb-4">
+                                    Explore exciting project opportunities with OWASP Bug Logging
+                                    Tool
+                                </p>
+                                <span class="inline-block px-4 py-2 bg-white dark:bg-gray-800 text-[#e74c3c] rounded-full font-medium">Featured Projects</span>
+                            </div>
+                            <div class="text-center">
+                                <div class="w-24 h-24 flex items-center justify-center bg-white dark:bg-gray-800 rounded-full mb-4 shadow-md mx-auto">
+                                    <i class="fa-solid fa-lightbulb text-[#e74c3c] text-4xl"></i>
+                                </div>
+                                <span class="inline-flex items-center text-[#e74c3c] font-medium">
+                                    Browse Now <i class="fa-solid fa-arrow-right ml-2"></i>
+                                </span>
+                            </div>
+                        </div>
+                    </a>
                 </div>
-              </div>
-              <div class="mentor-description-container">
-                <p
-                  class="text-gray-600 dark:text-gray-400 text-base leading-relaxed mentor-description-text"
-                >
-                  I’m a full stack developer with prior Google Summer of Code
-                  (GSoC) experience and a strong passion for open source. Having
-                  worked as a contributor, I understand the challenges of
-                  getting started - from reading large codebases to making
-                  meaningful pull requests. As a mentor, I enjoy guiding
-                  contributors through best practices, code reviews, and
-                  real-world problem solving. I continue to actively contribute
-                  to open source because I believe collaboration and knowledge
-                  sharing are what truly drive impactful software.
-                </p>
-              </div>
-            </div>
-          </div>
-        </div>
-        <!-- Preetham -->
-        <div
-          class="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-100 dark:border-gray-800 p-8"
-        >
-          <div class="flex items-center gap-6 mb-6">
-            <div
-              class="w-20 h-20 bg-red-100 rounded-full flex items-center justify-center"
-            >
-              <i class="fab fa-github text-[#e74c3c] text-3xl"></i>
-            </div>
-            <div class="flex-1">
-              <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100">
-                Preetham
-              </h3>
-              <p class="text-lg text-gray-600 dark:text-gray-400 mb-2">
-                2026 Contributor
-              </p>
-              <div class="flex gap-4">
-                <a
-                  href="https://github.com/Pritz395"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  class="inline-flex items-center px-4 py-2 bg-[#e74c3c] text-white rounded-lg hover:bg-red-700 transition-colors"
-                >
-                  <i class="fab fa-github mr-2"></i>
-                  GitHub Profile
-                </a>
-                <a
-                  href="https://Pritz395.github.io/MY-GSOC-TOOL/"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  class="inline-flex items-center px-4 py-2 border-2 border-[#e74c3c] text-[#e74c3c] rounded-lg hover:bg-[#e74c3c] hover:text-white transition-colors"
-                >
-                  <i class="fas fa-tools mr-2"></i>
-                  GSoC-Tool
-                </a>
-              </div>
-            </div>
-          </div>
-          <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-            <!-- Vinamra Vaswani -->
-            <div
-              class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4 border border-gray-200 dark:border-gray-700"
-            >
-              <div class="flex items-center gap-3 mb-3">
-                <div
-                  class="w-10 h-10 bg-red-100 rounded-full flex items-center justify-center"
-                >
-                  <i class="fas fa-code text-[#e74c3c] text-sm"></i>
+                <!-- Past Ideas Grid -->
+                <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+                    <a href="https://owasp.org/www-community/initiatives/gsoc/gsoc2025ideas"
+                       target="_blank"
+                       rel="noopener noreferrer"
+                       class="group block p-5 bg-white dark:bg-gray-800 shadow-md rounded-lg border border-gray-100 dark:border-gray-800 transition-all">
+                        <div class="flex items-center">
+                            <span class="font-semibold text-gray-900 dark:text-gray-100 group-hover:text-[#e74c3c] transition-colors">GSOC Project Ideas 2025</span>
+                            <i class="fa-solid fa-link ml-auto text-gray-400 dark:text-gray-600 group-hover:text-[#e74c3c]"></i>
+                        </div>
+                    </a>
+                    <a href="https://owasp.org/www-community/initiatives/gsoc/gsoc2024ideas"
+                       target="_blank"
+                       rel="noopener noreferrer"
+                       class="group block p-5 bg-white dark:bg-gray-800 shadow-md rounded-lg border border-gray-100 dark:border-gray-800 transition-all">
+                        <div class="flex items-center">
+                            <span class="font-semibold text-gray-900 dark:text-gray-100 group-hover:text-[#e74c3c] transition-colors">GSOC Project Ideas 2024</span>
+                            <i class="fa-solid fa-link ml-auto text-gray-400 dark:text-gray-600 group-hover:text-[#e74c3c]"></i>
+                        </div>
+                    </a>
+                    <a href="https://owasp.org/www-community/initiatives/gsoc/gsoc2023ideas"
+                       target="_blank"
+                       rel="noopener noreferrer"
+                       class="group block p-5 bg-white dark:bg-gray-800 shadow-md rounded-lg border border-gray-100 dark:border-gray-800 transition-all">
+                        <div class="flex items-center">
+                            <span class="font-semibold text-gray-900 dark:text-gray-100 group-hover:text-[#e74c3c] transition-colors">GSOC Project Ideas 2023</span>
+                            <i class="fa-solid fa-link ml-auto text-gray-400 dark:text-gray-600 group-hover:text-[#e74c3c]"></i>
+                        </div>
+                    </a>
+                    <a href="https://owasp.org/www-community/initiatives/gsoc/gsoc2022ideas"
+                       target="_blank"
+                       rel="noopener noreferrer"
+                       class="group block p-5 bg-white dark:bg-gray-800 shadow-md rounded-lg border border-gray-100 dark:border-gray-800 transition-all">
+                        <div class="flex items-center">
+                            <span class="font-semibold text-gray-900 dark:text-gray-100 group-hover:text-[#e74c3c] transition-colors">GSOC Project Ideas 2022</span>
+                            <i class="fa-solid fa-link ml-auto text-gray-400 dark:text-gray-600 group-hover:text-[#e74c3c]"></i>
+                        </div>
+                    </a>
+                    <a href="https://owasp.org/www-community/initiatives/gsoc/gsoc2021ideas"
+                       target="_blank"
+                       rel="noopener noreferrer"
+                       class="group block p-5 bg-white dark:bg-gray-800 shadow-md rounded-lg border border-gray-100 dark:border-gray-800 transition-all">
+                        <div class="flex items-center">
+                            <span class="font-semibold text-gray-900 dark:text-gray-100 group-hover:text-[#e74c3c] transition-colors">GSOC Project Ideas 2021</span>
+                            <i class="fa-solid fa-link ml-auto text-gray-400 dark:text-gray-600 group-hover:text-[#e74c3c]"></i>
+                        </div>
+                    </a>
+                    <a href="https://owasp.org/www-community/initiatives/gsoc/gsoc2020ideas"
+                       target="_blank"
+                       rel="noopener noreferrer"
+                       class="group block p-5 bg-white dark:bg-gray-800 shadow-md rounded-lg border border-gray-100 dark:border-gray-800 transition-all">
+                        <div class="flex items-center">
+                            <span class="font-semibold text-gray-900 dark:text-gray-100 group-hover:text-[#e74c3c] transition-colors">GSOC Project Ideas 2020</span>
+                            <i class="fa-solid fa-link ml-auto text-gray-400 dark:text-gray-600 group-hover:text-[#e74c3c]"></i>
+                        </div>
+                    </a>
+                    <a href="https://owasp.org/www-community/initiatives/gsoc/gsoc2019ideas"
+                       target="_blank"
+                       rel="noopener noreferrer"
+                       class="group block p-5 bg-white dark:bg-gray-800 shadow-md rounded-lg border border-gray-100 dark:border-gray-800 transition-all">
+                        <div class="flex items-center">
+                            <span class="font-semibold text-gray-900 dark:text-gray-100 group-hover:text-[#e74c3c] transition-colors">GSOC Project Ideas 2019</span>
+                            <i class="fa-solid fa-link ml-auto text-gray-400 dark:text-gray-600 group-hover:text-[#e74c3c]"></i>
+                        </div>
+                    </a>
+                    <a href="https://owasp.org/www-community/initiatives/gsoc/gsoc2018ideas"
+                       target="_blank"
+                       rel="noopener noreferrer"
+                       class="group block p-5 bg-white dark:bg-gray-800 shadow-md rounded-lg border border-gray-100 dark:border-gray-800 transition-all">
+                        <div class="flex items-center">
+                            <span class="font-semibold text-gray-900 dark:text-gray-100 group-hover:text-[#e74c3c] transition-colors">GSOC Project Ideas 2018</span>
+                            <i class="fa-solid fa-link ml-auto text-gray-400 dark:text-gray-600 group-hover:text-[#e74c3c]"></i>
+                        </div>
+                    </a>
+                    <a href="https://owasp.org/www-community/initiatives/gsoc/gsoc2017ideas"
+                       target="_blank"
+                       rel="noopener noreferrer"
+                       class="group block p-5 bg-white dark:bg-gray-800 shadow-md rounded-lg border border-gray-100 dark:border-gray-800 transition-all">
+                        <div class="flex items-center">
+                            <span class="font-semibold text-gray-900 dark:text-gray-100 group-hover:text-[#e74c3c] transition-colors">GSOC Project Ideas 2017</span>
+                            <i class="fa-solid fa-link ml-auto text-gray-400 dark:text-gray-600 group-hover:text-[#e74c3c]"></i>
+                        </div>
+                    </a>
                 </div>
-                <div>
-                  <h4
-                    class="text-lg font-bold text-gray-900 dark:text-gray-100"
-                  >
-                    Vinamra Vaswani
-                  </h4>
-                  <p class="text-sm text-gray-600 dark:text-gray-400">
-                    Backend Systems
-                  </p>
+            </div>
+            <!-- Past Events -->
+            <div class="bg-white dark:bg-gray-800 rounded-xl shadow-lg transition-all duration-300 p-8 mb-20 border border-gray-100 dark:border-gray-800">
+                <h2 class="text-3xl font-bold text-gray-900 dark:text-gray-100 mb-6">Past GSOC Events</h2>
+                <div class="grid grid-cols-1 lg:grid-cols-2 gap-8">
+                    <!-- 2023 -->
+                    <div class="bg-white dark:bg-gray-800 rounded-lg shadow-md transition-all border border-gray-200 dark:border-gray-700 overflow-hidden">
+                        <div class="p-2 bg-[#e74c3c]"></div>
+                        <div class="p-6">
+                            <a href="https://summerofcode.withgoogle.com/archive/2023/organizations/owasp-foundation"
+                               target="_blank"
+                               rel="noopener noreferrer"
+                               class="text-xl font-bold text-gray-900 dark:text-gray-100 hover:text-[#e74c3c] transition-colors flex items-center mb-4">
+                                <i aria-hidden="true" class="fas fa-calendar-alt mr-2 text-[#e74c3c]"></i>
+                                2023 GSOC Archive
+                            </a>
+                            <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4">
+                                <h4 class="text-lg font-semibold text-gray-800 dark:text-gray-200 mb-2 flex items-center">
+                                    <i aria-hidden="true" class="fas fa-users mr-2 text-[#e74c3c]"></i>
+                                    Mentors
+                                </h4>
+                                <p class="text-gray-700 dark:text-gray-300 leading-relaxed">
+                                    Abraham Aranguren, Aryan Prasad, Aryan Ranjan, Ben de Haan,
+                                    Björn Kimminich, Christian Folini, DonnieBLT, fzipitria, Jannik
+                                    Hollenbach, José Carlos Chávez, Mrigank Anand, Rick M,
+                                    ShubhamPalriwala, Simon Bennetts, thc202, Timo Pagel, Viyat
+                                </p>
+                            </div>
+                        </div>
+                    </div>
+                    <!-- 2022 -->
+                    <div class="bg-white dark:bg-gray-800 rounded-lg shadow-md transition-all border border-gray-200 dark:border-gray-700 overflow-hidden">
+                        <div class="p-2 bg-[#e74c3c]"></div>
+                        <div class="p-6">
+                            <a href="https://summerofcode.withgoogle.com/archive/2022/organizations/owasp-foundation"
+                               target="_blank"
+                               rel="noopener noreferrer"
+                               class="text-xl font-bold text-gray-900 dark:text-gray-100 hover:text-[#e74c3c] transition-colors flex items-center mb-4">
+                                <i aria-hidden="true" class="fas fa-calendar-alt mr-2 text-[#e74c3c]"></i>
+                                2022 GSOC Archive
+                            </a>
+                            <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4">
+                                <h4 class="text-lg font-semibold text-gray-800 dark:text-gray-200 mb-2 flex items-center">
+                                    <i aria-hidden="true" class="fas fa-users mr-2 text-[#e74c3c]"></i>
+                                    Mentors
+                                </h4>
+                                <p class="text-gray-700 dark:text-gray-300 leading-relaxed">
+                                    Abraham Aranguren, Ade Yoseman Putra, Ankit Choudhary, Björn
+                                    Kimminich, Dhiren Serai, Franziska, fzipitria, Glenn Ten Cate,
+                                    Jannik Hollenbach, Rejah Rehim, Rick M, Saeed Dehqan, Sam
+                                    Stepanyan, Sparsh Agrawal, thc202, Timo Pagel, Viyat
+                                </p>
+                            </div>
+                        </div>
+                    </div>
+                    <!-- 2021 -->
+                    <div class="bg-white dark:bg-gray-800 rounded-lg shadow-md transition-all border border-gray-200 dark:border-gray-700 overflow-hidden">
+                        <div class="p-2 bg-[#e74c3c]"></div>
+                        <div class="p-6">
+                            <a href="https://summerofcode.withgoogle.com/archive/2021/organizations/owasp-foundation"
+                               target="_blank"
+                               rel="noopener noreferrer"
+                               class="text-xl font-bold text-gray-900 dark:text-gray-100 hover:text-[#e74c3c] transition-colors flex items-center mb-4">
+                                <i aria-hidden="true" class="fas fa-calendar-alt mr-2 text-[#e74c3c]"></i>
+                                2021 GSOC Archive
+                            </a>
+                            <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4">
+                                <h4 class="text-lg font-semibold text-gray-800 dark:text-gray-200 mb-2 flex items-center">
+                                    <i aria-hidden="true" class="fas fa-users mr-2 text-[#e74c3c]"></i>
+                                    Mentors
+                                </h4>
+                                <p class="text-gray-700 dark:text-gray-300 leading-relaxed">
+                                    8f040, Abe, Abraham Aranguren, Ade Yoseman Putra, Ali Razmjoo
+                                    Qalaei, Anshul Singhal, Ashrith N Shetty, Björn Kimminich,
+                                    Damien Carol, Dhiren Devinder Serai, Glenn ten Cate, Jannik
+                                    Hollenbach, madchap, Mohit Sharma-2, Rejah Rehim, Riccardo Cate,
+                                    Rick M, Saeed Dehqan-1, Sam Stepanyan, Simon Bennetts, Sourav
+                                    Badami, thc202
+                                </p>
+                            </div>
+                        </div>
+                    </div>
+                    <!-- 2020 -->
+                    <div class="bg-white dark:bg-gray-800 rounded-lg shadow-md transition-all border border-gray-200 dark:border-gray-700 overflow-hidden">
+                        <div class="p-2 bg-[#e74c3c]"></div>
+                        <div class="p-6">
+                            <a href="https://summerofcode.withgoogle.com/archive/2020/organizations/owasp-foundation"
+                               target="_blank"
+                               rel="noopener noreferrer"
+                               class="text-xl font-bold text-gray-900 dark:text-gray-100 hover:text-[#e74c3c] transition-colors flex items-center mb-4">
+                                <i aria-hidden="true" class="fas fa-calendar-alt mr-2 text-[#e74c3c]"></i>
+                                2020 GSOC Archive
+                            </a>
+                            <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4">
+                                <h4 class="text-lg font-semibold text-gray-800 dark:text-gray-200 mb-2 flex items-center">
+                                    <i aria-hidden="true" class="fas fa-users mr-2 text-[#e74c3c]"></i>
+                                    Mentors
+                                </h4>
+                                <p class="text-gray-700 dark:text-gray-300 leading-relaxed">
+                                    Abe, Abraham Aranguren, Ade Yoseman Putra, Adrian Winckles, Ali
+                                    Razmjoo Qalaei, Björn Kimminich, Felipe Zipitria, Glenn ten
+                                    Cate, Jannik Hollenbach, Mohit Sharma, Rejah Rehim A A, Rejah
+                                    Rehim, Ricardo Pereira, Riccardo ten Cate, Rick M, S,
+                                    securestep9, Simon Bennetts, Soham Marik, souravbadami, spyros,
+                                    Sri Harsha G, Timo Pagel, Viyat Bhalodia
+                                </p>
+                            </div>
+                        </div>
+                    </div>
                 </div>
-              </div>
-              <div class="mentor-description-container">
-                <p
-                  class="text-gray-600 dark:text-gray-400 text-base leading-relaxed mentor-description-text"
-                >
-                  I am a software engineer experienced in building
-                  production-grade backend systems using Python, FastAPI, and
-                  MongoDB, with a focus on clean architecture and real-world
-                  problem solving. Through open-source style projects and
-                  mentorship programs, I have guided juniors in working with
-                  real codebases, collaborative workflows, and maintainable
-                  engineering practices. As a GSoC mentor, my goal is to help
-                  students move from tutorials to confident real-world
-                  contributors, while giving back to open source by supporting
-                  their technical and professional growth in a learning-first
-                  environment.
-                </p>
-              </div>
             </div>
-            <!-- Carla Voorhees -->
-            <div
-              class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4 border border-gray-200 dark:border-gray-700"
-            >
-              <div class="flex items-center gap-3 mb-3">
-                <div
-                  class="w-10 h-10 bg-red-100 rounded-full flex items-center justify-center"
-                >
-                  <i class="fas fa-code text-[#e74c3c] text-sm"></i>
+            <!-- Success Stories -->
+            <div class="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-100 dark:border-gray-800 p-8 mb-12">
+                <h2 class="text-3xl font-bold text-gray-900 dark:text-gray-100 mb-2 text-center">Success Stories</h2>
+                <div class="w-20 h-1 bg-[#e74c3c] mx-auto mb-8 rounded-full"></div>
+                <div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
+                    <!-- Shirish Jain -->
+                    <div class="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md border border-gray-100 dark:border-gray-800">
+                        <div class="flex items-center gap-4 mb-6">
+                            <div class="w-16 h-16 bg-red-100 rounded-full flex items-center justify-center">
+                                <i class="fas fa-code text-[#e74c3c] text-2xl"></i>
+                            </div>
+                            <div>
+                                <h3 class="text-2xl font-semibold">Shirish Jain</h3>
+                                <p class="text-gray-600 dark:text-gray-400">GSoC 2023</p>
+                            </div>
+                        </div>
+                        <p class="text-gray-700 dark:text-gray-300 mb-6 text-lg">
+                            Successfully implemented the Sizzle Time Tracking feature during
+                            GSoC 2023.
+                        </p>
+                        <div class="flex gap-4">
+                            <a href="https://medium.com/@shirishjain.2001/gsoc-2023-final-report-owasp-bug-logging-tool-f70d6368f9f5"
+                               class="flex-1 hover:text-white bg-[#e74c3c] text-white py-2 px-4 rounded-lg hover:bg-red-700 transition-colors text-center flex items-center justify-center gap-2">
+                                <i class="fas fa-book-open"></i>
+                                <span>Read Blog</span>
+                            </a>
+                            <a href="https://blt.owasp.org/contributors/?contributor=37"
+                               class="flex-1 border-2 border-[#e74c3c] text-[#e74c3c] py-2 px-4 rounded-lg hover:bg-[#e74c3c] hover:text-white transition-colors text-center flex items-center justify-center gap-2">
+                                <i class="fas fa-user"></i>
+                                <span>Profile</span>
+                            </a>
+                        </div>
+                    </div>
+                    <!-- Aryan Ranjan -->
+                    <div class="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md border border-gray-100 dark:border-gray-800">
+                        <div class="flex items-center gap-4 mb-6">
+                            <div class="w-16 h-16 bg-red-100 rounded-full flex items-center justify-center">
+                                <i class="fas fa-comments text-[#e74c3c] text-2xl"></i>
+                            </div>
+                            <div>
+                                <h3 class="text-2xl font-semibold">Aryan Ranjan</h3>
+                                <p class="text-gray-600 dark:text-gray-400">GSoC 2023</p>
+                            </div>
+                        </div>
+                        <p class="text-gray-700 dark:text-gray-300 mb-6 text-lg">Developed the Discussion Room feature during GSoC 2023.</p>
+                        <div class="flex gap-4">
+                            <a href="https://medium.com/@justary27/my-gsoc22-voyage-beginning-4296df5af625"
+                               class="flex-1 hover:text-white bg-[#e74c3c] text-white py-2 px-4 rounded-lg hover:bg-red-700 transition-colors text-center flex items-center justify-center gap-2">
+                                <i class="fas fa-book-open"></i>
+                                <span>Read Blog</span>
+                            </a>
+                            <a href="https://blt.owasp.org/contributors/?contributor=1"
+                               class="flex-1 border-2 border-[#e74c3c] text-[#e74c3c] py-2 px-4 rounded-lg hover:bg-[#e74c3c] hover:text-white transition-colors text-center flex items-center justify-center gap-2">
+                                <i class="fas fa-user"></i>
+                                <span>Profile</span>
+                            </a>
+                        </div>
+                    </div>
+                    <!-- Swapnil Shinde -->
+                    <div class="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md border border-gray-100 dark:border-gray-800">
+                        <div class="flex items-center gap-4 mb-6">
+                            <div class="w-16 h-16 bg-red-100 rounded-full flex items-center justify-center">
+                                <i class="fas fa-bug text-[#e74c3c] text-2xl"></i>
+                            </div>
+                            <div>
+                                <h3 class="text-2xl font-semibold">Swapnil Shinde</h3>
+                                <p class="text-gray-600 dark:text-gray-400">GSoC 2022</p>
+                            </div>
+                        </div>
+                        <p class="text-gray-700 dark:text-gray-300 mb-6 text-lg">Contributed to OWASP BLT development.</p>
+                        <div class="flex gap-4">
+                            <a href="https://gist.github.com/AtmegaBuzz/512a85827b5cc993e35c274dcbada669"
+                               class="flex-1 hover:text-white bg-[#e74c3c] text-white py-2 px-4 rounded-lg hover:bg-red-700 transition-colors text-center flex items-center justify-center gap-2">
+                                <i class="fas fa-file-alt"></i>
+                                <span>Report</span>
+                            </a>
+                            <a href="https://blt.owasp.org/contributors/?contributor=3"
+                               class="flex-1 border-2 border-[#e74c3c] text-[#e74c3c] py-2 px-4 rounded-lg hover:bg-[#e74c3c] hover:text-white transition-colors text-center flex items-center justify-center gap-2">
+                                <i class="fas fa-user"></i>
+                                <span>Profile</span>
+                            </a>
+                        </div>
+                    </div>
+                    <!-- Bishal Das -->
+                    <div class="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md border border-gray-100 dark:border-gray-800">
+                        <div class="flex items-center gap-4 mb-6">
+                            <div class="w-16 h-16 bg-red-100 rounded-full flex items-center justify-center">
+                                <i class="fas fa-graduation-cap text-[#e74c3c] text-2xl"></i>
+                            </div>
+                            <div>
+                                <h3 class="text-2xl font-semibold">Bishal Das</h3>
+                                <p class="text-gray-600 dark:text-gray-400">GSoC 2024</p>
+                            </div>
+                        </div>
+                        <p class="text-gray-700 dark:text-gray-300 mb-6 text-lg">GSoC Learning journey with OWASP BLT.</p>
+                        <div class="flex gap-4">
+                            <a href="https://bishaldas.hashnode.dev/gsoc-2024-a-summer-of-learning-coding-and-growth"
+                               class="flex-1 hover:text-white bg-[#e74c3c] text-white py-2 px-4 rounded-lg hover:bg-red-700 transition-colors text-center flex items-center justify-center gap-2">
+                                <i class="fas fa-book-open"></i>
+                                <span>Read Blog</span>
+                            </a>
+                            <a href="https://blt.owasp.org/contributors/?contributor=5"
+                               class="flex-1 border-2 border-[#e74c3c] text-[#e74c3c] py-2 px-4 rounded-lg hover:bg-[#e74c3c] hover:text-white transition-colors text-center flex items-center justify-center gap-2">
+                                <i class="fas fa-user"></i>
+                                <span>Profile</span>
+                            </a>
+                        </div>
+                    </div>
+                    <!-- Shubham Palriwala -->
+                    <div class="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md border border-gray-100 dark:border-gray-800">
+                        <div class="flex items-center gap-4 mb-6">
+                            <div class="w-16 h-16 bg-red-100 rounded-full flex items-center justify-center">
+                                <i class="fas fa-flask text-[#e74c3c] text-2xl"></i>
+                            </div>
+                            <div>
+                                <h3 class="text-2xl font-semibold">Shubham Palriwala</h3>
+                                <p class="text-gray-600 dark:text-gray-400">OWASP Juice Shop</p>
+                            </div>
+                        </div>
+                        <p class="text-gray-700 dark:text-gray-300 mb-6 text-lg">OWASP Juice Shop Journey</p>
+                        <div class="flex gap-4">
+                            <a href="https://medium.com/@shubhampalriwala/google-summer-of-code-journey-with-owasp-juice-shop-c1ca15c8e170"
+                               class="flex-1 hover:text-white bg-[#e74c3c] text-white py-2 px-4 rounded-lg hover:bg-red-700 transition-colors text-center flex items-center justify-center gap-2">
+                                <i class="fas fa-book-open"></i>
+                                <span>Read Blog</span>
+                            </a>
+                        </div>
+                    </div>
+                    <!-- Akshay Behl -->
+                    <div class="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md border border-gray-100 dark:border-gray-800">
+                        <div class="flex items-center gap-4 mb-6">
+                            <div class="w-16 h-16 bg-red-100 rounded-full flex items-center justify-center">
+                                <i class="fas fa-network-wired text-[#e74c3c] text-2xl"></i>
+                            </div>
+                            <div>
+                                <h3 class="text-2xl font-semibold">Akshay Behl</h3>
+                                <p class="text-gray-600 dark:text-gray-400">OWASP Nettacker</p>
+                            </div>
+                        </div>
+                        <p class="text-gray-700 dark:text-gray-300 mb-6 text-lg">OWASP Nettacker Experience</p>
+                        <div class="flex gap-4">
+                            <a href="https://medium.com/@akshaybehl231/diving-into-open-source-owasp-nettacker-gsoc24-e73114f37a11"
+                               class="flex-1 hover:text-white bg-[#e74c3c] text-white py-2 px-4 rounded-lg hover:bg-red-700 transition-colors text-center flex items-center justify-center gap-2">
+                                <i class="fas fa-book-open"></i>
+                                <span>Read Blog</span>
+                            </a>
+                        </div>
+                    </div>
+                    <!-- Chakshu Gupta -->
+                    <div class="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md border border-gray-100 dark:border-gray-800">
+                        <div class="flex items-center gap-4 mb-6">
+                            <div class="w-16 h-16 bg-red-100 rounded-full flex items-center justify-center">
+                                <i class="fas fa-shield-alt text-[#e74c3c] text-2xl"></i>
+                            </div>
+                            <div>
+                                <h3 class="text-2xl font-semibold">Chakshu Gupta</h3>
+                                <p class="text-gray-600 dark:text-gray-400">OWASP Honeypot Project</p>
+                            </div>
+                        </div>
+                        <p class="text-gray-700 dark:text-gray-300 mb-6 text-lg">OWASP Honeypot Project Journey</p>
+                        <div class="flex gap-4">
+                            <a href="https://medium.com/@ChGDream/my-google-summer-of-code-2020-journey-with-owasp-b772c3e67c3f"
+                               class="flex-1 hover:text-white bg-[#e74c3c] text-white py-2 px-4 rounded-lg hover:bg-red-700 transition-colors text-center flex items-center justify-center gap-2">
+                                <i class="fas fa-book-open"></i>
+                                <span>Read Blog</span>
+                            </a>
+                        </div>
+                    </div>
+                    <!-- Rishabh Keshan -->
+                    <div class="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md border border-gray-100 dark:border-gray-800">
+                        <div class="flex items-center gap-4 mb-6">
+                            <div class="w-16 h-16 bg-red-100 rounded-full flex items-center justify-center">
+                                <i class="fas fa-cube text-[#e74c3c] text-2xl"></i>
+                            </div>
+                            <div>
+                                <h3 class="text-2xl font-semibold">Rishabh Keshan</h3>
+                                <p class="text-gray-600 dark:text-gray-400">Web3 Juice Shop</p>
+                            </div>
+                        </div>
+                        <p class="text-gray-700 dark:text-gray-300 mb-6 text-lg">Web3 Journey with Juice Shop</p>
+                        <div class="flex gap-4">
+                            <a href="https://medium.com/@ChGDream/my-google-summer-of-code-2020-journey-with-owasp-b772c3e67c3f"
+                               class="flex-1 hover:text-white bg-[#e74c3c] text-white py-2 px-4 rounded-lg hover:bg-red-700 transition-colors text-center flex items-center justify-center gap-2">
+                                <i class="fas fa-book-open"></i>
+                                <span>Read Blog</span>
+                            </a>
+                        </div>
+                    </div>
                 </div>
-                <div>
-                  <h4
-                    class="text-lg font-bold text-gray-900 dark:text-gray-100"
-                  >
-                    Carla Voorhees
-                  </h4>
-                  <p class="text-sm text-gray-600 dark:text-gray-400">
-                    Technical Product Manager
-                  </p>
+            </div>
+            <!-- GSoC 2026 Students Section -->
+            <div class="mb-20">
+                <h2 class="text-3xl font-bold text-center text-gray-900 dark:text-gray-100 mb-2">2026 Contributors</h2>
+                <div class="w-20 h-1 bg-[#e74c3c] mx-auto mb-12 rounded-full"></div>
+                <div class="flex items-start space-x-6 mb-8">
+                    <div class="bg-red-100 rounded-full p-3 flex-shrink-0">
+                        <i class="fas fa-star text-[#e74c3c] text-xl"></i>
+                    </div>
+                    <div>
+                        <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100 mb-2">Lead Mentor</h3>
+                        <p class="text-lg text-gray-800 dark:text-gray-200 font-medium mb-1">Donnie Brown (All years)</p>
+                    </div>
                 </div>
-              </div>
-              <div class="mentor-description-container">
-                <p
-                  class="text-gray-600 dark:text-gray-400 text-base leading-relaxed mentor-description-text"
-                >
-                  I am a technical product manager with a background in
-                  cybersecurity and data management. I have experience mentoring
-                  students, helping them navigate complex requirements and
-                  understand best practices. I focus on guiding students through
-                  the product development lifecycle, from ideation to
-                  deployment, while fostering a collaborative and inclusive
-                  learning environment. I help them to understand how to take
-                  requirements and designs and turn them into working code. My
-                  goal is to empower students to become confident contributors
-                  to open source communities.
-                </p>
-              </div>
-            </div>
-          </div>
-        </div>
-        <!-- Siddharth Bansal -->
-        <div
-          class="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-100 dark:border-gray-800 p-8"
-        >
-          <div class="flex items-center gap-6 mb-6">
-            <div
-              class="w-20 h-20 bg-red-100 rounded-full flex items-center justify-center"
-            >
-              <i class="fab fa-github text-[#e74c3c] text-3xl"></i>
-            </div>
-            <div class="flex-1">
-              <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100">
-                Siddharth Bansal
-              </h3>
-              <p class="text-lg text-gray-600 dark:text-gray-400 mb-2">
-                2026 Contributor
-              </p>
-              <div class="flex gap-4">
-                <a
-                  href="https://github.com/sidd190"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  class="inline-flex items-center px-4 py-2 bg-[#e74c3c] text-white rounded-lg hover:bg-red-700 transition-colors"
-                >
-                  <i class="fab fa-github mr-2"></i>
-                  GitHub Profile
-                </a>
-                <a
-                  href="https://sidd190.github.io/MY-GSOC-TOOL/"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  class="inline-flex items-center px-4 py-2 border-2 border-[#e74c3c] text-[#e74c3c] rounded-lg hover:bg-[#e74c3c] hover:text-white transition-colors"
-                >
-                  <i class="fas fa-tools mr-2"></i>
-                  GSoC-Tool
-                </a>
-              </div>
-            </div>
-          </div>
-          <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-            <!-- Jigyasu Rajput -->
-            <div
-              class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4 border border-gray-200 dark:border-gray-700"
-            >
-              <div class="flex items-center gap-3 mb-3">
-                <div
-                  class="w-10 h-10 bg-red-100 rounded-full flex items-center justify-center"
-                >
-                  <i class="fas fa-code text-[#e74c3c] text-sm"></i>
+                <div class="space-y-8">
+                    <!-- Md Kaif Ansari -->
+                    <div class="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-100 dark:border-gray-800 p-8">
+                        <div class="flex items-center gap-6 mb-6">
+                            <div class="w-20 h-20 bg-red-100 rounded-full flex items-center justify-center">
+                                <i class="fab fa-github text-[#e74c3c] text-3xl"></i>
+                            </div>
+                            <div class="flex-1">
+                                <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100">Md Kaif Ansari</h3>
+                                <p class="text-lg text-gray-600 dark:text-gray-400 mb-2">2026 Contributor</p>
+                                <div class="flex gap-4">
+                                    <a href="https://github.com/mdkaifansari04"
+                                       target="_blank"
+                                       rel="noopener noreferrer"
+                                       class="inline-flex items-center px-4 py-2 bg-[#e74c3c] text-white rounded-lg hover:bg-red-700 transition-colors">
+                                        <i class="fab fa-github mr-2"></i>
+                                        GitHub Profile
+                                    </a>
+                                    <a href="https://mdkaifansari04.github.io/MY-GSOC-TOOL/"
+                                       target="_blank"
+                                       rel="noopener noreferrer"
+                                       class="inline-flex items-center px-4 py-2 border-2 border-[#e74c3c] text-[#e74c3c] rounded-lg hover:bg-[#e74c3c] hover:text-white transition-colors">
+                                        <i class="fas fa-tools mr-2"></i>
+                                        GSoC-Tool
+                                    </a>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+                            <!-- Rinkit Adhana -->
+                            <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4 border border-gray-200 dark:border-gray-700">
+                                <div class="flex items-center gap-3 mb-3">
+                                    <div class="w-10 h-10 bg-red-100 rounded-full flex items-center justify-center">
+                                        <i class="fas fa-code text-[#e74c3c] text-sm"></i>
+                                    </div>
+                                    <div>
+                                        <h4 class="text-lg font-bold text-gray-900 dark:text-gray-100">Rinkit Adhana</h4>
+                                        <p class="text-sm text-gray-600 dark:text-gray-400">Full Stack Development</p>
+                                    </div>
+                                </div>
+                                <div class="mentor-description-container">
+                                    <p class="text-gray-600 dark:text-gray-400 text-base leading-relaxed mentor-description-text">
+                                        As a full stack engineer and active BLT contributor, I bring
+                                        hands-on experience from both sides of the development
+                                        process. Having participated in GSoC 2025, I understand the
+                                        challenges new contributors face and can guide you through
+                                        your open source journey. I specialize in helping developers
+                                        build scalable web applications, navigate complex codebases,
+                                        and contribute effectively to real-world projects. My goal is
+                                        to share practical knowledge and help you grow as a developer
+                                        while making meaningful contributions to BLT.
+                                    </p>
+                                </div>
+                            </div>
+                            <!-- Raj Gupta -->
+                            <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4 border border-gray-200 dark:border-gray-700">
+                                <div class="flex items-center gap-3 mb-3">
+                                    <div class="w-10 h-10 bg-red-100 rounded-full flex items-center justify-center">
+                                        <i class="fas fa-code text-[#e74c3c] text-sm"></i>
+                                    </div>
+                                    <div>
+                                        <h4 class="text-lg font-bold text-gray-900 dark:text-gray-100">Raj Gupta</h4>
+                                        <p class="text-sm text-gray-600 dark:text-gray-400">Full Stack Development mentor</p>
+                                    </div>
+                                </div>
+                                <div class="mentor-description-container">
+                                    <p class="text-gray-600 dark:text-gray-400 text-base leading-relaxed mentor-description-text">
+                                        I’m a full stack developer with prior Google Summer of Code (GSoC)
+                                        experience and a strong passion for open source. Having worked as a
+                                        contributor, I understand the challenges of getting started - from
+                                        reading large codebases to making meaningful pull requests. As a
+                                        mentor, I enjoy guiding contributors through best practices, code
+                                        reviews, and real-world problem solving. I continue to actively
+                                        contribute to open source because I believe collaboration and
+                                        knowledge sharing are what truly drive impactful software.
+                                    </p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <!-- Preetham -->
+                    <div class="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-100 dark:border-gray-800 p-8">
+                        <div class="flex items-center gap-6 mb-6">
+                            <div class="w-20 h-20 bg-red-100 rounded-full flex items-center justify-center">
+                                <i class="fab fa-github text-[#e74c3c] text-3xl"></i>
+                            </div>
+                            <div class="flex-1">
+                                <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100">Preetham</h3>
+                                <p class="text-lg text-gray-600 dark:text-gray-400 mb-2">2026 Contributor</p>
+                                <div class="flex gap-4">
+                                    <a href="https://github.com/Pritz395"
+                                       target="_blank"
+                                       rel="noopener noreferrer"
+                                       class="inline-flex items-center px-4 py-2 bg-[#e74c3c] text-white rounded-lg hover:bg-red-700 transition-colors">
+                                        <i class="fab fa-github mr-2"></i>
+                                        GitHub Profile
+                                    </a>
+                                    <a href="https://Pritz395.github.io/MY-GSOC-TOOL/"
+                                       target="_blank"
+                                       rel="noopener noreferrer"
+                                       class="inline-flex items-center px-4 py-2 border-2 border-[#e74c3c] text-[#e74c3c] rounded-lg hover:bg-[#e74c3c] hover:text-white transition-colors">
+                                        <i class="fas fa-tools mr-2"></i>
+                                        GSoC-Tool
+                                    </a>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+                            <!-- Vinamra Vaswani -->
+                            <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4 border border-gray-200 dark:border-gray-700">
+                                <div class="flex items-center gap-3 mb-3">
+                                    <div class="w-10 h-10 bg-red-100 rounded-full flex items-center justify-center">
+                                        <i class="fas fa-code text-[#e74c3c] text-sm"></i>
+                                    </div>
+                                    <div>
+                                        <h4 class="text-lg font-bold text-gray-900 dark:text-gray-100">Vinamra Vaswani</h4>
+                                        <p class="text-sm text-gray-600 dark:text-gray-400">Backend Systems</p>
+                                    </div>
+                                </div>
+                                <div class="mentor-description-container">
+                                    <p class="text-gray-600 dark:text-gray-400 text-base leading-relaxed mentor-description-text">
+                                        I am a software engineer experienced in building
+                                        production-grade backend systems using Python, FastAPI, and
+                                        MongoDB, with a focus on clean architecture and real-world
+                                        problem solving. Through open-source style projects and
+                                        mentorship programs, I have guided juniors in working with
+                                        real codebases, collaborative workflows, and maintainable
+                                        engineering practices. As a GSoC mentor, my goal is to help
+                                        students move from tutorials to confident real-world
+                                        contributors, while giving back to open source by supporting
+                                        their technical and professional growth in a learning-first
+                                        environment.
+                                    </p>
+                                </div>
+                            </div>
+                            <!-- Carla Voorhees -->
+                            <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4 border border-gray-200 dark:border-gray-700">
+                                <div class="flex items-center gap-3 mb-3">
+                                    <div class="w-10 h-10 bg-red-100 rounded-full flex items-center justify-center">
+                                        <i class="fas fa-code text-[#e74c3c] text-sm"></i>
+                                    </div>
+                                    <div>
+                                        <h4 class="text-lg font-bold text-gray-900 dark:text-gray-100">Carla Voorhees</h4>
+                                        <p class="text-sm text-gray-600 dark:text-gray-400">Technical Product Manager</p>
+                                    </div>
+                                </div>
+                                <div class="mentor-description-container">
+                                    <p class="text-gray-600 dark:text-gray-400 text-base leading-relaxed mentor-description-text">
+                                        I am a technical product manager with a background in cybersecurity
+                                        and data management. I have experience mentoring students,
+                                        helping them navigate complex requirements and understand best practices.
+                                        I focus on guiding students through the product development lifecycle,
+                                        from ideation to deployment, while fostering a collaborative and
+                                        inclusive learning environment. I help them to understand how to take
+                                        requirements and designs and turn them into working code. My goal is to empower
+                                        students to become confident contributors to open source communities.
+                                    </p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <!-- Siddharth Bansal -->
+                    <div class="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-100 dark:border-gray-800 p-8">
+                        <div class="flex items-center gap-6 mb-6">
+                            <div class="w-20 h-20 bg-red-100 rounded-full flex items-center justify-center">
+                                <i class="fab fa-github text-[#e74c3c] text-3xl"></i>
+                            </div>
+                            <div class="flex-1">
+                                <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100">Siddharth Bansal</h3>
+                                <p class="text-lg text-gray-600 dark:text-gray-400 mb-2">2026 Contributor</p>
+                                <div class="flex gap-4">
+                                    <a href="https://github.com/sidd190"
+                                       target="_blank"
+                                       rel="noopener noreferrer"
+                                       class="inline-flex items-center px-4 py-2 bg-[#e74c3c] text-white rounded-lg hover:bg-red-700 transition-colors">
+                                        <i class="fab fa-github mr-2"></i>
+                                        GitHub Profile
+                                    </a>
+                                    <a href="https://sidd190.github.io/MY-GSOC-TOOL/"
+                                       target="_blank"
+                                       rel="noopener noreferrer"
+                                       class="inline-flex items-center px-4 py-2 border-2 border-[#e74c3c] text-[#e74c3c] rounded-lg hover:bg-[#e74c3c] hover:text-white transition-colors">
+                                        <i class="fas fa-tools mr-2"></i>
+                                        GSoC-Tool
+                                    </a>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+                            <!-- Jigyasu Rajput -->
+                            <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4 border border-gray-200 dark:border-gray-700">
+                                <div class="flex items-center gap-3 mb-3">
+                                    <div class="w-10 h-10 bg-red-100 rounded-full flex items-center justify-center">
+                                        <i class="fas fa-code text-[#e74c3c] text-sm"></i>
+                                    </div>
+                                    <div>
+                                        <h4 class="text-lg font-bold text-gray-900 dark:text-gray-100">Jigyasu Rajput</h4>
+                                        <p class="text-sm text-gray-600 dark:text-gray-400">Full Stack Development</p>
+                                    </div>
+                                </div>
+                                <div class="mentor-description-container">
+                                    <p class="text-gray-600 dark:text-gray-400 text-base leading-relaxed mentor-description-text">
+                                        I'm a full-stack developer with prior GSoC experience and a
+                                        deep love for open source. Having been a contributor myself, I
+                                        know how overwhelming it can feel at the start — from
+                                        understanding huge codebases to shipping your first meaningful
+                                        PR. As a mentor, I focus on helping people build confidence
+                                        through clean practices, thoughtful code reviews, and
+                                        real-world problem solving. I stay active in open source
+                                        because collaboration and shared learning are what actually
+                                        move great software forward.
+                                    </p>
+                                </div>
+                            </div>
+                            <!-- Rishab Kumar Jha -->
+                            <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4 border border-gray-200 dark:border-gray-700">
+                                <div class="flex items-center gap-3 mb-3">
+                                    <div class="w-10 h-10 bg-red-100 rounded-full flex items-center justify-center">
+                                        <i class="fas fa-code text-[#e74c3c] text-sm"></i>
+                                    </div>
+                                    <div>
+                                        <h4 class="text-lg font-bold text-gray-900 dark:text-gray-100">Rishab Kumar Jha</h4>
+                                        <p class="text-sm text-gray-600 dark:text-gray-400">Full Stack/Blockchain</p>
+                                    </div>
+                                </div>
+                                <div class="mentor-description-container">
+                                    <p class="text-gray-600 dark:text-gray-400 text-base leading-relaxed mentor-description-text">
+                                        I'm a software developer interested in distributed systems,
+                                        web3, cloud native technologies & deep-tech. As a past GSoC
+                                        and LFX alumnus myself, I understand the pain points of new
+                                        contributors. Happy to mentor and help mentees navigate
+                                        open-source effectively.
+                                    </p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <!-- Manahil Afzal -->
+                      <div class="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-100 dark:border-gray-800 p-8">
+                        <div class="flex items-center gap-6 mb-6">
+                            <div class="w-20 h-20 bg-red-100 rounded-full flex items-center justify-center">
+                                <i class="fab fa-github text-[#e74c3c] text-3xl"></i>
+                            </div>
+                            <div class="flex-1">
+                                <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100">Manahil Afzal</h3>
+                                <p class="text-lg text-gray-600 dark:text-gray-400 mb-2">MERN Stack Engineer / 2026 Contributor</p>
+                                <p class="text-gray-600 dark:text-gray-400 mb-4 text-sm">
+                                    Passionate about building meaningful web applications. Exploring cloud, AI, and open source programs like GSoC & Outreachy. Interested in contributing to organizations like OWASP Foundation & Apache.
+                                </p>
+                                <div class="flex gap-4">
+                                    <a href="https://github.com/Manahil-Afzal"
+                                       target="_blank"
+                                       rel="noopener noreferrer"
+                                       class="inline-flex items-center px-4 py-2 bg-[#e74c3c] text-white rounded-lg hover:bg-red-700 transition-colors">
+                                        <i class="fab fa-github mr-2"></i>
+                                        GitHub Profile
+                                    </a>
+                                    <a href="https://manahil-afzal.github.io/MY-GSOC-TOOL/"
+                                       target="_blank"
+                                       rel="noopener noreferrer"
+                                       class="inline-flex items-center px-4 py-2 border-2 border-[#e74c3c] text-[#e74c3c] rounded-lg hover:bg-[#e74c3c] hover:text-white transition-colors">
+                                        <i class="fas fa-tools mr-2"></i>
+                                        GSoC-Tool
+                                    </a>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <!-- Sakshee Suman -->
+                    <div class="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-100 dark:border-gray-800 p-8">
+                        <div class="flex items-center gap-6 mb-6">
+                            <div class="w-20 h-20 bg-red-100 rounded-full flex items-center justify-center">
+                                <i class="fab fa-github text-[#e74c3c] text-3xl"></i>
+                            </div>
+                            <div class="flex-1">
+                                <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100">Sakshee Suman</h3>
+                                <p class="text-lg text-gray-600 dark:text-gray-400 mb-2">2026 Contributor</p>
+                                <div class="flex gap-4">
+                                    <a href="https://github.com/e-esakman"
+                                       target="_blank"
+                                       rel="noopener noreferrer"
+                                       class="inline-flex items-center px-4 py-2 bg-[#e74c3c] text-white rounded-lg hover:bg-red-700 transition-colors">
+                                        <i class="fab fa-github mr-2"></i>
+                                        GitHub Profile
+                                    </a>
+                                    <a href="https://e-esakman.github.io/MY-GSOC-TOOL/"
+                                       target="_blank"
+                                       rel="noopener noreferrer"
+                                       class="inline-flex items-center px-4 py-2 border-2 border-[#e74c3c] text-[#e74c3c] rounded-lg hover:bg-[#e74c3c] hover:text-white transition-colors">
+                                        <i class="fas fa-tools mr-2"></i>
+                                        GSoC-Tool
+                                    </a>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <!-- Arnav Kirti -->
+                    <div class="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-100 dark:border-gray-800 p-8">
+                        <div class="flex items-center gap-6 mb-6">
+                            <div class="w-20 h-20 bg-red-100 rounded-full flex items-center justify-center">
+                                <i class="fab fa-github text-[#e74c3c] text-3xl"></i>
+                            </div>
+                            <div class="flex-1">
+                                <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100">Arnav Kirti</h3>
+                                <p class="text-lg text-gray-600 dark:text-gray-400 mb-2">2026 Contributor</p>
+                                <div class="flex gap-4">
+                                    <a href="https://github.com/arnavkirti"
+                                       target="_blank"
+                                       rel="noopener noreferrer"
+                                       class="inline-flex items-center px-4 py-2 bg-[#e74c3c] text-white rounded-lg hover:bg-red-700 transition-colors">
+                                        <i class="fab fa-github mr-2"></i>
+                                        GitHub Profile
+                                    </a>
+                                    <a href="https://arnavkirti.github.io/MY-GSOC-TOOL/"
+                                       target="_blank"
+                                       rel="noopener noreferrer"
+                                       class="inline-flex items-center px-4 py-2 border-2 border-[#e74c3c] text-[#e74c3c] rounded-lg hover:bg-[#e74c3c] hover:text-white transition-colors">
+                                        <i class="fas fa-tools mr-2"></i>
+                                        GSoC-Tool
+                                    </a>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <!-- Savio D'souza -->
+                    <div class="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-100 dark:border-gray-800 p-8">
+                        <div class="flex items-center gap-6 mb-6">
+                            <div class="w-20 h-20 bg-red-100 rounded-full flex items-center justify-center">
+                                <i class="fab fa-github text-[#e74c3c] text-3xl"></i>
+                            </div>
+                            <div class="flex-1">
+                                <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100">Savio D'souza</h3>
+                                <p class="text-lg text-gray-600 dark:text-gray-400 mb-2">2026 Contributor</p>
+                                <div class="flex gap-4">
+                                    <a href="https://github.com/S3DFX-CYBER"
+                                       target="_blank"
+                                       rel="noopener noreferrer"
+                                       class="inline-flex items-center px-4 py-2 bg-[#e74c3c] text-white rounded-lg hover:bg-red-700 transition-colors">
+                                        <i class="fab fa-github mr-2"></i>
+                                        GitHub Profile
+                                    </a>
+                                    <a href="https://S3DFX-CYBER.github.io/MY-GSOC-TOOL/"
+                                       target="_blank"
+                                       rel="noopener noreferrer"
+                                       class="inline-flex items-center px-4 py-2 border-2 border-[#e74c3c] text-[#e74c3c] rounded-lg hover:bg-[#e74c3c] hover:text-white transition-colors">
+                                        <i class="fas fa-tools mr-2"></i>
+                                        GSoC-Tool
+                                    </a>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <!-- Jayant Malvi -->
+                    <div class="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-100 dark:border-gray-800 p-8">
+                        <div class="flex items-center gap-6 mb-6">
+                            <div class="w-20 h-20 bg-red-100 rounded-full flex items-center justify-center">
+                                <i class="fab fa-github text-[#e74c3c] text-3xl"></i>
+                            </div>
+                            <div class="flex-1">
+                                <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100">Jayant Malvi</h3>
+                                <p class="text-lg text-gray-600 dark:text-gray-400 mb-2">2026 Contributor</p>
+                                <div class="flex gap-4">
+                                    <a href="https://github.com/Jayant2908"
+                                       target="_blank"
+                                       rel="noopener noreferrer"
+                                       class="inline-flex items-center px-4 py-2 bg-[#e74c3c] text-white rounded-lg hover:bg-red-700 transition-colors">
+                                        <i class="fab fa-github mr-2"></i>
+                                        GitHub Profile
+                                    </a>
+                                    <a href="https://Jayant2908.github.io/MY-GSOC-TOOL/"
+                                       target="_blank"
+                                       rel="noopener noreferrer"
+                                       class="inline-flex items-center px-4 py-2 border-2 border-[#e74c3c] text-[#e74c3c] rounded-lg hover:bg-[#e74c3c] hover:text-white transition-colors">
+                                        <i class="fas fa-tools mr-2"></i>
+                                        GSoC-Tool
+                                    </a>
+                                </div>
+                            </div>
+                        </div>
+                        <!-- Mentors grid -->
+                        <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+                            <!-- Manikandan Chandran -->
+                            <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4 border border-gray-200 dark:border-gray-700">
+                                <div class="flex items-center gap-3 mb-3">
+                                    <div class="w-10 h-10 bg-red-100 rounded-full flex items-center justify-center">
+                                        <i class="fas fa-code text-[#e74c3c] text-sm"></i>
+                                    </div>
+                                    <div>
+                                        <h4 class="text-lg font-bold text-gray-900 dark:text-gray-100">Manikandan Chandran</h4>
+                                        <p class="text-sm text-gray-600 dark:text-gray-400">React/OAuth/REST API</p>
+                                    </div>
+                                </div>
+                                <div class="mentor-description-container">
+                                    <p class="text-gray-600 dark:text-gray-400 text-base leading-relaxed mentor-description-text">
+                                        Mentors teams on building secure React apps with real-world OAuth flows and robust REST APIs.
+                                    </p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
                 </div>
-                <div>
-                  <h4
-                    class="text-lg font-bold text-gray-900 dark:text-gray-100"
-                  >
-                    Jigyasu Rajput
-                  </h4>
-                  <p class="text-sm text-gray-600 dark:text-gray-400">
-                    Full Stack Development
-                  </p>
+                <!-- Available Mentors Section -->
+                <div class="mt-16 bg-gray-50 dark:bg-gray-900 rounded-xl p-8 border border-gray-200 dark:border-gray-700">
+                    <h3 class="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-6 text-center">
+                        Available Mentors for Future Students
+                    </h3>
+                    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                        <!-- Manikandan Chandran -->
+                        <div class="bg-white dark:bg-gray-800 rounded-lg p-6 border border-gray-200 dark:border-gray-700">
+                            <div class="flex items-center gap-3 mb-3">
+                                <div class="w-12 h-12 bg-red-100 rounded-full flex items-center justify-center">
+                                    <i class="fas fa-chalkboard-teacher text-[#e74c3c] text-lg"></i>
+                                </div>
+                                <div>
+                                    <h4 class="text-lg font-bold text-gray-900 dark:text-gray-100">Manikandan Chandran</h4>
+                                    <p class="text-sm text-gray-600 dark:text-gray-400">React/OAuth/REST API</p>
+                                </div>
+                            </div>
+                            <p class="text-gray-600 dark:text-gray-400 text-sm">
+                                Mentors teams on building secure React apps with real-world OAuth
+                                flows and robust REST APIs.
+                            </p>
+                        </div>
+                        <!-- Ahmed ElSheikh -->
+                        <div class="bg-white dark:bg-gray-800 rounded-lg p-6 border border-gray-200 dark:border-gray-700">
+                            <div class="flex items-center gap-3 mb-3">
+                                <div class="w-12 h-12 bg-red-100 rounded-full flex items-center justify-center">
+                                    <i class="fas fa-chalkboard-teacher text-[#e74c3c] text-lg"></i>
+                                </div>
+                                <div>
+                                    <h4 class="text-lg font-bold text-gray-900 dark:text-gray-100">Ahmed ElSheikh</h4>
+                                    <p class="text-sm text-gray-600 dark:text-gray-400">React/OAuth/REST API</p>
+                                </div>
+                            </div>
+                            <p class="text-gray-600 dark:text-gray-400 text-sm">
+                                Cybersecurity analyst and AI security engineer specializing in
+                                secure system design.
+                            </p>
+                        </div>
+                    </div>
                 </div>
-              </div>
-              <div class="mentor-description-container">
-                <p
-                  class="text-gray-600 dark:text-gray-400 text-base leading-relaxed mentor-description-text"
-                >
-                  I'm a full-stack developer with prior GSoC experience and a
-                  deep love for open source. Having been a contributor myself, I
-                  know how overwhelming it can feel at the start — from
-                  understanding huge codebases to shipping your first meaningful
-                  PR. As a mentor, I focus on helping people build confidence
-                  through clean practices, thoughtful code reviews, and
-                  real-world problem solving. I stay active in open source
-                  because collaboration and shared learning are what actually
-                  move great software forward.
-                </p>
-              </div>
             </div>
-            <!-- Rishab Kumar Jha -->
-            <div
-              class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4 border border-gray-200 dark:border-gray-700"
-            >
-              <div class="flex items-center gap-3 mb-3">
-                <div
-                  class="w-10 h-10 bg-red-100 rounded-full flex items-center justify-center"
-                >
-                  <i class="fas fa-code text-[#e74c3c] text-sm"></i>
-                </div>
-                <div>
-                  <h4
-                    class="text-lg font-bold text-gray-900 dark:text-gray-100"
-                  >
-                    Rishab Kumar Jha
-                  </h4>
-                  <p class="text-sm text-gray-600 dark:text-gray-400">
-                    Full Stack/Blockchain
-                  </p>
-                </div>
-              </div>
-              <div class="mentor-description-container">
-                <p
-                  class="text-gray-600 dark:text-gray-400 text-base leading-relaxed mentor-description-text"
-                >
-                  I'm a software developer interested in distributed systems,
-                  web3, cloud native technologies & deep-tech. As a past GSoC
-                  and LFX alumnus myself, I understand the pain points of new
-                  contributors. Happy to mentor and help mentees navigate
-                  open-source effectively.
-                </p>
-              </div>
-            </div>
-          </div>
-        </div>
-        <!-- Manahil Afzal -->
-        <div
-          class="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-100 dark:border-gray-800 p-8"
-        >
-          <div class="flex items-center gap-6 mb-6">
-            <div
-              class="w-20 h-20 bg-red-100 rounded-full flex items-center justify-center"
-            >
-              <i class="fab fa-github text-[#e74c3c] text-3xl"></i>
-            </div>
-            <div class="flex-1">
-              <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100">
-                Manahil Afzal
-              </h3>
-              <p class="text-lg text-gray-600 dark:text-gray-400 mb-2">
-                MERN Stack Engineer / 2026 Contributor
-              </p>
-              <p class="text-gray-600 dark:text-gray-400 mb-4 text-sm">
-                Passionate about building meaningful web applications. Exploring
-                cloud, AI, and open source programs like GSoC & Outreachy.
-                Interested in contributing to organizations like OWASP
-                Foundation & Apache.
-              </p>
-              <div class="flex gap-4">
-                <a
-                  href="https://github.com/Manahil-Afzal"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  class="inline-flex items-center px-4 py-2 bg-[#e74c3c] text-white rounded-lg hover:bg-red-700 transition-colors"
-                >
-                  <i class="fab fa-github mr-2"></i>
-                  GitHub Profile
-                </a>
-                <a
-                  href="https://manahil-afzal.github.io/MY-GSOC-TOOL/"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  class="inline-flex items-center px-4 py-2 border-2 border-[#e74c3c] text-[#e74c3c] rounded-lg hover:bg-[#e74c3c] hover:text-white transition-colors"
-                >
-                  <i class="fas fa-tools mr-2"></i>
-                  GSoC Tool
-                </a>
-              </div>
-            </div>
-          </div>
-        </div>
-        <!-- Sakshee Suman -->
-        <div
-          class="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-100 dark:border-gray-800 p-8"
-        >
-          <div class="flex items-center gap-6 mb-6">
-            <div
-              class="w-20 h-20 bg-red-100 rounded-full flex items-center justify-center"
-            >
-              <i class="fab fa-github text-[#e74c3c] text-3xl"></i>
-            </div>
-            <div class="flex-1">
-              <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100">
-                Sakshee Suman
-              </h3>
-              <p class="text-lg text-gray-600 dark:text-gray-400 mb-2">
-                2026 Contributor
-              </p>
-              <div class="flex gap-4">
-                <a
-                  href="https://github.com/e-esakman"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  class="inline-flex items-center px-4 py-2 bg-[#e74c3c] text-white rounded-lg hover:bg-red-700 transition-colors"
-                >
-                  <i class="fab fa-github mr-2"></i>
-                  GitHub Profile
-                </a>
-                <a
-                  href="https://e-esakman.github.io/MY-GSOC-TOOL/"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  class="inline-flex items-center px-4 py-2 border-2 border-[#e74c3c] text-[#e74c3c] rounded-lg hover:bg-[#e74c3c] hover:text-white transition-colors"
-                >
-                  <i class="fas fa-tools mr-2"></i>
-                  GSoC-Tool
-                </a>
-              </div>
-            </div>
-          </div>
-        </div>
-        <!-- Arnav Kirti -->
-        <div
-          class="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-100 dark:border-gray-800 p-8"
-        >
-          <div class="flex items-center gap-6 mb-6">
-            <div
-              class="w-20 h-20 bg-red-100 rounded-full flex items-center justify-center"
-            >
-              <i class="fab fa-github text-[#e74c3c] text-3xl"></i>
-            </div>
-            <div class="flex-1">
-              <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100">
-                Arnav Kirti
-              </h3>
-              <p class="text-lg text-gray-600 dark:text-gray-400 mb-2">
-                2026 Contributor
-              </p>
-              <div class="flex gap-4">
-                <a
-                  href="https://github.com/arnavkirti"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  class="inline-flex items-center px-4 py-2 bg-[#e74c3c] text-white rounded-lg hover:bg-red-700 transition-colors"
-                >
-                  <i class="fab fa-github mr-2"></i>
-                  GitHub Profile
-                </a>
-                <a
-                  href="https://arnavkirti.github.io/MY-GSOC-TOOL/"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  class="inline-flex items-center px-4 py-2 border-2 border-[#e74c3c] text-[#e74c3c] rounded-lg hover:bg-[#e74c3c] hover:text-white transition-colors"
-                >
-                  <i class="fas fa-tools mr-2"></i>
-                  GSoC-Tool
-                </a>
-              </div>
-            </div>
-          </div>
-        </div>
-        <!-- Savio D'souza -->
-        <div
-          class="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-100 dark:border-gray-800 p-8"
-        >
-          <div class="flex items-center gap-6 mb-6">
-            <div
-              class="w-20 h-20 bg-red-100 rounded-full flex items-center justify-center"
-            >
-              <i class="fab fa-github text-[#e74c3c] text-3xl"></i>
-            </div>
-            <div class="flex-1">
-              <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100">
-                Savio D'souza
-              </h3>
-              <p class="text-lg text-gray-600 dark:text-gray-400 mb-2">
-                2026 Contributor
-              </p>
-              <div class="flex gap-4">
-                <a
-                  href="https://github.com/S3DFX-CYBER"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  class="inline-flex items-center px-4 py-2 bg-[#e74c3c] text-white rounded-lg hover:bg-red-700 transition-colors"
-                >
-                  <i class="fab fa-github mr-2"></i>
-                  GitHub Profile
-                </a>
-                <a
-                  href="https://S3DFX-CYBER.github.io/MY-GSOC-TOOL/"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  class="inline-flex items-center px-4 py-2 border-2 border-[#e74c3c] text-[#e74c3c] rounded-lg hover:bg-[#e74c3c] hover:text-white transition-colors"
-                >
-                  <i class="fas fa-tools mr-2"></i>
-                  GSoC-Tool
-                </a>
-              </div>
-            </div>
-          </div>
-        </div>
-        <!-- Jayant Malvi -->
-        <div
-          class="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-100 dark:border-gray-800 p-8"
-        >
-          <div class="flex items-center gap-6 mb-6">
-            <div
-              class="w-20 h-20 bg-red-100 rounded-full flex items-center justify-center"
-            >
-              <i class="fab fa-github text-[#e74c3c] text-3xl"></i>
-            </div>
-            <div class="flex-1">
-              <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100">
-                Jayant Malvi
-              </h3>
-              <p class="text-lg text-gray-600 dark:text-gray-400 mb-2">
-                2026 Contributor
-              </p>
-              <div class="flex gap-4">
-                <a
-                  href="https://github.com/Jayant2908"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  class="inline-flex items-center px-4 py-2 bg-[#e74c3c] text-white rounded-lg hover:bg-red-700 transition-colors"
-                >
-                  <i class="fab fa-github mr-2"></i>
-                  GitHub Profile
-                </a>
-                <a
-                  href="https://Jayant2908.github.io/MY-GSOC-TOOL/"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  class="inline-flex items-center px-4 py-2 border-2 border-[#e74c3c] text-[#e74c3c] rounded-lg hover:bg-[#e74c3c] hover:text-white transition-colors"
-                >
-                  <i class="fas fa-tools mr-2"></i>
-                  GSoC-Tool
-                </a>
-              </div>
-            </div>
-          </div>
-          <!-- Mentors grid -->
-          <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-            <!-- Manikandan Chandran -->
-            <div
-              class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4 border border-gray-200 dark:border-gray-700"
-            >
-              <div class="flex items-center gap-3 mb-3">
-                <div
-                  class="w-10 h-10 bg-red-100 rounded-full flex items-center justify-center"
-                >
-                  <i class="fas fa-code text-[#e74c3c] text-sm"></i>
-                </div>
-                <div>
-                  <h4
-                    class="text-lg font-bold text-gray-900 dark:text-gray-100"
-                  >
-                    Manikandan Chandran
-                  </h4>
-                  <p class="text-sm text-gray-600 dark:text-gray-400">
-                    React/OAuth/REST API
-                  </p>
-                </div>
-              </div>
-              <div class="mentor-description-container">
-                <p
-                  class="text-gray-600 dark:text-gray-400 text-base leading-relaxed mentor-description-text"
-                >
-                  Mentors teams on building secure React apps with real-world
-                  OAuth flows and robust REST APIs.
-                </p>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-      <!-- Available Mentors Section -->
-      <div
-        class="mt-16 bg-gray-50 dark:bg-gray-900 rounded-xl p-8 border border-gray-200 dark:border-gray-700"
-      >
-        <h3
-          class="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-6 text-center"
-        >
-          Available Mentors for Future Students
-        </h3>
-        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          <!-- Manikandan Chandran -->
-          <div
-            class="bg-white dark:bg-gray-800 rounded-lg p-6 border border-gray-200 dark:border-gray-700"
-          >
-            <div class="flex items-center gap-3 mb-3">
-              <div
-                class="w-12 h-12 bg-red-100 rounded-full flex items-center justify-center"
-              >
-                <i class="fas fa-chalkboard-teacher text-[#e74c3c] text-lg"></i>
-              </div>
-              <div>
-                <h4 class="text-lg font-bold text-gray-900 dark:text-gray-100">
-                  Manikandan Chandran
-                </h4>
-                <p class="text-sm text-gray-600 dark:text-gray-400">
-                  React/OAuth/REST API
-                </p>
-              </div>
-            </div>
-            <p class="text-gray-600 dark:text-gray-400 text-sm">
-              Mentors teams on building secure React apps with real-world OAuth
-              flows and robust REST APIs.
-            </p>
-          </div>
-          <!-- Ahmed ElSheikh -->
-          <div
-            class="bg-white dark:bg-gray-800 rounded-lg p-6 border border-gray-200 dark:border-gray-700"
-          >
-            <div class="flex items-center gap-3 mb-3">
-              <div
-                class="w-12 h-12 bg-red-100 rounded-full flex items-center justify-center"
-              >
-                <i class="fas fa-chalkboard-teacher text-[#e74c3c] text-lg"></i>
-              </div>
-              <div>
-                <h4 class="text-lg font-bold text-gray-900 dark:text-gray-100">
-                  Ahmed ElSheikh
-                </h4>
-                <p class="text-sm text-gray-600 dark:text-gray-400">
-                  React/OAuth/REST API
-                </p>
-              </div>
-            </div>
-            <p class="text-gray-600 dark:text-gray-400 text-sm">
-              Cybersecurity analyst and AI security engineer specializing in
-              secure system design.
-            </p>
-          </div>
-        </div>
-      </div>
-    </div>
-    <!-- Past Mentors Section -->
-    <div
-      class="bg-white dark:bg-gray-800 rounded-xl shadow-lg transition-all duration-300 p-8 mb-20 border border-gray-100 dark:border-gray-800"
-    >
-      <h2
-        class="text-3xl font-bold text-gray-900 dark:text-gray-100 text-center mb-2"
-      >
-        Past GSoC Mentors
-      </h2>
-      <div class="w-20 h-1 bg-[#e74c3c] mx-auto mb-8 rounded-full"></div>
-      <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
-        <div
-          class="bg-gray-50 dark:bg-gray-900 rounded-lg p-6 border border-gray-200 dark:border-gray-700"
-        >
-          <h4
-            class="text-lg font-bold text-gray-900 dark:text-gray-100 mb-3 flex items-center"
-          >
-            <i
-              aria-hidden="true"
-              class="fas fa-calendar-alt text-[#e74c3c] mr-2"
-            ></i
-            >2025
-          </h4>
-          <ul class="space-y-2 text-gray-700 dark:text-gray-300">
-            <li class="flex items-start">
-              <i class="fas fa-user-tie text-[#e74c3c] mt-1 mr-2"></i>
-              <span
-                >Rahul Negi
-                <span class="text-gray-500 dark:text-gray-500"
-                  >(Python/Django Mentor)</span
-                ></span
-              >
-            </li>
-            <li class="flex items-start">
-              <i class="fas fa-user-tie text-[#e74c3c] mt-1 mr-2"></i>
-              <span
-                >Bishal Das
-                <span class="text-gray-500 dark:text-gray-500"
-                  >(Django & UI/UX Mentor)</span
-                ></span
-              >
-            </li>
-            <li class="flex items-start">
-              <i class="fas fa-user-tie text-[#e74c3c] mt-1 mr-2"></i>
-              <span
-                >Sudhir Palavalasa
-                <span class="text-gray-500 dark:text-gray-500"
-                  >(Backend and OAuth mentor)</span
-                ></span
-              >
-            </li>
-          </ul>
-        </div>
-        <div
-          class="bg-gray-50 dark:bg-gray-900 rounded-lg p-6 border border-gray-200 dark:border-gray-700"
-        >
-          <h4
-            class="text-lg font-bold text-gray-900 dark:text-gray-100 mb-3 flex items-center"
-          >
-            <i
-              aria-hidden="true"
-              class="fas fa-calendar-alt text-[#e74c3c] mr-2"
-            ></i
-            >2024
-          </h4>
-          <ul class="space-y-2 text-gray-700 dark:text-gray-300">
-            <li class="flex items-start">
-              <i class="fas fa-user-tie text-[#e74c3c] mt-1 mr-2"></i>
-              <span
-                >Swapnil Shinde
-                <span class="text-gray-500 dark:text-gray-500"
-                  >(Django and blockchain mentor)</span
-                ></span
-              >
-            </li>
-            <li class="flex items-start">
-              <i class="fas fa-user-tie text-[#e74c3c] mt-1 mr-2"></i>
-              <span
-                >Arkadii Yakovets
-                <span class="text-gray-500 dark:text-gray-500"
-                  >(Python/Django mentor)</span
-                ></span
-              >
-            </li>
-          </ul>
-        </div>
-        <div
-          class="bg-gray-50 dark:bg-gray-900 rounded-lg p-6 border border-gray-200 dark:border-gray-700"
-        >
-          <h4
-            class="text-lg font-bold text-gray-900 dark:text-gray-100 mb-3 flex items-center"
-          >
-            <i
-              aria-hidden="true"
-              class="fas fa-calendar-alt text-[#e74c3c] mr-2"
-            ></i
-            >2023
-          </h4>
-          <ul class="space-y-2 text-gray-700 dark:text-gray-300">
-            <li class="flex items-start">
-              <i class="fas fa-user-tie text-[#e74c3c] mt-1 mr-2"></i>
-              <span
-                >Aryan Ranjan
-                <span class="text-gray-500 dark:text-gray-500"
-                  >(Flutter and Django Mentor)</span
-                ></span
-              >
-            </li>
-          </ul>
-        </div>
-        <div
-          class="bg-gray-50 dark:bg-gray-900 rounded-lg p-6 border border-gray-200 dark:border-gray-700"
-        >
-          <h4
-            class="text-lg font-bold text-gray-900 dark:text-gray-100 mb-3 flex items-center"
-          >
-            <i
-              aria-hidden="true"
-              class="fas fa-calendar-alt text-[#e74c3c] mr-2"
-            ></i
-            >2022
-          </h4>
-          <ul class="space-y-2 text-gray-700 dark:text-gray-300">
-            <li class="flex items-start">
-              <i class="fas fa-user-tie text-[#e74c3c] mt-1 mr-2"></i>
-              <span
-                >Sourav Badami
-                <span class="text-gray-500 dark:text-gray-500"
-                  >(Django Mentor)</span
-                ></span
-              >
-            </li>
-            <li class="flex items-start">
-              <i class="fas fa-user-tie text-[#e74c3c] mt-1 mr-2"></i>
-              <span
-                >Rahul Badami
-                <span class="text-gray-500 dark:text-gray-500"
-                  >(Payments Mentor)</span
-                ></span
-              >
-            </li>
-            <li class="flex items-start">
-              <i class="fas fa-user-tie text-[#e74c3c] mt-1 mr-2"></i>
-              <span
-                >Ankit Choudhary
-                <span class="text-gray-500 dark:text-gray-500"
-                  >(Flutter Mentor)</span
-                ></span
-              >
-            </li>
-            <li class="flex items-start">
-              <i class="fas fa-user-tie text-[#e74c3c] mt-1 mr-2"></i>
-              <span
-                >Sparsh Agrawal
-                <span class="text-gray-500 dark:text-gray-500"
-                  >(Flutter Mentor)</span
-                ></span
-              >
-            </li>
-          </ul>
-        </div>
-        <div
-          class="bg-gray-50 dark:bg-gray-900 rounded-lg p-6 border border-gray-200 dark:border-gray-700"
-        >
-          <h4
-            class="text-lg font-bold text-gray-900 dark:text-gray-100 mb-3 flex items-center"
-          >
-            <i
-              aria-hidden="true"
-              class="fas fa-calendar-alt text-[#e74c3c] mr-2"
-            ></i
-            >2020-2021
-          </h4>
-          <ul class="space-y-2 text-gray-700 dark:text-gray-300">
-            <li class="flex items-start">
-              <i class="fas fa-user-tie text-[#e74c3c] mt-1 mr-2"></i>
-              <span
-                >Sourav Badami
-                <span class="text-gray-500 dark:text-gray-500"
-                  >(Django Mentor)</span
-                ></span
-              >
-            </li>
-          </ul>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-{% endblock content %}
+            <!-- Past Mentors Section -->
+            <div class="bg-white dark:bg-gray-800 rounded-xl shadow-lg transition-all duration-300 p-8 mb-20 border border-gray-100 dark:border-gray-800">
+                <h2 class="text-3xl font-bold text-gray-900 dark:text-gray-100 text-center mb-2">Past GSoC Mentors</h2>
+                <div class="w-20 h-1 bg-[#e74c3c] mx-auto mb-8 rounded-full"></div>
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
+                    <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-6 border border-gray-200 dark:border-gray-700">
+                        <h4 class="text-lg font-bold text-gray-900 dark:text-gray-100 mb-3 flex items-center">
+                            <i aria-hidden="true" class="fas fa-calendar-alt text-[#e74c3c] mr-2"></i>2025
+                        </h4>
+                        <ul class="space-y-2 text-gray-700 dark:text-gray-300">
+                            <li class="flex items-start">
+                                <i class="fas fa-user-tie text-[#e74c3c] mt-1 mr-2"></i>
+                                <span>Rahul Negi
+                                    <span class="text-gray-500 dark:text-gray-500">(Python/Django Mentor)</span></span>
+                                </li>
+                                <li class="flex items-start">
+                                    <i class="fas fa-user-tie text-[#e74c3c] mt-1 mr-2"></i>
+                                    <span>Bishal Das
+                                        <span class="text-gray-500 dark:text-gray-500">(Django & UI/UX Mentor)</span></span>
+                                    </li>
+                                    <li class="flex items-start">
+                                        <i class="fas fa-user-tie text-[#e74c3c] mt-1 mr-2"></i>
+                                        <span>Sudhir Palavalasa
+                                            <span class="text-gray-500 dark:text-gray-500">(Backend and OAuth mentor)</span></span>
+                                        </li>
+                                    </ul>
+                                </div>
+                                <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-6 border border-gray-200 dark:border-gray-700">
+                                    <h4 class="text-lg font-bold text-gray-900 dark:text-gray-100 mb-3 flex items-center">
+                                        <i aria-hidden="true" class="fas fa-calendar-alt text-[#e74c3c] mr-2"></i>2024
+                                    </h4>
+                                    <ul class="space-y-2 text-gray-700 dark:text-gray-300">
+                                        <li class="flex items-start">
+                                            <i class="fas fa-user-tie text-[#e74c3c] mt-1 mr-2"></i>
+                                            <span>Swapnil Shinde
+                                                <span class="text-gray-500 dark:text-gray-500">(Django and blockchain mentor)</span></span>
+                                            </li>
+                                            <li class="flex items-start">
+                                                <i class="fas fa-user-tie text-[#e74c3c] mt-1 mr-2"></i>
+                                                <span>Arkadii Yakovets
+                                                    <span class="text-gray-500 dark:text-gray-500">(Python/Django mentor)</span></span>
+                                                </li>
+                                            </ul>
+                                        </div>
+                                        <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-6 border border-gray-200 dark:border-gray-700">
+                                            <h4 class="text-lg font-bold text-gray-900 dark:text-gray-100 mb-3 flex items-center">
+                                                <i aria-hidden="true" class="fas fa-calendar-alt text-[#e74c3c] mr-2"></i>2023
+                                            </h4>
+                                            <ul class="space-y-2 text-gray-700 dark:text-gray-300">
+                                                <li class="flex items-start">
+                                                    <i class="fas fa-user-tie text-[#e74c3c] mt-1 mr-2"></i>
+                                                    <span>Aryan Ranjan
+                                                        <span class="text-gray-500 dark:text-gray-500">(Flutter and Django Mentor)</span></span>
+                                                    </li>
+                                                </ul>
+                                            </div>
+                                            <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-6 border border-gray-200 dark:border-gray-700">
+                                                <h4 class="text-lg font-bold text-gray-900 dark:text-gray-100 mb-3 flex items-center">
+                                                    <i aria-hidden="true" class="fas fa-calendar-alt text-[#e74c3c] mr-2"></i>2022
+                                                </h4>
+                                                <ul class="space-y-2 text-gray-700 dark:text-gray-300">
+                                                    <li class="flex items-start">
+                                                        <i class="fas fa-user-tie text-[#e74c3c] mt-1 mr-2"></i>
+                                                        <span>Sourav Badami
+                                                            <span class="text-gray-500 dark:text-gray-500">(Django Mentor)</span></span>
+                                                        </li>
+                                                        <li class="flex items-start">
+                                                            <i class="fas fa-user-tie text-[#e74c3c] mt-1 mr-2"></i>
+                                                            <span>Rahul Badami
+                                                                <span class="text-gray-500 dark:text-gray-500">(Payments Mentor)</span></span>
+                                                            </li>
+                                                            <li class="flex items-start">
+                                                                <i class="fas fa-user-tie text-[#e74c3c] mt-1 mr-2"></i>
+                                                                <span>Ankit Choudhary
+                                                                    <span class="text-gray-500 dark:text-gray-500">(Flutter Mentor)</span></span>
+                                                                </li>
+                                                                <li class="flex items-start">
+                                                                    <i class="fas fa-user-tie text-[#e74c3c] mt-1 mr-2"></i>
+                                                                    <span>Sparsh Agrawal
+                                                                        <span class="text-gray-500 dark:text-gray-500">(Flutter Mentor)</span></span>
+                                                                    </li>
+                                                                </ul>
+                                                            </div>
+                                                            <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-6 border border-gray-200 dark:border-gray-700">
+                                                                <h4 class="text-lg font-bold text-gray-900 dark:text-gray-100 mb-3 flex items-center">
+                                                                    <i aria-hidden="true" class="fas fa-calendar-alt text-[#e74c3c] mr-2"></i>2020-2021
+                                                                </h4>
+                                                                <ul class="space-y-2 text-gray-700 dark:text-gray-300">
+                                                                    <li class="flex items-start">
+                                                                        <i class="fas fa-user-tie text-[#e74c3c] mt-1 mr-2"></i>
+                                                                        <span>Sourav Badami
+                                                                            <span class="text-gray-500 dark:text-gray-500">(Django Mentor)</span></span>
+                                                                        </li>
+                                                                    </ul>
+                                                                </div>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            {% endblock content %}

--- a/website/templates/gsoc.html
+++ b/website/templates/gsoc.html
@@ -1,1207 +1,1801 @@
-{% extends "base.html" %}
-{% load static %}
-{% load custom_tags %}
-{% block title %}
-    Google Summer of Code with OWASP
-{% endblock title %}
-{% block description %}
-    Join the Google Summer of Code program with OWASP and contribute to open source security projects.
-{% endblock description %}
-{% block keywords %}
-    GSoC, Google Summer of Code, OWASP, Open Source, Student Program, Mentorship
-{% endblock keywords %}
-{% block og_title %}
-    Google Summer of Code with OWASP
-{% endblock og_title %}
-{% block og_description %}
-    Learn about the Google Summer of Code (GSoC) program, its benefits, and its partnership with OWASP {% env 'PROJECT_NAME' %}.
-{% endblock og_description %}
-{% block extra_head %}
-    <style>
-.mentor-description-container {
+{% extends "base.html" %} {% load static %} {% load custom_tags %} {% block
+title %} Google Summer of Code with OWASP {% endblock title %} {% block
+description %} Join the Google Summer of Code program with OWASP and contribute
+to open source security projects. {% endblock description %} {% block keywords
+%} GSoC, Google Summer of Code, OWASP, Open Source, Student Program, Mentorship
+{% endblock keywords %} {% block og_title %} Google Summer of Code with OWASP {%
+endblock og_title %} {% block og_description %} Learn about the Google Summer of
+Code (GSoC) program, its benefits, and its partnership with OWASP {% env
+'PROJECT_NAME' %}. {% endblock og_description %} {% block extra_head %}
+<style>
+  .mentor-description-container {
     max-height: 8rem;
     overflow-y: auto;
     scrollbar-width: none;
     -ms-overflow-style: none;
-}
-.mentor-description-container::-webkit-scrollbar {
+  }
+  .mentor-description-container::-webkit-scrollbar {
     display: none;
-}
-.mentor-description-text {
+  }
+  .mentor-description-text {
     scrollbar-width: none;
     -ms-overflow-style: none;
-}
-.mentor-description-text::-webkit-scrollbar {
+  }
+  .mentor-description-text::-webkit-scrollbar {
     display: none;
-}
-    </style>
-{% endblock extra_head %}
-{% block content %}
-    {% include "includes/sidenav.html" %}
-    <!-- Hero Section -->
-    <div class="mt-[100px] bg-zinc-100 py-16">
-        <div class="w-[85%] mx-auto">
-            <div class="flex flex-col md:flex-row items-center gap-8">
-                <div class="md:w-1/3 flex justify-center">
-                    <div class="relative">
-                        <div class="absolute -inset-4 bg-[#e74c3c] rounded-full blur-md opacity-30 animate-pulse"></div>
-                        <img src="{% static 'images/gsoc.png' %}"
-                             alt="Google Summer of Code Logo"
-                             class="w-[160px] h-auto object-contain relative"
-                             width="200"
-                             height="200" />
-                    </div>
-                </div>
-                <div class="md:w-2/3">
-                    <h1 class="text-4xl md:text-5xl font-bold text-gray-900 dark:text-gray-100 mb-4">Google Summer of Code</h1>
-                    <h2 class="text-xl md:text-2xl font-medium text-red-500 mb-6">
-                        with Open Worldwide Application Security Project (OWASP) Foundation
-                    </h2>
-                    <p class="text-xl text-gray-700 dark:text-gray-300 leading-relaxed mb-2">
-                        The
-                        <a href="https://summerofcode.withgoogle.com/"
-                           class="text-[#e74c3c] hover:text-red-700 hover:underline transition-colors font-medium">Google Summer of Code program</a>
-                        (GSoC) is designed to encourage student participation in open source
-                        development. Through GSoC, accepted student applicants will be paired
-                        with OWASP mentors that will guide them through their coding tasks.
-                    </p>
-                    <p class="text-gray-700 dark:text-gray-300 leading-relaxed mb-6">
-                        <i class="fas fa-info-circle mr-2"></i> This program is done
-                        completely online. Students and mentors from more than 100 countries
-                        have participated in past years.
-                    </p>
-                    <div class="flex flex-wrap gap-4">
-                        <a href="https://owasp.org/www-community/initiatives/gsoc/"
-                           class="inline-flex items-center px-6 py-3 bg-red-500 shadow-md hover:bg-red-600 hover:text-white text-white font-medium rounded-lg transition-colors duration-200">
-                            <i class="fas fa-code-branch mr-2"></i> Browse Projects
-                        </a>
-                        <a href="https://summerofcode.withgoogle.com/"
-                           class="inline-flex items-center px-6 py-3 bg-white dark:bg-gray-800 shadow-md hover:bg-gray-100 hover:text-gray-800 text-gray-800 dark:text-gray-200 font-medium rounded-lg transition-colors border border-gray-300 dark:border-gray-600 duration-200">
-                            <i class="fas fa-external-link-alt mr-2"></i> Official GSoC Site
-                        </a>
-                    </div>
-                </div>
-            </div>
+  }
+</style>
+{% endblock extra_head %} {% block content %} {% include "includes/sidenav.html"
+%}
+<!-- Hero Section -->
+<div class="mt-[100px] bg-zinc-100 py-16">
+  <div class="w-[85%] mx-auto">
+    <div class="flex flex-col md:flex-row items-center gap-8">
+      <div class="md:w-1/3 flex justify-center">
+        <div class="relative">
+          <div
+            class="absolute -inset-4 bg-[#e74c3c] rounded-full blur-md opacity-30 animate-pulse"
+          ></div>
+          <img
+            src="{% static 'images/gsoc.png' %}"
+            alt="Google Summer of Code Logo"
+            class="w-[160px] h-auto object-contain relative"
+            width="200"
+            height="200"
+          />
         </div>
+      </div>
+      <div class="md:w-2/3">
+        <h1
+          class="text-4xl md:text-5xl font-bold text-gray-900 dark:text-gray-100 mb-4"
+        >
+          Google Summer of Code
+        </h1>
+        <h2 class="text-xl md:text-2xl font-medium text-red-500 mb-6">
+          with Open Worldwide Application Security Project (OWASP) Foundation
+        </h2>
+        <p
+          class="text-xl text-gray-700 dark:text-gray-300 leading-relaxed mb-2"
+        >
+          The
+          <a
+            href="https://summerofcode.withgoogle.com/"
+            class="text-[#e74c3c] hover:text-red-700 hover:underline transition-colors font-medium"
+            >Google Summer of Code program</a
+          >
+          (GSoC) is designed to encourage student participation in open source
+          development. Through GSoC, accepted student applicants will be paired
+          with OWASP mentors that will guide them through their coding tasks.
+        </p>
+        <p class="text-gray-700 dark:text-gray-300 leading-relaxed mb-6">
+          <i class="fas fa-info-circle mr-2"></i> This program is done
+          completely online. Students and mentors from more than 100 countries
+          have participated in past years.
+        </p>
+        <div class="flex flex-wrap gap-4">
+          <a
+            href="https://owasp.org/www-community/initiatives/gsoc/"
+            class="inline-flex items-center px-6 py-3 bg-red-500 shadow-md hover:bg-red-600 hover:text-white text-white font-medium rounded-lg transition-colors duration-200"
+          >
+            <i class="fas fa-code-branch mr-2"></i> Browse Projects
+          </a>
+          <a
+            href="https://summerofcode.withgoogle.com/"
+            class="inline-flex items-center px-6 py-3 bg-white dark:bg-gray-800 shadow-md hover:bg-gray-100 hover:text-gray-800 text-gray-800 dark:text-gray-200 font-medium rounded-lg transition-colors border border-gray-300 dark:border-gray-600 duration-200"
+          >
+            <i class="fas fa-external-link-alt mr-2"></i> Official GSoC Site
+          </a>
+        </div>
+      </div>
     </div>
-    <!-- Main Content -->
-    <div class="py-16 px-4 sm:px-6 lg:px-8 bg-white dark:bg-gray-800">
-        <div class="w-[85%] mx-auto">
-            <!-- Stats Section -->
-            <div class="mb-16">
-                <div class="grid grid-cols-1 sm:grid-cols-3 gap-6">
-                    <div class="bg-white dark:bg-gray-800 shadow-lg rounded-xl overflow-hidden transform">
-                        <div class="p-2 bg-[#e74c3c]"></div>
-                        <div class="p-6 text-center">
-                            <div class="text-5xl font-bold mb-2 text-[#e74c3c]">100+</div>
-                            <div class="text-gray-700 dark:text-gray-300 font-medium">Countries Participated</div>
-                        </div>
-                    </div>
-                    <div class="bg-white dark:bg-gray-800 shadow-lg rounded-xl overflow-hidden transform">
-                        <div class="p-2 bg-[#e74c3c]"></div>
-                        <div class="p-6 text-center">
-                            <div class="text-5xl font-bold mb-2 text-[#e74c3c]">7</div>
-                            <div class="text-gray-700 dark:text-gray-300 font-medium">Years with OWASP BLT</div>
-                        </div>
-                    </div>
-                    <div class="bg-white dark:bg-gray-800 shadow-lg rounded-xl overflow-hidden transform">
-                        <div class="p-2 bg-[#e74c3c]"></div>
-                        <div class="p-6 text-center">
-                            <div class="text-5xl font-bold mb-2 text-[#e74c3c]">20+</div>
-                            <div class="text-gray-700 dark:text-gray-300 font-medium">Successful Projects</div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-            <!-- Benefits Section -->
-            <div class="mb-20">
-                <h2 class="text-3xl font-bold text-center text-gray-900 dark:text-gray-100 mb-2">Program Benefits</h2>
-                <div class="w-20 h-1 bg-[#e74c3c] mx-auto mb-12 rounded-full"></div>
-                <div class="grid grid-cols-1 lg:grid-cols-2 gap-10">
-                    <!-- Student Benefits -->
-                    <div class="bg-white dark:bg-gray-800 rounded-xl shadow-lg transition-all duration-300 p-8 border border-gray-100 dark:border-gray-800">
-                        <div class="flex items-center mb-6">
-                            <div class="w-12 h-12 flex items-center justify-center bg-red-100 text-[#e74c3c] rounded-full mr-4">
-                                <i class="fas fa-user-graduate text-xl" aria-hidden="true"></i>
-                            </div>
-                            <h3 class="text-2xl font-bold text-gray-900 dark:text-gray-100">For Students</h3>
-                        </div>
-                        <ul class="space-y-4">
-                            <li class="flex items-start">
-                                <i class="fas fa-check-circle text-[#e74c3c] mt-1 mr-3"
-                                   aria-hidden="true"></i>
-                                <p class="text-gray-700 dark:text-gray-300">Gaining exposure to real-world software development scenarios</p>
-                            </li>
-                            <li class="flex items-start">
-                                <i class="fas fa-check-circle text-[#e74c3c] mt-1 mr-3"
-                                   aria-hidden="true"></i>
-                                <p class="text-gray-700 dark:text-gray-300">
-                                    An opportunity for employment in areas related to their academic
-                                    pursuits
-                                </p>
-                            </li>
-                            <li class="flex items-start">
-                                <i class="fas fa-check-circle text-[#e74c3c] mt-1 mr-3"
-                                   aria-hidden="true"></i>
-                                <p class="text-gray-700 dark:text-gray-300">
-                                    Google will be offering successful student contributors a
-                                    stipend
-                                </p>
-                            </li>
-                            <li class="flex items-start">
-                                <i class="fas fa-check-circle text-[#e74c3c] mt-1 mr-3"
-                                   aria-hidden="true"></i>
-                                <p class="text-gray-700 dark:text-gray-300">Build your professional network</p>
-                            </li>
-                            <li class="flex items-start">
-                                <i class="fas fa-check-circle text-[#e74c3c] mt-1 mr-3"
-                                   aria-hidden="true"></i>
-                                <p class="text-gray-700 dark:text-gray-300">Gain valuable experience in cybersecurity</p>
-                            </li>
-                            <li class="flex items-start">
-                                <i class="fas fa-check-circle text-[#e74c3c] mt-1 mr-3"
-                                   aria-hidden="true"></i>
-                                <p class="text-gray-700 dark:text-gray-300">Receive a certificate upon completion</p>
-                            </li>
-                        </ul>
-                    </div>
-                    <!-- Mentor Benefits -->
-                    <div class="bg-white dark:bg-gray-800 rounded-xl shadow-lg transition-all duration-300 p-8 border border-gray-100 dark:border-gray-800">
-                        <div class="flex items-center mb-6">
-                            <div class="w-12 h-12 flex items-center justify-center bg-red-100 text-[#e74c3c] rounded-full mr-4">
-                                <i class="fas fa-chalkboard-teacher text-xl" aria-hidden="true"></i>
-                            </div>
-                            <h3 class="text-2xl font-bold text-gray-900 dark:text-gray-100">For Mentors</h3>
-                        </div>
-                        <ul class="space-y-4">
-                            <li class="flex items-start">
-                                <i class="fas fa-check-circle text-[#e74c3c] mt-1 mr-3"
-                                   aria-hidden="true"></i>
-                                <p class="text-gray-700 dark:text-gray-300">Shape the next generation of open-source developers</p>
-                            </li>
-                            <li class="flex items-start">
-                                <i class="fas fa-check-circle text-[#e74c3c] mt-1 mr-3"
-                                   aria-hidden="true"></i>
-                                <p class="text-gray-700 dark:text-gray-300">Enhance project visibility and community engagement</p>
-                            </li>
-                            <li class="flex items-start">
-                                <i class="fas fa-check-circle text-[#e74c3c] mt-1 mr-3"
-                                   aria-hidden="true"></i>
-                                <p class="text-gray-700 dark:text-gray-300">Develop leadership and mentoring skills</p>
-                            </li>
-                            <li class="flex items-start">
-                                <i class="fas fa-check-circle text-[#e74c3c] mt-1 mr-3"
-                                   aria-hidden="true"></i>
-                                <p class="text-gray-700 dark:text-gray-300">Expand your professional network within OWASP</p>
-                            </li>
-                            <li class="flex items-start">
-                                <i class="fas fa-check-circle text-[#e74c3c] mt-1 mr-3"
-                                   aria-hidden="true"></i>
-                                <p class="text-gray-700 dark:text-gray-300">Recognition in the global security community</p>
-                            </li>
-                            <li class="flex items-start">
-                                <i class="fas fa-check-circle text-[#e74c3c] mt-1 mr-3"
-                                   aria-hidden="true"></i>
-                                <p class="text-gray-700 dark:text-gray-300">Contribute to the growth of open-source security projects</p>
-                            </li>
-                        </ul>
-                    </div>
-                </div>
-            </div>
-            <!-- OWASP Partnership Card -->
-            <div class="bg-white rounded-xl shadow-lg transition-all duration-300 p-8 mb-20 border border-gray-100">
-                <h2 class="text-3xl font-bold text-gray-900 mb-6">OWASP BLT & GSOC Partnership</h2>
-                <div class="space-y-6 text-gray-700">
-                    <p class="leading-relaxed">
-                        OWASP is an open community dedicated to enabling organizations to
-                        conceive, develop, acquire, operate, and maintain applications that
-                        can be trusted. OWASP has been an active participant in the Google
-                        Summer of Code program, providing students with the opportunity to
-                        contribute to various OWASP projects.
-                    </p>
-                    <p class="leading-relaxed">
-                        OWASP BLT (Bug Logging Tool) has been participating in the Google
-                        Summer of Code program for the past 5 consecutive years, from 2020 to
-                        2024. OWASP BLT is an open-source platform dedicated to making the
-                        internet safer through community-driven bug reporting and
-                        collaboration.
-                    </p>
-                    <p class="leading-relaxed">
-                        All students currently enrolled in an accredited institution are
-                        welcome to participate in the Google Summer of Code program, hopefully
-                        along with the OWASP Foundation.
-                    </p>
-                </div>
-            </div>
-            <!-- Project Ideas Section -->
-            <div class="mb-20">
-                <h2 class="text-3xl font-bold text-center text-gray-900 dark:text-gray-100 mb-2">Project Ideas</h2>
-                <div class="w-20 h-1 bg-[#e74c3c] mx-auto mb-12 rounded-full"></div>
-                <!-- OWASP BLT Projects (Highlighted) -->
-                <div class="mb-12">
-                    <a href="https://github.com/OWASP-BLT/BLT/milestones"
-                       rel="noopener noreferrer"
-                       target="_blank"
-                       class="block p-8 bg-gradient-to-br from-red-50 to-red-100 border-2 border-red-200 rounded-xl transition-all">
-                        <div class="flex flex-col md:flex-row items-center justify-between">
-                            <div class="mb-6 md:mb-0">
-                                <h3 class="text-2xl font-bold text-red-700 mb-3">OWASP BLT Project Ideas</h3>
-                                <p class="text-red-600 text-lg mb-4">
-                                    Explore exciting project opportunities with OWASP Bug Logging
-                                    Tool
-                                </p>
-                                <span class="inline-block px-4 py-2 bg-white dark:bg-gray-800 text-[#e74c3c] rounded-full font-medium">Featured Projects</span>
-                            </div>
-                            <div class="text-center">
-                                <div class="w-24 h-24 flex items-center justify-center bg-white dark:bg-gray-800 rounded-full mb-4 shadow-md mx-auto">
-                                    <i class="fa-solid fa-lightbulb text-[#e74c3c] text-4xl"></i>
-                                </div>
-                                <span class="inline-flex items-center text-[#e74c3c] font-medium">
-                                    Browse Now <i class="fa-solid fa-arrow-right ml-2"></i>
-                                </span>
-                            </div>
-                        </div>
-                    </a>
-                </div>
-                <!-- Past Ideas Grid -->
-                <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
-                    <a href="https://owasp.org/www-community/initiatives/gsoc/gsoc2025ideas"
-                       target="_blank"
-                       rel="noopener noreferrer"
-                       class="group block p-5 bg-white dark:bg-gray-800 shadow-md rounded-lg border border-gray-100 dark:border-gray-800 transition-all">
-                        <div class="flex items-center">
-                            <span class="font-semibold text-gray-900 dark:text-gray-100 group-hover:text-[#e74c3c] transition-colors">GSOC Project Ideas 2025</span>
-                            <i class="fa-solid fa-link ml-auto text-gray-400 dark:text-gray-600 group-hover:text-[#e74c3c]"></i>
-                        </div>
-                    </a>
-                    <a href="https://owasp.org/www-community/initiatives/gsoc/gsoc2024ideas"
-                       target="_blank"
-                       rel="noopener noreferrer"
-                       class="group block p-5 bg-white dark:bg-gray-800 shadow-md rounded-lg border border-gray-100 dark:border-gray-800 transition-all">
-                        <div class="flex items-center">
-                            <span class="font-semibold text-gray-900 dark:text-gray-100 group-hover:text-[#e74c3c] transition-colors">GSOC Project Ideas 2024</span>
-                            <i class="fa-solid fa-link ml-auto text-gray-400 dark:text-gray-600 group-hover:text-[#e74c3c]"></i>
-                        </div>
-                    </a>
-                    <a href="https://owasp.org/www-community/initiatives/gsoc/gsoc2023ideas"
-                       target="_blank"
-                       rel="noopener noreferrer"
-                       class="group block p-5 bg-white dark:bg-gray-800 shadow-md rounded-lg border border-gray-100 dark:border-gray-800 transition-all">
-                        <div class="flex items-center">
-                            <span class="font-semibold text-gray-900 dark:text-gray-100 group-hover:text-[#e74c3c] transition-colors">GSOC Project Ideas 2023</span>
-                            <i class="fa-solid fa-link ml-auto text-gray-400 dark:text-gray-600 group-hover:text-[#e74c3c]"></i>
-                        </div>
-                    </a>
-                    <a href="https://owasp.org/www-community/initiatives/gsoc/gsoc2022ideas"
-                       target="_blank"
-                       rel="noopener noreferrer"
-                       class="group block p-5 bg-white dark:bg-gray-800 shadow-md rounded-lg border border-gray-100 dark:border-gray-800 transition-all">
-                        <div class="flex items-center">
-                            <span class="font-semibold text-gray-900 dark:text-gray-100 group-hover:text-[#e74c3c] transition-colors">GSOC Project Ideas 2022</span>
-                            <i class="fa-solid fa-link ml-auto text-gray-400 dark:text-gray-600 group-hover:text-[#e74c3c]"></i>
-                        </div>
-                    </a>
-                    <a href="https://owasp.org/www-community/initiatives/gsoc/gsoc2021ideas"
-                       target="_blank"
-                       rel="noopener noreferrer"
-                       class="group block p-5 bg-white dark:bg-gray-800 shadow-md rounded-lg border border-gray-100 dark:border-gray-800 transition-all">
-                        <div class="flex items-center">
-                            <span class="font-semibold text-gray-900 dark:text-gray-100 group-hover:text-[#e74c3c] transition-colors">GSOC Project Ideas 2021</span>
-                            <i class="fa-solid fa-link ml-auto text-gray-400 dark:text-gray-600 group-hover:text-[#e74c3c]"></i>
-                        </div>
-                    </a>
-                    <a href="https://owasp.org/www-community/initiatives/gsoc/gsoc2020ideas"
-                       target="_blank"
-                       rel="noopener noreferrer"
-                       class="group block p-5 bg-white dark:bg-gray-800 shadow-md rounded-lg border border-gray-100 dark:border-gray-800 transition-all">
-                        <div class="flex items-center">
-                            <span class="font-semibold text-gray-900 dark:text-gray-100 group-hover:text-[#e74c3c] transition-colors">GSOC Project Ideas 2020</span>
-                            <i class="fa-solid fa-link ml-auto text-gray-400 dark:text-gray-600 group-hover:text-[#e74c3c]"></i>
-                        </div>
-                    </a>
-                    <a href="https://owasp.org/www-community/initiatives/gsoc/gsoc2019ideas"
-                       target="_blank"
-                       rel="noopener noreferrer"
-                       class="group block p-5 bg-white dark:bg-gray-800 shadow-md rounded-lg border border-gray-100 dark:border-gray-800 transition-all">
-                        <div class="flex items-center">
-                            <span class="font-semibold text-gray-900 dark:text-gray-100 group-hover:text-[#e74c3c] transition-colors">GSOC Project Ideas 2019</span>
-                            <i class="fa-solid fa-link ml-auto text-gray-400 dark:text-gray-600 group-hover:text-[#e74c3c]"></i>
-                        </div>
-                    </a>
-                    <a href="https://owasp.org/www-community/initiatives/gsoc/gsoc2018ideas"
-                       target="_blank"
-                       rel="noopener noreferrer"
-                       class="group block p-5 bg-white dark:bg-gray-800 shadow-md rounded-lg border border-gray-100 dark:border-gray-800 transition-all">
-                        <div class="flex items-center">
-                            <span class="font-semibold text-gray-900 dark:text-gray-100 group-hover:text-[#e74c3c] transition-colors">GSOC Project Ideas 2018</span>
-                            <i class="fa-solid fa-link ml-auto text-gray-400 dark:text-gray-600 group-hover:text-[#e74c3c]"></i>
-                        </div>
-                    </a>
-                    <a href="https://owasp.org/www-community/initiatives/gsoc/gsoc2017ideas"
-                       target="_blank"
-                       rel="noopener noreferrer"
-                       class="group block p-5 bg-white dark:bg-gray-800 shadow-md rounded-lg border border-gray-100 dark:border-gray-800 transition-all">
-                        <div class="flex items-center">
-                            <span class="font-semibold text-gray-900 dark:text-gray-100 group-hover:text-[#e74c3c] transition-colors">GSOC Project Ideas 2017</span>
-                            <i class="fa-solid fa-link ml-auto text-gray-400 dark:text-gray-600 group-hover:text-[#e74c3c]"></i>
-                        </div>
-                    </a>
-                </div>
-            </div>
-            <!-- Past Events -->
-            <div class="bg-white dark:bg-gray-800 rounded-xl shadow-lg transition-all duration-300 p-8 mb-20 border border-gray-100 dark:border-gray-800">
-                <h2 class="text-3xl font-bold text-gray-900 dark:text-gray-100 mb-6">Past GSOC Events</h2>
-                <div class="grid grid-cols-1 lg:grid-cols-2 gap-8">
-                    <!-- 2023 -->
-                    <div class="bg-white dark:bg-gray-800 rounded-lg shadow-md transition-all border border-gray-200 dark:border-gray-700 overflow-hidden">
-                        <div class="p-2 bg-[#e74c3c]"></div>
-                        <div class="p-6">
-                            <a href="https://summerofcode.withgoogle.com/archive/2023/organizations/owasp-foundation"
-                               target="_blank"
-                               rel="noopener noreferrer"
-                               class="text-xl font-bold text-gray-900 dark:text-gray-100 hover:text-[#e74c3c] transition-colors flex items-center mb-4">
-                                <i aria-hidden="true" class="fas fa-calendar-alt mr-2 text-[#e74c3c]"></i>
-                                2023 GSOC Archive
-                            </a>
-                            <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4">
-                                <h4 class="text-lg font-semibold text-gray-800 dark:text-gray-200 mb-2 flex items-center">
-                                    <i aria-hidden="true" class="fas fa-users mr-2 text-[#e74c3c]"></i>
-                                    Mentors
-                                </h4>
-                                <p class="text-gray-700 dark:text-gray-300 leading-relaxed">
-                                    Abraham Aranguren, Aryan Prasad, Aryan Ranjan, Ben de Haan,
-                                    Björn Kimminich, Christian Folini, DonnieBLT, fzipitria, Jannik
-                                    Hollenbach, José Carlos Chávez, Mrigank Anand, Rick M,
-                                    ShubhamPalriwala, Simon Bennetts, thc202, Timo Pagel, Viyat
-                                </p>
-                            </div>
-                        </div>
-                    </div>
-                    <!-- 2022 -->
-                    <div class="bg-white dark:bg-gray-800 rounded-lg shadow-md transition-all border border-gray-200 dark:border-gray-700 overflow-hidden">
-                        <div class="p-2 bg-[#e74c3c]"></div>
-                        <div class="p-6">
-                            <a href="https://summerofcode.withgoogle.com/archive/2022/organizations/owasp-foundation"
-                               target="_blank"
-                               rel="noopener noreferrer"
-                               class="text-xl font-bold text-gray-900 dark:text-gray-100 hover:text-[#e74c3c] transition-colors flex items-center mb-4">
-                                <i aria-hidden="true" class="fas fa-calendar-alt mr-2 text-[#e74c3c]"></i>
-                                2022 GSOC Archive
-                            </a>
-                            <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4">
-                                <h4 class="text-lg font-semibold text-gray-800 dark:text-gray-200 mb-2 flex items-center">
-                                    <i aria-hidden="true" class="fas fa-users mr-2 text-[#e74c3c]"></i>
-                                    Mentors
-                                </h4>
-                                <p class="text-gray-700 dark:text-gray-300 leading-relaxed">
-                                    Abraham Aranguren, Ade Yoseman Putra, Ankit Choudhary, Björn
-                                    Kimminich, Dhiren Serai, Franziska, fzipitria, Glenn Ten Cate,
-                                    Jannik Hollenbach, Rejah Rehim, Rick M, Saeed Dehqan, Sam
-                                    Stepanyan, Sparsh Agrawal, thc202, Timo Pagel, Viyat
-                                </p>
-                            </div>
-                        </div>
-                    </div>
-                    <!-- 2021 -->
-                    <div class="bg-white dark:bg-gray-800 rounded-lg shadow-md transition-all border border-gray-200 dark:border-gray-700 overflow-hidden">
-                        <div class="p-2 bg-[#e74c3c]"></div>
-                        <div class="p-6">
-                            <a href="https://summerofcode.withgoogle.com/archive/2021/organizations/owasp-foundation"
-                               target="_blank"
-                               rel="noopener noreferrer"
-                               class="text-xl font-bold text-gray-900 dark:text-gray-100 hover:text-[#e74c3c] transition-colors flex items-center mb-4">
-                                <i aria-hidden="true" class="fas fa-calendar-alt mr-2 text-[#e74c3c]"></i>
-                                2021 GSOC Archive
-                            </a>
-                            <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4">
-                                <h4 class="text-lg font-semibold text-gray-800 dark:text-gray-200 mb-2 flex items-center">
-                                    <i aria-hidden="true" class="fas fa-users mr-2 text-[#e74c3c]"></i>
-                                    Mentors
-                                </h4>
-                                <p class="text-gray-700 dark:text-gray-300 leading-relaxed">
-                                    8f040, Abe, Abraham Aranguren, Ade Yoseman Putra, Ali Razmjoo
-                                    Qalaei, Anshul Singhal, Ashrith N Shetty, Björn Kimminich,
-                                    Damien Carol, Dhiren Devinder Serai, Glenn ten Cate, Jannik
-                                    Hollenbach, madchap, Mohit Sharma-2, Rejah Rehim, Riccardo Cate,
-                                    Rick M, Saeed Dehqan-1, Sam Stepanyan, Simon Bennetts, Sourav
-                                    Badami, thc202
-                                </p>
-                            </div>
-                        </div>
-                    </div>
-                    <!-- 2020 -->
-                    <div class="bg-white dark:bg-gray-800 rounded-lg shadow-md transition-all border border-gray-200 dark:border-gray-700 overflow-hidden">
-                        <div class="p-2 bg-[#e74c3c]"></div>
-                        <div class="p-6">
-                            <a href="https://summerofcode.withgoogle.com/archive/2020/organizations/owasp-foundation"
-                               target="_blank"
-                               rel="noopener noreferrer"
-                               class="text-xl font-bold text-gray-900 dark:text-gray-100 hover:text-[#e74c3c] transition-colors flex items-center mb-4">
-                                <i aria-hidden="true" class="fas fa-calendar-alt mr-2 text-[#e74c3c]"></i>
-                                2020 GSOC Archive
-                            </a>
-                            <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4">
-                                <h4 class="text-lg font-semibold text-gray-800 dark:text-gray-200 mb-2 flex items-center">
-                                    <i aria-hidden="true" class="fas fa-users mr-2 text-[#e74c3c]"></i>
-                                    Mentors
-                                </h4>
-                                <p class="text-gray-700 dark:text-gray-300 leading-relaxed">
-                                    Abe, Abraham Aranguren, Ade Yoseman Putra, Adrian Winckles, Ali
-                                    Razmjoo Qalaei, Björn Kimminich, Felipe Zipitria, Glenn ten
-                                    Cate, Jannik Hollenbach, Mohit Sharma, Rejah Rehim A A, Rejah
-                                    Rehim, Ricardo Pereira, Riccardo ten Cate, Rick M, S,
-                                    securestep9, Simon Bennetts, Soham Marik, souravbadami, spyros,
-                                    Sri Harsha G, Timo Pagel, Viyat Bhalodia
-                                </p>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-            <!-- Success Stories -->
-            <div class="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-100 dark:border-gray-800 p-8 mb-12">
-                <h2 class="text-3xl font-bold text-gray-900 dark:text-gray-100 mb-2 text-center">Success Stories</h2>
-                <div class="w-20 h-1 bg-[#e74c3c] mx-auto mb-8 rounded-full"></div>
-                <div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
-                    <!-- Shirish Jain -->
-                    <div class="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md border border-gray-100 dark:border-gray-800">
-                        <div class="flex items-center gap-4 mb-6">
-                            <div class="w-16 h-16 bg-red-100 rounded-full flex items-center justify-center">
-                                <i class="fas fa-code text-[#e74c3c] text-2xl"></i>
-                            </div>
-                            <div>
-                                <h3 class="text-2xl font-semibold">Shirish Jain</h3>
-                                <p class="text-gray-600 dark:text-gray-400">GSoC 2023</p>
-                            </div>
-                        </div>
-                        <p class="text-gray-700 dark:text-gray-300 mb-6 text-lg">
-                            Successfully implemented the Sizzle Time Tracking feature during
-                            GSoC 2023.
-                        </p>
-                        <div class="flex gap-4">
-                            <a href="https://medium.com/@shirishjain.2001/gsoc-2023-final-report-owasp-bug-logging-tool-f70d6368f9f5"
-                               class="flex-1 hover:text-white bg-[#e74c3c] text-white py-2 px-4 rounded-lg hover:bg-red-700 transition-colors text-center flex items-center justify-center gap-2">
-                                <i class="fas fa-book-open"></i>
-                                <span>Read Blog</span>
-                            </a>
-                            <a href="https://blt.owasp.org/contributors/?contributor=37"
-                               class="flex-1 border-2 border-[#e74c3c] text-[#e74c3c] py-2 px-4 rounded-lg hover:bg-[#e74c3c] hover:text-white transition-colors text-center flex items-center justify-center gap-2">
-                                <i class="fas fa-user"></i>
-                                <span>Profile</span>
-                            </a>
-                        </div>
-                    </div>
-                    <!-- Aryan Ranjan -->
-                    <div class="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md border border-gray-100 dark:border-gray-800">
-                        <div class="flex items-center gap-4 mb-6">
-                            <div class="w-16 h-16 bg-red-100 rounded-full flex items-center justify-center">
-                                <i class="fas fa-comments text-[#e74c3c] text-2xl"></i>
-                            </div>
-                            <div>
-                                <h3 class="text-2xl font-semibold">Aryan Ranjan</h3>
-                                <p class="text-gray-600 dark:text-gray-400">GSoC 2023</p>
-                            </div>
-                        </div>
-                        <p class="text-gray-700 dark:text-gray-300 mb-6 text-lg">Developed the Discussion Room feature during GSoC 2023.</p>
-                        <div class="flex gap-4">
-                            <a href="https://medium.com/@justary27/my-gsoc22-voyage-beginning-4296df5af625"
-                               class="flex-1 hover:text-white bg-[#e74c3c] text-white py-2 px-4 rounded-lg hover:bg-red-700 transition-colors text-center flex items-center justify-center gap-2">
-                                <i class="fas fa-book-open"></i>
-                                <span>Read Blog</span>
-                            </a>
-                            <a href="https://blt.owasp.org/contributors/?contributor=1"
-                               class="flex-1 border-2 border-[#e74c3c] text-[#e74c3c] py-2 px-4 rounded-lg hover:bg-[#e74c3c] hover:text-white transition-colors text-center flex items-center justify-center gap-2">
-                                <i class="fas fa-user"></i>
-                                <span>Profile</span>
-                            </a>
-                        </div>
-                    </div>
-                    <!-- Swapnil Shinde -->
-                    <div class="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md border border-gray-100 dark:border-gray-800">
-                        <div class="flex items-center gap-4 mb-6">
-                            <div class="w-16 h-16 bg-red-100 rounded-full flex items-center justify-center">
-                                <i class="fas fa-bug text-[#e74c3c] text-2xl"></i>
-                            </div>
-                            <div>
-                                <h3 class="text-2xl font-semibold">Swapnil Shinde</h3>
-                                <p class="text-gray-600 dark:text-gray-400">GSoC 2022</p>
-                            </div>
-                        </div>
-                        <p class="text-gray-700 dark:text-gray-300 mb-6 text-lg">Contributed to OWASP BLT development.</p>
-                        <div class="flex gap-4">
-                            <a href="https://gist.github.com/AtmegaBuzz/512a85827b5cc993e35c274dcbada669"
-                               class="flex-1 hover:text-white bg-[#e74c3c] text-white py-2 px-4 rounded-lg hover:bg-red-700 transition-colors text-center flex items-center justify-center gap-2">
-                                <i class="fas fa-file-alt"></i>
-                                <span>Report</span>
-                            </a>
-                            <a href="https://blt.owasp.org/contributors/?contributor=3"
-                               class="flex-1 border-2 border-[#e74c3c] text-[#e74c3c] py-2 px-4 rounded-lg hover:bg-[#e74c3c] hover:text-white transition-colors text-center flex items-center justify-center gap-2">
-                                <i class="fas fa-user"></i>
-                                <span>Profile</span>
-                            </a>
-                        </div>
-                    </div>
-                    <!-- Bishal Das -->
-                    <div class="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md border border-gray-100 dark:border-gray-800">
-                        <div class="flex items-center gap-4 mb-6">
-                            <div class="w-16 h-16 bg-red-100 rounded-full flex items-center justify-center">
-                                <i class="fas fa-graduation-cap text-[#e74c3c] text-2xl"></i>
-                            </div>
-                            <div>
-                                <h3 class="text-2xl font-semibold">Bishal Das</h3>
-                                <p class="text-gray-600 dark:text-gray-400">GSoC 2024</p>
-                            </div>
-                        </div>
-                        <p class="text-gray-700 dark:text-gray-300 mb-6 text-lg">GSoC Learning journey with OWASP BLT.</p>
-                        <div class="flex gap-4">
-                            <a href="https://bishaldas.hashnode.dev/gsoc-2024-a-summer-of-learning-coding-and-growth"
-                               class="flex-1 hover:text-white bg-[#e74c3c] text-white py-2 px-4 rounded-lg hover:bg-red-700 transition-colors text-center flex items-center justify-center gap-2">
-                                <i class="fas fa-book-open"></i>
-                                <span>Read Blog</span>
-                            </a>
-                            <a href="https://blt.owasp.org/contributors/?contributor=5"
-                               class="flex-1 border-2 border-[#e74c3c] text-[#e74c3c] py-2 px-4 rounded-lg hover:bg-[#e74c3c] hover:text-white transition-colors text-center flex items-center justify-center gap-2">
-                                <i class="fas fa-user"></i>
-                                <span>Profile</span>
-                            </a>
-                        </div>
-                    </div>
-                    <!-- Shubham Palriwala -->
-                    <div class="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md border border-gray-100 dark:border-gray-800">
-                        <div class="flex items-center gap-4 mb-6">
-                            <div class="w-16 h-16 bg-red-100 rounded-full flex items-center justify-center">
-                                <i class="fas fa-flask text-[#e74c3c] text-2xl"></i>
-                            </div>
-                            <div>
-                                <h3 class="text-2xl font-semibold">Shubham Palriwala</h3>
-                                <p class="text-gray-600 dark:text-gray-400">OWASP Juice Shop</p>
-                            </div>
-                        </div>
-                        <p class="text-gray-700 dark:text-gray-300 mb-6 text-lg">OWASP Juice Shop Journey</p>
-                        <div class="flex gap-4">
-                            <a href="https://medium.com/@shubhampalriwala/google-summer-of-code-journey-with-owasp-juice-shop-c1ca15c8e170"
-                               class="flex-1 hover:text-white bg-[#e74c3c] text-white py-2 px-4 rounded-lg hover:bg-red-700 transition-colors text-center flex items-center justify-center gap-2">
-                                <i class="fas fa-book-open"></i>
-                                <span>Read Blog</span>
-                            </a>
-                        </div>
-                    </div>
-                    <!-- Akshay Behl -->
-                    <div class="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md border border-gray-100 dark:border-gray-800">
-                        <div class="flex items-center gap-4 mb-6">
-                            <div class="w-16 h-16 bg-red-100 rounded-full flex items-center justify-center">
-                                <i class="fas fa-network-wired text-[#e74c3c] text-2xl"></i>
-                            </div>
-                            <div>
-                                <h3 class="text-2xl font-semibold">Akshay Behl</h3>
-                                <p class="text-gray-600 dark:text-gray-400">OWASP Nettacker</p>
-                            </div>
-                        </div>
-                        <p class="text-gray-700 dark:text-gray-300 mb-6 text-lg">OWASP Nettacker Experience</p>
-                        <div class="flex gap-4">
-                            <a href="https://medium.com/@akshaybehl231/diving-into-open-source-owasp-nettacker-gsoc24-e73114f37a11"
-                               class="flex-1 hover:text-white bg-[#e74c3c] text-white py-2 px-4 rounded-lg hover:bg-red-700 transition-colors text-center flex items-center justify-center gap-2">
-                                <i class="fas fa-book-open"></i>
-                                <span>Read Blog</span>
-                            </a>
-                        </div>
-                    </div>
-                    <!-- Chakshu Gupta -->
-                    <div class="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md border border-gray-100 dark:border-gray-800">
-                        <div class="flex items-center gap-4 mb-6">
-                            <div class="w-16 h-16 bg-red-100 rounded-full flex items-center justify-center">
-                                <i class="fas fa-shield-alt text-[#e74c3c] text-2xl"></i>
-                            </div>
-                            <div>
-                                <h3 class="text-2xl font-semibold">Chakshu Gupta</h3>
-                                <p class="text-gray-600 dark:text-gray-400">OWASP Honeypot Project</p>
-                            </div>
-                        </div>
-                        <p class="text-gray-700 dark:text-gray-300 mb-6 text-lg">OWASP Honeypot Project Journey</p>
-                        <div class="flex gap-4">
-                            <a href="https://medium.com/@ChGDream/my-google-summer-of-code-2020-journey-with-owasp-b772c3e67c3f"
-                               class="flex-1 hover:text-white bg-[#e74c3c] text-white py-2 px-4 rounded-lg hover:bg-red-700 transition-colors text-center flex items-center justify-center gap-2">
-                                <i class="fas fa-book-open"></i>
-                                <span>Read Blog</span>
-                            </a>
-                        </div>
-                    </div>
-                    <!-- Rishabh Keshan -->
-                    <div class="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md border border-gray-100 dark:border-gray-800">
-                        <div class="flex items-center gap-4 mb-6">
-                            <div class="w-16 h-16 bg-red-100 rounded-full flex items-center justify-center">
-                                <i class="fas fa-cube text-[#e74c3c] text-2xl"></i>
-                            </div>
-                            <div>
-                                <h3 class="text-2xl font-semibold">Rishabh Keshan</h3>
-                                <p class="text-gray-600 dark:text-gray-400">Web3 Juice Shop</p>
-                            </div>
-                        </div>
-                        <p class="text-gray-700 dark:text-gray-300 mb-6 text-lg">Web3 Journey with Juice Shop</p>
-                        <div class="flex gap-4">
-                            <a href="https://medium.com/@ChGDream/my-google-summer-of-code-2020-journey-with-owasp-b772c3e67c3f"
-                               class="flex-1 hover:text-white bg-[#e74c3c] text-white py-2 px-4 rounded-lg hover:bg-red-700 transition-colors text-center flex items-center justify-center gap-2">
-                                <i class="fas fa-book-open"></i>
-                                <span>Read Blog</span>
-                            </a>
-                        </div>
-                    </div>
-                </div>
-            </div>
-            <!-- GSoC 2026 Students Section -->
-            <div class="mb-20">
-                <h2 class="text-3xl font-bold text-center text-gray-900 dark:text-gray-100 mb-2">2026 Contributors</h2>
-                <div class="w-20 h-1 bg-[#e74c3c] mx-auto mb-12 rounded-full"></div>
-                <div class="flex items-start space-x-6 mb-8">
-                    <div class="bg-red-100 rounded-full p-3 flex-shrink-0">
-                        <i class="fas fa-star text-[#e74c3c] text-xl"></i>
-                    </div>
-                    <div>
-                        <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100 mb-2">Lead Mentor</h3>
-                        <p class="text-lg text-gray-800 dark:text-gray-200 font-medium mb-1">Donnie Brown (All years)</p>
-                    </div>
-                </div>
-                <div class="space-y-8">
-                    <!-- Md Kaif Ansari -->
-                    <div class="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-100 dark:border-gray-800 p-8">
-                        <div class="flex items-center gap-6 mb-6">
-                            <div class="w-20 h-20 bg-red-100 rounded-full flex items-center justify-center">
-                                <i class="fab fa-github text-[#e74c3c] text-3xl"></i>
-                            </div>
-                            <div class="flex-1">
-                                <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100">Md Kaif Ansari</h3>
-                                <p class="text-lg text-gray-600 dark:text-gray-400 mb-2">2026 Contributor</p>
-                                <div class="flex gap-4">
-                                    <a href="https://github.com/mdkaifansari04"
-                                       target="_blank"
-                                       rel="noopener noreferrer"
-                                       class="inline-flex items-center px-4 py-2 bg-[#e74c3c] text-white rounded-lg hover:bg-red-700 transition-colors">
-                                        <i class="fab fa-github mr-2"></i>
-                                        GitHub Profile
-                                    </a>
-                                    <a href="https://mdkaifansari04.github.io/MY-GSOC-TOOL/"
-                                       target="_blank"
-                                       rel="noopener noreferrer"
-                                       class="inline-flex items-center px-4 py-2 border-2 border-[#e74c3c] text-[#e74c3c] rounded-lg hover:bg-[#e74c3c] hover:text-white transition-colors">
-                                        <i class="fas fa-tools mr-2"></i>
-                                        GSoC-Tool
-                                    </a>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-                            <!-- Rinkit Adhana -->
-                            <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4 border border-gray-200 dark:border-gray-700">
-                                <div class="flex items-center gap-3 mb-3">
-                                    <div class="w-10 h-10 bg-red-100 rounded-full flex items-center justify-center">
-                                        <i class="fas fa-code text-[#e74c3c] text-sm"></i>
-                                    </div>
-                                    <div>
-                                        <h4 class="text-lg font-bold text-gray-900 dark:text-gray-100">Rinkit Adhana</h4>
-                                        <p class="text-sm text-gray-600 dark:text-gray-400">Full Stack Development</p>
-                                    </div>
-                                </div>
-                                <div class="mentor-description-container">
-                                    <p class="text-gray-600 dark:text-gray-400 text-base leading-relaxed mentor-description-text">
-                                        As a full stack engineer and active BLT contributor, I bring
-                                        hands-on experience from both sides of the development
-                                        process. Having participated in GSoC 2025, I understand the
-                                        challenges new contributors face and can guide you through
-                                        your open source journey. I specialize in helping developers
-                                        build scalable web applications, navigate complex codebases,
-                                        and contribute effectively to real-world projects. My goal is
-                                        to share practical knowledge and help you grow as a developer
-                                        while making meaningful contributions to BLT.
-                                    </p>
-                                </div>
-                            </div>
-                            <!-- Raj Gupta -->
-                            <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4 border border-gray-200 dark:border-gray-700">
-                                <div class="flex items-center gap-3 mb-3">
-                                    <div class="w-10 h-10 bg-red-100 rounded-full flex items-center justify-center">
-                                        <i class="fas fa-code text-[#e74c3c] text-sm"></i>
-                                    </div>
-                                    <div>
-                                        <h4 class="text-lg font-bold text-gray-900 dark:text-gray-100">Raj Gupta</h4>
-                                        <p class="text-sm text-gray-600 dark:text-gray-400">Full Stack Development mentor</p>
-                                    </div>
-                                </div>
-                                <div class="mentor-description-container">
-                                    <p class="text-gray-600 dark:text-gray-400 text-base leading-relaxed mentor-description-text">
-                                        I’m a full stack developer with prior Google Summer of Code (GSoC)
-                                        experience and a strong passion for open source. Having worked as a
-                                        contributor, I understand the challenges of getting started - from
-                                        reading large codebases to making meaningful pull requests. As a
-                                        mentor, I enjoy guiding contributors through best practices, code
-                                        reviews, and real-world problem solving. I continue to actively
-                                        contribute to open source because I believe collaboration and
-                                        knowledge sharing are what truly drive impactful software.
-                                    </p>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    <!-- Preetham -->
-                    <div class="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-100 dark:border-gray-800 p-8">
-                        <div class="flex items-center gap-6 mb-6">
-                            <div class="w-20 h-20 bg-red-100 rounded-full flex items-center justify-center">
-                                <i class="fab fa-github text-[#e74c3c] text-3xl"></i>
-                            </div>
-                            <div class="flex-1">
-                                <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100">Preetham</h3>
-                                <p class="text-lg text-gray-600 dark:text-gray-400 mb-2">2026 Contributor</p>
-                                <div class="flex gap-4">
-                                    <a href="https://github.com/Pritz395"
-                                       target="_blank"
-                                       rel="noopener noreferrer"
-                                       class="inline-flex items-center px-4 py-2 bg-[#e74c3c] text-white rounded-lg hover:bg-red-700 transition-colors">
-                                        <i class="fab fa-github mr-2"></i>
-                                        GitHub Profile
-                                    </a>
-                                    <a href="https://Pritz395.github.io/MY-GSOC-TOOL/"
-                                       target="_blank"
-                                       rel="noopener noreferrer"
-                                       class="inline-flex items-center px-4 py-2 border-2 border-[#e74c3c] text-[#e74c3c] rounded-lg hover:bg-[#e74c3c] hover:text-white transition-colors">
-                                        <i class="fas fa-tools mr-2"></i>
-                                        GSoC-Tool
-                                    </a>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-                            <!-- Vinamra Vaswani -->
-                            <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4 border border-gray-200 dark:border-gray-700">
-                                <div class="flex items-center gap-3 mb-3">
-                                    <div class="w-10 h-10 bg-red-100 rounded-full flex items-center justify-center">
-                                        <i class="fas fa-code text-[#e74c3c] text-sm"></i>
-                                    </div>
-                                    <div>
-                                        <h4 class="text-lg font-bold text-gray-900 dark:text-gray-100">Vinamra Vaswani</h4>
-                                        <p class="text-sm text-gray-600 dark:text-gray-400">Backend Systems</p>
-                                    </div>
-                                </div>
-                                <div class="mentor-description-container">
-                                    <p class="text-gray-600 dark:text-gray-400 text-base leading-relaxed mentor-description-text">
-                                        I am a software engineer experienced in building
-                                        production-grade backend systems using Python, FastAPI, and
-                                        MongoDB, with a focus on clean architecture and real-world
-                                        problem solving. Through open-source style projects and
-                                        mentorship programs, I have guided juniors in working with
-                                        real codebases, collaborative workflows, and maintainable
-                                        engineering practices. As a GSoC mentor, my goal is to help
-                                        students move from tutorials to confident real-world
-                                        contributors, while giving back to open source by supporting
-                                        their technical and professional growth in a learning-first
-                                        environment.
-                                    </p>
-                                </div>
-                            </div>
-                            <!-- Carla Voorhees -->
-                            <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4 border border-gray-200 dark:border-gray-700">
-                                <div class="flex items-center gap-3 mb-3">
-                                    <div class="w-10 h-10 bg-red-100 rounded-full flex items-center justify-center">
-                                        <i class="fas fa-code text-[#e74c3c] text-sm"></i>
-                                    </div>
-                                    <div>
-                                        <h4 class="text-lg font-bold text-gray-900 dark:text-gray-100">Carla Voorhees</h4>
-                                        <p class="text-sm text-gray-600 dark:text-gray-400">Technical Product Manager</p>
-                                    </div>
-                                </div>
-                                <div class="mentor-description-container">
-                                    <p class="text-gray-600 dark:text-gray-400 text-base leading-relaxed mentor-description-text">
-                                        I am a technical product manager with a background in cybersecurity
-                                        and data management. I have experience mentoring students,
-                                        helping them navigate complex requirements and understand best practices.
-                                        I focus on guiding students through the product development lifecycle,
-                                        from ideation to deployment, while fostering a collaborative and
-                                        inclusive learning environment. I help them to understand how to take
-                                        requirements and designs and turn them into working code. My goal is to empower
-                                        students to become confident contributors to open source communities.
-                                    </p>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    <!-- Siddharth Bansal -->
-                    <div class="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-100 dark:border-gray-800 p-8">
-                        <div class="flex items-center gap-6 mb-6">
-                            <div class="w-20 h-20 bg-red-100 rounded-full flex items-center justify-center">
-                                <i class="fab fa-github text-[#e74c3c] text-3xl"></i>
-                            </div>
-                            <div class="flex-1">
-                                <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100">Siddharth Bansal</h3>
-                                <p class="text-lg text-gray-600 dark:text-gray-400 mb-2">2026 Contributor</p>
-                                <div class="flex gap-4">
-                                    <a href="https://github.com/sidd190"
-                                       target="_blank"
-                                       rel="noopener noreferrer"
-                                       class="inline-flex items-center px-4 py-2 bg-[#e74c3c] text-white rounded-lg hover:bg-red-700 transition-colors">
-                                        <i class="fab fa-github mr-2"></i>
-                                        GitHub Profile
-                                    </a>
-                                    <a href="https://sidd190.github.io/MY-GSOC-TOOL/"
-                                       target="_blank"
-                                       rel="noopener noreferrer"
-                                       class="inline-flex items-center px-4 py-2 border-2 border-[#e74c3c] text-[#e74c3c] rounded-lg hover:bg-[#e74c3c] hover:text-white transition-colors">
-                                        <i class="fas fa-tools mr-2"></i>
-                                        GSoC-Tool
-                                    </a>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-                            <!-- Jigyasu Rajput -->
-                            <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4 border border-gray-200 dark:border-gray-700">
-                                <div class="flex items-center gap-3 mb-3">
-                                    <div class="w-10 h-10 bg-red-100 rounded-full flex items-center justify-center">
-                                        <i class="fas fa-code text-[#e74c3c] text-sm"></i>
-                                    </div>
-                                    <div>
-                                        <h4 class="text-lg font-bold text-gray-900 dark:text-gray-100">Jigyasu Rajput</h4>
-                                        <p class="text-sm text-gray-600 dark:text-gray-400">Full Stack Development</p>
-                                    </div>
-                                </div>
-                                <div class="mentor-description-container">
-                                    <p class="text-gray-600 dark:text-gray-400 text-base leading-relaxed mentor-description-text">
-                                        I'm a full-stack developer with prior GSoC experience and a
-                                        deep love for open source. Having been a contributor myself, I
-                                        know how overwhelming it can feel at the start — from
-                                        understanding huge codebases to shipping your first meaningful
-                                        PR. As a mentor, I focus on helping people build confidence
-                                        through clean practices, thoughtful code reviews, and
-                                        real-world problem solving. I stay active in open source
-                                        because collaboration and shared learning are what actually
-                                        move great software forward.
-                                    </p>
-                                </div>
-                            </div>
-                            <!-- Rishab Kumar Jha -->
-                            <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4 border border-gray-200 dark:border-gray-700">
-                                <div class="flex items-center gap-3 mb-3">
-                                    <div class="w-10 h-10 bg-red-100 rounded-full flex items-center justify-center">
-                                        <i class="fas fa-code text-[#e74c3c] text-sm"></i>
-                                    </div>
-                                    <div>
-                                        <h4 class="text-lg font-bold text-gray-900 dark:text-gray-100">Rishab Kumar Jha</h4>
-                                        <p class="text-sm text-gray-600 dark:text-gray-400">Full Stack/Blockchain</p>
-                                    </div>
-                                </div>
-                                <div class="mentor-description-container">
-                                    <p class="text-gray-600 dark:text-gray-400 text-base leading-relaxed mentor-description-text">
-                                        I'm a software developer interested in distributed systems,
-                                        web3, cloud native technologies & deep-tech. As a past GSoC
-                                        and LFX alumnus myself, I understand the pain points of new
-                                        contributors. Happy to mentor and help mentees navigate
-                                        open-source effectively.
-                                    </p>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-
-                    <!-- Manahil Afzal -->
-<div class="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-100 dark:border-gray-800 p-8">
-    <div class="flex items-center gap-6 mb-6">
-        <div class="w-20 h-20 bg-red-100 rounded-full flex items-center justify-center">
-            <i class="fab fa-github text-[#e74c3c] text-3xl"></i>
-        </div>
-        <div class="flex-1">
-            <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100">Manahil Afzal</h3>
-            <p class="text-lg text-gray-600 dark:text-gray-400 mb-2">MERN Stack Engineer / 2026 Contributor</p>
-            <p class="text-gray-600 dark:text-gray-400 mb-4 text-sm">
-                Passionate about building meaningful web applications. Exploring cloud, AI, and open source programs like GSoC & Outreachy. Interested in contributing to organizations like OWASP Foundation & Apache.
-            </p>
-            <div class="flex gap-4">
-                <a href="https://github.com/Manahil-Afzal"
-                   target="_blank"
-                   rel="noopener noreferrer"
-                   class="inline-flex items-center px-4 py-2 bg-[#e74c3c] text-white rounded-lg hover:bg-red-700 transition-colors">
-                    <i class="fab fa-github mr-2"></i>
-                    GitHub Profile
-                </a>
-                <a href="https://manahil-afzal.github.io/MY-GSOC-TOOL/"
-                   target="_blank"
-                   rel="noopener noreferrer"
-                   class="inline-flex items-center px-4 py-2 border-2 border-[#e74c3c] text-[#e74c3c] rounded-lg hover:bg-[#e74c3c] hover:text-white transition-colors">
-                    <i class="fas fa-tools mr-2"></i>
-                    GSoC Tool
-                </a>
-            </div>
-        </div>
-    </div>
+  </div>
 </div>
-
-                    <!-- Sakshee Suman -->
-                    <div class="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-100 dark:border-gray-800 p-8">
-                        <div class="flex items-center gap-6 mb-6">
-                            <div class="w-20 h-20 bg-red-100 rounded-full flex items-center justify-center">
-                                <i class="fab fa-github text-[#e74c3c] text-3xl"></i>
-                            </div>
-                            <div class="flex-1">
-                                <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100">Sakshee Suman</h3>
-                                <p class="text-lg text-gray-600 dark:text-gray-400 mb-2">2026 Contributor</p>
-                                <div class="flex gap-4">
-                                    <a href="https://github.com/e-esakman"
-                                       target="_blank"
-                                       rel="noopener noreferrer"
-                                       class="inline-flex items-center px-4 py-2 bg-[#e74c3c] text-white rounded-lg hover:bg-red-700 transition-colors">
-                                        <i class="fab fa-github mr-2"></i>
-                                        GitHub Profile
-                                    </a>
-                                    <a href="https://e-esakman.github.io/MY-GSOC-TOOL/"
-                                       target="_blank"
-                                       rel="noopener noreferrer"
-                                       class="inline-flex items-center px-4 py-2 border-2 border-[#e74c3c] text-[#e74c3c] rounded-lg hover:bg-[#e74c3c] hover:text-white transition-colors">
-                                        <i class="fas fa-tools mr-2"></i>
-                                        GSoC-Tool
-                                    </a>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    <!-- Arnav Kirti -->
-                    <div class="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-100 dark:border-gray-800 p-8">
-                        <div class="flex items-center gap-6 mb-6">
-                            <div class="w-20 h-20 bg-red-100 rounded-full flex items-center justify-center">
-                                <i class="fab fa-github text-[#e74c3c] text-3xl"></i>
-                            </div>
-                            <div class="flex-1">
-                                <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100">Arnav Kirti</h3>
-                                <p class="text-lg text-gray-600 dark:text-gray-400 mb-2">2026 Contributor</p>
-                                <div class="flex gap-4">
-                                    <a href="https://github.com/arnavkirti"
-                                       target="_blank"
-                                       rel="noopener noreferrer"
-                                       class="inline-flex items-center px-4 py-2 bg-[#e74c3c] text-white rounded-lg hover:bg-red-700 transition-colors">
-                                        <i class="fab fa-github mr-2"></i>
-                                        GitHub Profile
-                                    </a>
-                                    <a href="https://arnavkirti.github.io/MY-GSOC-TOOL/"
-                                       target="_blank"
-                                       rel="noopener noreferrer"
-                                       class="inline-flex items-center px-4 py-2 border-2 border-[#e74c3c] text-[#e74c3c] rounded-lg hover:bg-[#e74c3c] hover:text-white transition-colors">
-                                        <i class="fas fa-tools mr-2"></i>
-                                        GSoC-Tool
-                                    </a>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    <!-- Savio D'souza -->
-                    <div class="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-100 dark:border-gray-800 p-8">
-                        <div class="flex items-center gap-6 mb-6">
-                            <div class="w-20 h-20 bg-red-100 rounded-full flex items-center justify-center">
-                                <i class="fab fa-github text-[#e74c3c] text-3xl"></i>
-                            </div>
-                            <div class="flex-1">
-                                <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100">Savio D'souza</h3>
-                                <p class="text-lg text-gray-600 dark:text-gray-400 mb-2">2026 Contributor</p>
-                                <div class="flex gap-4">
-                                    <a href="https://github.com/S3DFX-CYBER"
-                                       target="_blank"
-                                       rel="noopener noreferrer"
-                                       class="inline-flex items-center px-4 py-2 bg-[#e74c3c] text-white rounded-lg hover:bg-red-700 transition-colors">
-                                        <i class="fab fa-github mr-2"></i>
-                                        GitHub Profile
-                                    </a>
-                                    <a href="https://S3DFX-CYBER.github.io/MY-GSOC-TOOL/"
-                                       target="_blank"
-                                       rel="noopener noreferrer"
-                                       class="inline-flex items-center px-4 py-2 border-2 border-[#e74c3c] text-[#e74c3c] rounded-lg hover:bg-[#e74c3c] hover:text-white transition-colors">
-                                        <i class="fas fa-tools mr-2"></i>
-                                        GSoC-Tool
-                                    </a>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    <!-- Jayant Malvi -->
-                    <div class="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-100 dark:border-gray-800 p-8">
-                        <div class="flex items-center gap-6 mb-6">
-                            <div class="w-20 h-20 bg-red-100 rounded-full flex items-center justify-center">
-                                <i class="fab fa-github text-[#e74c3c] text-3xl"></i>
-                            </div>
-                            <div class="flex-1">
-                                <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100">Jayant Malvi</h3>
-                                <p class="text-lg text-gray-600 dark:text-gray-400 mb-2">2026 Contributor</p>
-                                <div class="flex gap-4">
-                                    <a href="https://github.com/Jayant2908"
-                                       target="_blank"
-                                       rel="noopener noreferrer"
-                                       class="inline-flex items-center px-4 py-2 bg-[#e74c3c] text-white rounded-lg hover:bg-red-700 transition-colors">
-                                        <i class="fab fa-github mr-2"></i>
-                                        GitHub Profile
-                                    </a>
-                                    <a href="https://Jayant2908.github.io/MY-GSOC-TOOL/"
-                                       target="_blank"
-                                       rel="noopener noreferrer"
-                                       class="inline-flex items-center px-4 py-2 border-2 border-[#e74c3c] text-[#e74c3c] rounded-lg hover:bg-[#e74c3c] hover:text-white transition-colors">
-                                        <i class="fas fa-tools mr-2"></i>
-                                        GSoC-Tool
-                                    </a>
-                                </div>
-                            </div>
-                        </div>
-                        <!-- Mentors grid -->
-                        <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-                            <!-- Manikandan Chandran -->
-                            <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4 border border-gray-200 dark:border-gray-700">
-                                <div class="flex items-center gap-3 mb-3">
-                                    <div class="w-10 h-10 bg-red-100 rounded-full flex items-center justify-center">
-                                        <i class="fas fa-code text-[#e74c3c] text-sm"></i>
-                                    </div>
-                                    <div>
-                                        <h4 class="text-lg font-bold text-gray-900 dark:text-gray-100">Manikandan Chandran</h4>
-                                        <p class="text-sm text-gray-600 dark:text-gray-400">React/OAuth/REST API</p>
-                                    </div>
-                                </div>
-                                <div class="mentor-description-container">
-                                    <p class="text-gray-600 dark:text-gray-400 text-base leading-relaxed mentor-description-text">
-                                        Mentors teams on building secure React apps with real-world OAuth flows and robust REST APIs.
-                                    </p>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- Available Mentors Section -->
-                <div class="mt-16 bg-gray-50 dark:bg-gray-900 rounded-xl p-8 border border-gray-200 dark:border-gray-700">
-                    <h3 class="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-6 text-center">
-                        Available Mentors for Future Students
-                    </h3>
-                    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-                        <!-- Manikandan Chandran -->
-                        <div class="bg-white dark:bg-gray-800 rounded-lg p-6 border border-gray-200 dark:border-gray-700">
-                            <div class="flex items-center gap-3 mb-3">
-                                <div class="w-12 h-12 bg-red-100 rounded-full flex items-center justify-center">
-                                    <i class="fas fa-chalkboard-teacher text-[#e74c3c] text-lg"></i>
-                                </div>
-                                <div>
-                                    <h4 class="text-lg font-bold text-gray-900 dark:text-gray-100">Manikandan Chandran</h4>
-                                    <p class="text-sm text-gray-600 dark:text-gray-400">React/OAuth/REST API</p>
-                                </div>
-                            </div>
-                            <p class="text-gray-600 dark:text-gray-400 text-sm">
-                                Mentors teams on building secure React apps with real-world OAuth
-                                flows and robust REST APIs.
-                            </p>
-                        </div>
-                        <!-- Ahmed ElSheikh -->
-                        <div class="bg-white dark:bg-gray-800 rounded-lg p-6 border border-gray-200 dark:border-gray-700">
-                            <div class="flex items-center gap-3 mb-3">
-                                <div class="w-12 h-12 bg-red-100 rounded-full flex items-center justify-center">
-                                    <i class="fas fa-chalkboard-teacher text-[#e74c3c] text-lg"></i>
-                                </div>
-                                <div>
-                                    <h4 class="text-lg font-bold text-gray-900 dark:text-gray-100">Ahmed ElSheikh</h4>
-                                    <p class="text-sm text-gray-600 dark:text-gray-400">React/OAuth/REST API</p>
-                                </div>
-                            </div>
-                            <p class="text-gray-600 dark:text-gray-400 text-sm">
-                                Cybersecurity analyst and AI security engineer specializing in
-                                secure system design.
-                            </p>
-                        </div>
-                    </div>
-                </div>
+<!-- Main Content -->
+<div class="py-16 px-4 sm:px-6 lg:px-8 bg-white dark:bg-gray-800">
+  <div class="w-[85%] mx-auto">
+    <!-- Stats Section -->
+    <div class="mb-16">
+      <div class="grid grid-cols-1 sm:grid-cols-3 gap-6">
+        <div
+          class="bg-white dark:bg-gray-800 shadow-lg rounded-xl overflow-hidden transform"
+        >
+          <div class="p-2 bg-[#e74c3c]"></div>
+          <div class="p-6 text-center">
+            <div class="text-5xl font-bold mb-2 text-[#e74c3c]">100+</div>
+            <div class="text-gray-700 dark:text-gray-300 font-medium">
+              Countries Participated
             </div>
-            <!-- Past Mentors Section -->
-            <div class="bg-white dark:bg-gray-800 rounded-xl shadow-lg transition-all duration-300 p-8 mb-20 border border-gray-100 dark:border-gray-800">
-                <h2 class="text-3xl font-bold text-gray-900 dark:text-gray-100 text-center mb-2">Past GSoC Mentors</h2>
-                <div class="w-20 h-1 bg-[#e74c3c] mx-auto mb-8 rounded-full"></div>
-                <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
-                    <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-6 border border-gray-200 dark:border-gray-700">
-                        <h4 class="text-lg font-bold text-gray-900 dark:text-gray-100 mb-3 flex items-center">
-                            <i aria-hidden="true" class="fas fa-calendar-alt text-[#e74c3c] mr-2"></i>2025
-                        </h4>
-                        <ul class="space-y-2 text-gray-700 dark:text-gray-300">
-                            <li class="flex items-start">
-                                <i class="fas fa-user-tie text-[#e74c3c] mt-1 mr-2"></i>
-                                <span>Rahul Negi
-                                    <span class="text-gray-500 dark:text-gray-500">(Python/Django Mentor)</span></span>
-                                </li>
-                                <li class="flex items-start">
-                                    <i class="fas fa-user-tie text-[#e74c3c] mt-1 mr-2"></i>
-                                    <span>Bishal Das
-                                        <span class="text-gray-500 dark:text-gray-500">(Django & UI/UX Mentor)</span></span>
-                                    </li>
-                                    <li class="flex items-start">
-                                        <i class="fas fa-user-tie text-[#e74c3c] mt-1 mr-2"></i>
-                                        <span>Sudhir Palavalasa
-                                            <span class="text-gray-500 dark:text-gray-500">(Backend and OAuth mentor)</span></span>
-                                        </li>
-                                    </ul>
-                                </div>
-                                <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-6 border border-gray-200 dark:border-gray-700">
-                                    <h4 class="text-lg font-bold text-gray-900 dark:text-gray-100 mb-3 flex items-center">
-                                        <i aria-hidden="true" class="fas fa-calendar-alt text-[#e74c3c] mr-2"></i>2024
-                                    </h4>
-                                    <ul class="space-y-2 text-gray-700 dark:text-gray-300">
-                                        <li class="flex items-start">
-                                            <i class="fas fa-user-tie text-[#e74c3c] mt-1 mr-2"></i>
-                                            <span>Swapnil Shinde
-                                                <span class="text-gray-500 dark:text-gray-500">(Django and blockchain mentor)</span></span>
-                                            </li>
-                                            <li class="flex items-start">
-                                                <i class="fas fa-user-tie text-[#e74c3c] mt-1 mr-2"></i>
-                                                <span>Arkadii Yakovets
-                                                    <span class="text-gray-500 dark:text-gray-500">(Python/Django mentor)</span></span>
-                                                </li>
-                                            </ul>
-                                        </div>
-                                        <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-6 border border-gray-200 dark:border-gray-700">
-                                            <h4 class="text-lg font-bold text-gray-900 dark:text-gray-100 mb-3 flex items-center">
-                                                <i aria-hidden="true" class="fas fa-calendar-alt text-[#e74c3c] mr-2"></i>2023
-                                            </h4>
-                                            <ul class="space-y-2 text-gray-700 dark:text-gray-300">
-                                                <li class="flex items-start">
-                                                    <i class="fas fa-user-tie text-[#e74c3c] mt-1 mr-2"></i>
-                                                    <span>Aryan Ranjan
-                                                        <span class="text-gray-500 dark:text-gray-500">(Flutter and Django Mentor)</span></span>
-                                                    </li>
-                                                </ul>
-                                            </div>
-                                            <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-6 border border-gray-200 dark:border-gray-700">
-                                                <h4 class="text-lg font-bold text-gray-900 dark:text-gray-100 mb-3 flex items-center">
-                                                    <i aria-hidden="true" class="fas fa-calendar-alt text-[#e74c3c] mr-2"></i>2022
-                                                </h4>
-                                                <ul class="space-y-2 text-gray-700 dark:text-gray-300">
-                                                    <li class="flex items-start">
-                                                        <i class="fas fa-user-tie text-[#e74c3c] mt-1 mr-2"></i>
-                                                        <span>Sourav Badami
-                                                            <span class="text-gray-500 dark:text-gray-500">(Django Mentor)</span></span>
-                                                        </li>
-                                                        <li class="flex items-start">
-                                                            <i class="fas fa-user-tie text-[#e74c3c] mt-1 mr-2"></i>
-                                                            <span>Rahul Badami
-                                                                <span class="text-gray-500 dark:text-gray-500">(Payments Mentor)</span></span>
-                                                            </li>
-                                                            <li class="flex items-start">
-                                                                <i class="fas fa-user-tie text-[#e74c3c] mt-1 mr-2"></i>
-                                                                <span>Ankit Choudhary
-                                                                    <span class="text-gray-500 dark:text-gray-500">(Flutter Mentor)</span></span>
-                                                                </li>
-                                                                <li class="flex items-start">
-                                                                    <i class="fas fa-user-tie text-[#e74c3c] mt-1 mr-2"></i>
-                                                                    <span>Sparsh Agrawal
-                                                                        <span class="text-gray-500 dark:text-gray-500">(Flutter Mentor)</span></span>
-                                                                    </li>
-                                                                </ul>
-                                                            </div>
-                                                            <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-6 border border-gray-200 dark:border-gray-700">
-                                                                <h4 class="text-lg font-bold text-gray-900 dark:text-gray-100 mb-3 flex items-center">
-                                                                    <i aria-hidden="true" class="fas fa-calendar-alt text-[#e74c3c] mr-2"></i>2020-2021
-                                                                </h4>
-                                                                <ul class="space-y-2 text-gray-700 dark:text-gray-300">
-                                                                    <li class="flex items-start">
-                                                                        <i class="fas fa-user-tie text-[#e74c3c] mt-1 mr-2"></i>
-                                                                        <span>Sourav Badami
-                                                                            <span class="text-gray-500 dark:text-gray-500">(Django Mentor)</span></span>
-                                                                        </li>
-                                                                    </ul>
-                                                                </div>
-                                                            </div>
-                                                        </div>
-                                                    </div>
-                                                </div>
-                                            {% endblock content %}
+          </div>
+        </div>
+        <div
+          class="bg-white dark:bg-gray-800 shadow-lg rounded-xl overflow-hidden transform"
+        >
+          <div class="p-2 bg-[#e74c3c]"></div>
+          <div class="p-6 text-center">
+            <div class="text-5xl font-bold mb-2 text-[#e74c3c]">7</div>
+            <div class="text-gray-700 dark:text-gray-300 font-medium">
+              Years with OWASP BLT
+            </div>
+          </div>
+        </div>
+        <div
+          class="bg-white dark:bg-gray-800 shadow-lg rounded-xl overflow-hidden transform"
+        >
+          <div class="p-2 bg-[#e74c3c]"></div>
+          <div class="p-6 text-center">
+            <div class="text-5xl font-bold mb-2 text-[#e74c3c]">20+</div>
+            <div class="text-gray-700 dark:text-gray-300 font-medium">
+              Successful Projects
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <!-- Benefits Section -->
+    <div class="mb-20">
+      <h2
+        class="text-3xl font-bold text-center text-gray-900 dark:text-gray-100 mb-2"
+      >
+        Program Benefits
+      </h2>
+      <div class="w-20 h-1 bg-[#e74c3c] mx-auto mb-12 rounded-full"></div>
+      <div class="grid grid-cols-1 lg:grid-cols-2 gap-10">
+        <!-- Student Benefits -->
+        <div
+          class="bg-white dark:bg-gray-800 rounded-xl shadow-lg transition-all duration-300 p-8 border border-gray-100 dark:border-gray-800"
+        >
+          <div class="flex items-center mb-6">
+            <div
+              class="w-12 h-12 flex items-center justify-center bg-red-100 text-[#e74c3c] rounded-full mr-4"
+            >
+              <i class="fas fa-user-graduate text-xl" aria-hidden="true"></i>
+            </div>
+            <h3 class="text-2xl font-bold text-gray-900 dark:text-gray-100">
+              For Students
+            </h3>
+          </div>
+          <ul class="space-y-4">
+            <li class="flex items-start">
+              <i
+                class="fas fa-check-circle text-[#e74c3c] mt-1 mr-3"
+                aria-hidden="true"
+              ></i>
+              <p class="text-gray-700 dark:text-gray-300">
+                Gaining exposure to real-world software development scenarios
+              </p>
+            </li>
+            <li class="flex items-start">
+              <i
+                class="fas fa-check-circle text-[#e74c3c] mt-1 mr-3"
+                aria-hidden="true"
+              ></i>
+              <p class="text-gray-700 dark:text-gray-300">
+                An opportunity for employment in areas related to their academic
+                pursuits
+              </p>
+            </li>
+            <li class="flex items-start">
+              <i
+                class="fas fa-check-circle text-[#e74c3c] mt-1 mr-3"
+                aria-hidden="true"
+              ></i>
+              <p class="text-gray-700 dark:text-gray-300">
+                Google will be offering successful student contributors a
+                stipend
+              </p>
+            </li>
+            <li class="flex items-start">
+              <i
+                class="fas fa-check-circle text-[#e74c3c] mt-1 mr-3"
+                aria-hidden="true"
+              ></i>
+              <p class="text-gray-700 dark:text-gray-300">
+                Build your professional network
+              </p>
+            </li>
+            <li class="flex items-start">
+              <i
+                class="fas fa-check-circle text-[#e74c3c] mt-1 mr-3"
+                aria-hidden="true"
+              ></i>
+              <p class="text-gray-700 dark:text-gray-300">
+                Gain valuable experience in cybersecurity
+              </p>
+            </li>
+            <li class="flex items-start">
+              <i
+                class="fas fa-check-circle text-[#e74c3c] mt-1 mr-3"
+                aria-hidden="true"
+              ></i>
+              <p class="text-gray-700 dark:text-gray-300">
+                Receive a certificate upon completion
+              </p>
+            </li>
+          </ul>
+        </div>
+        <!-- Mentor Benefits -->
+        <div
+          class="bg-white dark:bg-gray-800 rounded-xl shadow-lg transition-all duration-300 p-8 border border-gray-100 dark:border-gray-800"
+        >
+          <div class="flex items-center mb-6">
+            <div
+              class="w-12 h-12 flex items-center justify-center bg-red-100 text-[#e74c3c] rounded-full mr-4"
+            >
+              <i
+                class="fas fa-chalkboard-teacher text-xl"
+                aria-hidden="true"
+              ></i>
+            </div>
+            <h3 class="text-2xl font-bold text-gray-900 dark:text-gray-100">
+              For Mentors
+            </h3>
+          </div>
+          <ul class="space-y-4">
+            <li class="flex items-start">
+              <i
+                class="fas fa-check-circle text-[#e74c3c] mt-1 mr-3"
+                aria-hidden="true"
+              ></i>
+              <p class="text-gray-700 dark:text-gray-300">
+                Shape the next generation of open-source developers
+              </p>
+            </li>
+            <li class="flex items-start">
+              <i
+                class="fas fa-check-circle text-[#e74c3c] mt-1 mr-3"
+                aria-hidden="true"
+              ></i>
+              <p class="text-gray-700 dark:text-gray-300">
+                Enhance project visibility and community engagement
+              </p>
+            </li>
+            <li class="flex items-start">
+              <i
+                class="fas fa-check-circle text-[#e74c3c] mt-1 mr-3"
+                aria-hidden="true"
+              ></i>
+              <p class="text-gray-700 dark:text-gray-300">
+                Develop leadership and mentoring skills
+              </p>
+            </li>
+            <li class="flex items-start">
+              <i
+                class="fas fa-check-circle text-[#e74c3c] mt-1 mr-3"
+                aria-hidden="true"
+              ></i>
+              <p class="text-gray-700 dark:text-gray-300">
+                Expand your professional network within OWASP
+              </p>
+            </li>
+            <li class="flex items-start">
+              <i
+                class="fas fa-check-circle text-[#e74c3c] mt-1 mr-3"
+                aria-hidden="true"
+              ></i>
+              <p class="text-gray-700 dark:text-gray-300">
+                Recognition in the global security community
+              </p>
+            </li>
+            <li class="flex items-start">
+              <i
+                class="fas fa-check-circle text-[#e74c3c] mt-1 mr-3"
+                aria-hidden="true"
+              ></i>
+              <p class="text-gray-700 dark:text-gray-300">
+                Contribute to the growth of open-source security projects
+              </p>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+    <!-- OWASP Partnership Card -->
+    <div
+      class="bg-white rounded-xl shadow-lg transition-all duration-300 p-8 mb-20 border border-gray-100"
+    >
+      <h2 class="text-3xl font-bold text-gray-900 mb-6">
+        OWASP BLT & GSOC Partnership
+      </h2>
+      <div class="space-y-6 text-gray-700">
+        <p class="leading-relaxed">
+          OWASP is an open community dedicated to enabling organizations to
+          conceive, develop, acquire, operate, and maintain applications that
+          can be trusted. OWASP has been an active participant in the Google
+          Summer of Code program, providing students with the opportunity to
+          contribute to various OWASP projects.
+        </p>
+        <p class="leading-relaxed">
+          OWASP BLT (Bug Logging Tool) has been participating in the Google
+          Summer of Code program for the past 5 consecutive years, from 2020 to
+          2024. OWASP BLT is an open-source platform dedicated to making the
+          internet safer through community-driven bug reporting and
+          collaboration.
+        </p>
+        <p class="leading-relaxed">
+          All students currently enrolled in an accredited institution are
+          welcome to participate in the Google Summer of Code program, hopefully
+          along with the OWASP Foundation.
+        </p>
+      </div>
+    </div>
+    <!-- Project Ideas Section -->
+    <div class="mb-20">
+      <h2
+        class="text-3xl font-bold text-center text-gray-900 dark:text-gray-100 mb-2"
+      >
+        Project Ideas
+      </h2>
+      <div class="w-20 h-1 bg-[#e74c3c] mx-auto mb-12 rounded-full"></div>
+      <!-- OWASP BLT Projects (Highlighted) -->
+      <div class="mb-12">
+        <a
+          href="https://github.com/OWASP-BLT/BLT/milestones"
+          rel="noopener noreferrer"
+          target="_blank"
+          class="block p-8 bg-gradient-to-br from-red-50 to-red-100 border-2 border-red-200 rounded-xl transition-all"
+        >
+          <div class="flex flex-col md:flex-row items-center justify-between">
+            <div class="mb-6 md:mb-0">
+              <h3 class="text-2xl font-bold text-red-700 mb-3">
+                OWASP BLT Project Ideas
+              </h3>
+              <p class="text-red-600 text-lg mb-4">
+                Explore exciting project opportunities with OWASP Bug Logging
+                Tool
+              </p>
+              <span
+                class="inline-block px-4 py-2 bg-white dark:bg-gray-800 text-[#e74c3c] rounded-full font-medium"
+                >Featured Projects</span
+              >
+            </div>
+            <div class="text-center">
+              <div
+                class="w-24 h-24 flex items-center justify-center bg-white dark:bg-gray-800 rounded-full mb-4 shadow-md mx-auto"
+              >
+                <i class="fa-solid fa-lightbulb text-[#e74c3c] text-4xl"></i>
+              </div>
+              <span class="inline-flex items-center text-[#e74c3c] font-medium">
+                Browse Now <i class="fa-solid fa-arrow-right ml-2"></i>
+              </span>
+            </div>
+          </div>
+        </a>
+      </div>
+      <!-- Past Ideas Grid -->
+      <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <a
+          href="https://owasp.org/www-community/initiatives/gsoc/gsoc2025ideas"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="group block p-5 bg-white dark:bg-gray-800 shadow-md rounded-lg border border-gray-100 dark:border-gray-800 transition-all"
+        >
+          <div class="flex items-center">
+            <span
+              class="font-semibold text-gray-900 dark:text-gray-100 group-hover:text-[#e74c3c] transition-colors"
+              >GSOC Project Ideas 2025</span
+            >
+            <i
+              class="fa-solid fa-link ml-auto text-gray-400 dark:text-gray-600 group-hover:text-[#e74c3c]"
+            ></i>
+          </div>
+        </a>
+        <a
+          href="https://owasp.org/www-community/initiatives/gsoc/gsoc2024ideas"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="group block p-5 bg-white dark:bg-gray-800 shadow-md rounded-lg border border-gray-100 dark:border-gray-800 transition-all"
+        >
+          <div class="flex items-center">
+            <span
+              class="font-semibold text-gray-900 dark:text-gray-100 group-hover:text-[#e74c3c] transition-colors"
+              >GSOC Project Ideas 2024</span
+            >
+            <i
+              class="fa-solid fa-link ml-auto text-gray-400 dark:text-gray-600 group-hover:text-[#e74c3c]"
+            ></i>
+          </div>
+        </a>
+        <a
+          href="https://owasp.org/www-community/initiatives/gsoc/gsoc2023ideas"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="group block p-5 bg-white dark:bg-gray-800 shadow-md rounded-lg border border-gray-100 dark:border-gray-800 transition-all"
+        >
+          <div class="flex items-center">
+            <span
+              class="font-semibold text-gray-900 dark:text-gray-100 group-hover:text-[#e74c3c] transition-colors"
+              >GSOC Project Ideas 2023</span
+            >
+            <i
+              class="fa-solid fa-link ml-auto text-gray-400 dark:text-gray-600 group-hover:text-[#e74c3c]"
+            ></i>
+          </div>
+        </a>
+        <a
+          href="https://owasp.org/www-community/initiatives/gsoc/gsoc2022ideas"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="group block p-5 bg-white dark:bg-gray-800 shadow-md rounded-lg border border-gray-100 dark:border-gray-800 transition-all"
+        >
+          <div class="flex items-center">
+            <span
+              class="font-semibold text-gray-900 dark:text-gray-100 group-hover:text-[#e74c3c] transition-colors"
+              >GSOC Project Ideas 2022</span
+            >
+            <i
+              class="fa-solid fa-link ml-auto text-gray-400 dark:text-gray-600 group-hover:text-[#e74c3c]"
+            ></i>
+          </div>
+        </a>
+        <a
+          href="https://owasp.org/www-community/initiatives/gsoc/gsoc2021ideas"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="group block p-5 bg-white dark:bg-gray-800 shadow-md rounded-lg border border-gray-100 dark:border-gray-800 transition-all"
+        >
+          <div class="flex items-center">
+            <span
+              class="font-semibold text-gray-900 dark:text-gray-100 group-hover:text-[#e74c3c] transition-colors"
+              >GSOC Project Ideas 2021</span
+            >
+            <i
+              class="fa-solid fa-link ml-auto text-gray-400 dark:text-gray-600 group-hover:text-[#e74c3c]"
+            ></i>
+          </div>
+        </a>
+        <a
+          href="https://owasp.org/www-community/initiatives/gsoc/gsoc2020ideas"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="group block p-5 bg-white dark:bg-gray-800 shadow-md rounded-lg border border-gray-100 dark:border-gray-800 transition-all"
+        >
+          <div class="flex items-center">
+            <span
+              class="font-semibold text-gray-900 dark:text-gray-100 group-hover:text-[#e74c3c] transition-colors"
+              >GSOC Project Ideas 2020</span
+            >
+            <i
+              class="fa-solid fa-link ml-auto text-gray-400 dark:text-gray-600 group-hover:text-[#e74c3c]"
+            ></i>
+          </div>
+        </a>
+        <a
+          href="https://owasp.org/www-community/initiatives/gsoc/gsoc2019ideas"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="group block p-5 bg-white dark:bg-gray-800 shadow-md rounded-lg border border-gray-100 dark:border-gray-800 transition-all"
+        >
+          <div class="flex items-center">
+            <span
+              class="font-semibold text-gray-900 dark:text-gray-100 group-hover:text-[#e74c3c] transition-colors"
+              >GSOC Project Ideas 2019</span
+            >
+            <i
+              class="fa-solid fa-link ml-auto text-gray-400 dark:text-gray-600 group-hover:text-[#e74c3c]"
+            ></i>
+          </div>
+        </a>
+        <a
+          href="https://owasp.org/www-community/initiatives/gsoc/gsoc2018ideas"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="group block p-5 bg-white dark:bg-gray-800 shadow-md rounded-lg border border-gray-100 dark:border-gray-800 transition-all"
+        >
+          <div class="flex items-center">
+            <span
+              class="font-semibold text-gray-900 dark:text-gray-100 group-hover:text-[#e74c3c] transition-colors"
+              >GSOC Project Ideas 2018</span
+            >
+            <i
+              class="fa-solid fa-link ml-auto text-gray-400 dark:text-gray-600 group-hover:text-[#e74c3c]"
+            ></i>
+          </div>
+        </a>
+        <a
+          href="https://owasp.org/www-community/initiatives/gsoc/gsoc2017ideas"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="group block p-5 bg-white dark:bg-gray-800 shadow-md rounded-lg border border-gray-100 dark:border-gray-800 transition-all"
+        >
+          <div class="flex items-center">
+            <span
+              class="font-semibold text-gray-900 dark:text-gray-100 group-hover:text-[#e74c3c] transition-colors"
+              >GSOC Project Ideas 2017</span
+            >
+            <i
+              class="fa-solid fa-link ml-auto text-gray-400 dark:text-gray-600 group-hover:text-[#e74c3c]"
+            ></i>
+          </div>
+        </a>
+      </div>
+    </div>
+    <!-- Past Events -->
+    <div
+      class="bg-white dark:bg-gray-800 rounded-xl shadow-lg transition-all duration-300 p-8 mb-20 border border-gray-100 dark:border-gray-800"
+    >
+      <h2 class="text-3xl font-bold text-gray-900 dark:text-gray-100 mb-6">
+        Past GSOC Events
+      </h2>
+      <div class="grid grid-cols-1 lg:grid-cols-2 gap-8">
+        <!-- 2023 -->
+        <div
+          class="bg-white dark:bg-gray-800 rounded-lg shadow-md transition-all border border-gray-200 dark:border-gray-700 overflow-hidden"
+        >
+          <div class="p-2 bg-[#e74c3c]"></div>
+          <div class="p-6">
+            <a
+              href="https://summerofcode.withgoogle.com/archive/2023/organizations/owasp-foundation"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="text-xl font-bold text-gray-900 dark:text-gray-100 hover:text-[#e74c3c] transition-colors flex items-center mb-4"
+            >
+              <i
+                aria-hidden="true"
+                class="fas fa-calendar-alt mr-2 text-[#e74c3c]"
+              ></i>
+              2023 GSOC Archive
+            </a>
+            <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4">
+              <h4
+                class="text-lg font-semibold text-gray-800 dark:text-gray-200 mb-2 flex items-center"
+              >
+                <i
+                  aria-hidden="true"
+                  class="fas fa-users mr-2 text-[#e74c3c]"
+                ></i>
+                Mentors
+              </h4>
+              <p class="text-gray-700 dark:text-gray-300 leading-relaxed">
+                Abraham Aranguren, Aryan Prasad, Aryan Ranjan, Ben de Haan,
+                Björn Kimminich, Christian Folini, DonnieBLT, fzipitria, Jannik
+                Hollenbach, José Carlos Chávez, Mrigank Anand, Rick M,
+                ShubhamPalriwala, Simon Bennetts, thc202, Timo Pagel, Viyat
+              </p>
+            </div>
+          </div>
+        </div>
+        <!-- 2022 -->
+        <div
+          class="bg-white dark:bg-gray-800 rounded-lg shadow-md transition-all border border-gray-200 dark:border-gray-700 overflow-hidden"
+        >
+          <div class="p-2 bg-[#e74c3c]"></div>
+          <div class="p-6">
+            <a
+              href="https://summerofcode.withgoogle.com/archive/2022/organizations/owasp-foundation"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="text-xl font-bold text-gray-900 dark:text-gray-100 hover:text-[#e74c3c] transition-colors flex items-center mb-4"
+            >
+              <i
+                aria-hidden="true"
+                class="fas fa-calendar-alt mr-2 text-[#e74c3c]"
+              ></i>
+              2022 GSOC Archive
+            </a>
+            <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4">
+              <h4
+                class="text-lg font-semibold text-gray-800 dark:text-gray-200 mb-2 flex items-center"
+              >
+                <i
+                  aria-hidden="true"
+                  class="fas fa-users mr-2 text-[#e74c3c]"
+                ></i>
+                Mentors
+              </h4>
+              <p class="text-gray-700 dark:text-gray-300 leading-relaxed">
+                Abraham Aranguren, Ade Yoseman Putra, Ankit Choudhary, Björn
+                Kimminich, Dhiren Serai, Franziska, fzipitria, Glenn Ten Cate,
+                Jannik Hollenbach, Rejah Rehim, Rick M, Saeed Dehqan, Sam
+                Stepanyan, Sparsh Agrawal, thc202, Timo Pagel, Viyat
+              </p>
+            </div>
+          </div>
+        </div>
+        <!-- 2021 -->
+        <div
+          class="bg-white dark:bg-gray-800 rounded-lg shadow-md transition-all border border-gray-200 dark:border-gray-700 overflow-hidden"
+        >
+          <div class="p-2 bg-[#e74c3c]"></div>
+          <div class="p-6">
+            <a
+              href="https://summerofcode.withgoogle.com/archive/2021/organizations/owasp-foundation"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="text-xl font-bold text-gray-900 dark:text-gray-100 hover:text-[#e74c3c] transition-colors flex items-center mb-4"
+            >
+              <i
+                aria-hidden="true"
+                class="fas fa-calendar-alt mr-2 text-[#e74c3c]"
+              ></i>
+              2021 GSOC Archive
+            </a>
+            <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4">
+              <h4
+                class="text-lg font-semibold text-gray-800 dark:text-gray-200 mb-2 flex items-center"
+              >
+                <i
+                  aria-hidden="true"
+                  class="fas fa-users mr-2 text-[#e74c3c]"
+                ></i>
+                Mentors
+              </h4>
+              <p class="text-gray-700 dark:text-gray-300 leading-relaxed">
+                8f040, Abe, Abraham Aranguren, Ade Yoseman Putra, Ali Razmjoo
+                Qalaei, Anshul Singhal, Ashrith N Shetty, Björn Kimminich,
+                Damien Carol, Dhiren Devinder Serai, Glenn ten Cate, Jannik
+                Hollenbach, madchap, Mohit Sharma-2, Rejah Rehim, Riccardo Cate,
+                Rick M, Saeed Dehqan-1, Sam Stepanyan, Simon Bennetts, Sourav
+                Badami, thc202
+              </p>
+            </div>
+          </div>
+        </div>
+        <!-- 2020 -->
+        <div
+          class="bg-white dark:bg-gray-800 rounded-lg shadow-md transition-all border border-gray-200 dark:border-gray-700 overflow-hidden"
+        >
+          <div class="p-2 bg-[#e74c3c]"></div>
+          <div class="p-6">
+            <a
+              href="https://summerofcode.withgoogle.com/archive/2020/organizations/owasp-foundation"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="text-xl font-bold text-gray-900 dark:text-gray-100 hover:text-[#e74c3c] transition-colors flex items-center mb-4"
+            >
+              <i
+                aria-hidden="true"
+                class="fas fa-calendar-alt mr-2 text-[#e74c3c]"
+              ></i>
+              2020 GSOC Archive
+            </a>
+            <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4">
+              <h4
+                class="text-lg font-semibold text-gray-800 dark:text-gray-200 mb-2 flex items-center"
+              >
+                <i
+                  aria-hidden="true"
+                  class="fas fa-users mr-2 text-[#e74c3c]"
+                ></i>
+                Mentors
+              </h4>
+              <p class="text-gray-700 dark:text-gray-300 leading-relaxed">
+                Abe, Abraham Aranguren, Ade Yoseman Putra, Adrian Winckles, Ali
+                Razmjoo Qalaei, Björn Kimminich, Felipe Zipitria, Glenn ten
+                Cate, Jannik Hollenbach, Mohit Sharma, Rejah Rehim A A, Rejah
+                Rehim, Ricardo Pereira, Riccardo ten Cate, Rick M, S,
+                securestep9, Simon Bennetts, Soham Marik, souravbadami, spyros,
+                Sri Harsha G, Timo Pagel, Viyat Bhalodia
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <!-- Success Stories -->
+    <div
+      class="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-100 dark:border-gray-800 p-8 mb-12"
+    >
+      <h2
+        class="text-3xl font-bold text-gray-900 dark:text-gray-100 mb-2 text-center"
+      >
+        Success Stories
+      </h2>
+      <div class="w-20 h-1 bg-[#e74c3c] mx-auto mb-8 rounded-full"></div>
+      <div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
+        <!-- Shirish Jain -->
+        <div
+          class="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md border border-gray-100 dark:border-gray-800"
+        >
+          <div class="flex items-center gap-4 mb-6">
+            <div
+              class="w-16 h-16 bg-red-100 rounded-full flex items-center justify-center"
+            >
+              <i class="fas fa-code text-[#e74c3c] text-2xl"></i>
+            </div>
+            <div>
+              <h3 class="text-2xl font-semibold">Shirish Jain</h3>
+              <p class="text-gray-600 dark:text-gray-400">GSoC 2023</p>
+            </div>
+          </div>
+          <p class="text-gray-700 dark:text-gray-300 mb-6 text-lg">
+            Successfully implemented the Sizzle Time Tracking feature during
+            GSoC 2023.
+          </p>
+          <div class="flex gap-4">
+            <a
+              href="https://medium.com/@shirishjain.2001/gsoc-2023-final-report-owasp-bug-logging-tool-f70d6368f9f5"
+              class="flex-1 hover:text-white bg-[#e74c3c] text-white py-2 px-4 rounded-lg hover:bg-red-700 transition-colors text-center flex items-center justify-center gap-2"
+            >
+              <i class="fas fa-book-open"></i>
+              <span>Read Blog</span>
+            </a>
+            <a
+              href="https://blt.owasp.org/contributors/?contributor=37"
+              class="flex-1 border-2 border-[#e74c3c] text-[#e74c3c] py-2 px-4 rounded-lg hover:bg-[#e74c3c] hover:text-white transition-colors text-center flex items-center justify-center gap-2"
+            >
+              <i class="fas fa-user"></i>
+              <span>Profile</span>
+            </a>
+          </div>
+        </div>
+        <!-- Aryan Ranjan -->
+        <div
+          class="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md border border-gray-100 dark:border-gray-800"
+        >
+          <div class="flex items-center gap-4 mb-6">
+            <div
+              class="w-16 h-16 bg-red-100 rounded-full flex items-center justify-center"
+            >
+              <i class="fas fa-comments text-[#e74c3c] text-2xl"></i>
+            </div>
+            <div>
+              <h3 class="text-2xl font-semibold">Aryan Ranjan</h3>
+              <p class="text-gray-600 dark:text-gray-400">GSoC 2023</p>
+            </div>
+          </div>
+          <p class="text-gray-700 dark:text-gray-300 mb-6 text-lg">
+            Developed the Discussion Room feature during GSoC 2023.
+          </p>
+          <div class="flex gap-4">
+            <a
+              href="https://medium.com/@justary27/my-gsoc22-voyage-beginning-4296df5af625"
+              class="flex-1 hover:text-white bg-[#e74c3c] text-white py-2 px-4 rounded-lg hover:bg-red-700 transition-colors text-center flex items-center justify-center gap-2"
+            >
+              <i class="fas fa-book-open"></i>
+              <span>Read Blog</span>
+            </a>
+            <a
+              href="https://blt.owasp.org/contributors/?contributor=1"
+              class="flex-1 border-2 border-[#e74c3c] text-[#e74c3c] py-2 px-4 rounded-lg hover:bg-[#e74c3c] hover:text-white transition-colors text-center flex items-center justify-center gap-2"
+            >
+              <i class="fas fa-user"></i>
+              <span>Profile</span>
+            </a>
+          </div>
+        </div>
+        <!-- Swapnil Shinde -->
+        <div
+          class="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md border border-gray-100 dark:border-gray-800"
+        >
+          <div class="flex items-center gap-4 mb-6">
+            <div
+              class="w-16 h-16 bg-red-100 rounded-full flex items-center justify-center"
+            >
+              <i class="fas fa-bug text-[#e74c3c] text-2xl"></i>
+            </div>
+            <div>
+              <h3 class="text-2xl font-semibold">Swapnil Shinde</h3>
+              <p class="text-gray-600 dark:text-gray-400">GSoC 2022</p>
+            </div>
+          </div>
+          <p class="text-gray-700 dark:text-gray-300 mb-6 text-lg">
+            Contributed to OWASP BLT development.
+          </p>
+          <div class="flex gap-4">
+            <a
+              href="https://gist.github.com/AtmegaBuzz/512a85827b5cc993e35c274dcbada669"
+              class="flex-1 hover:text-white bg-[#e74c3c] text-white py-2 px-4 rounded-lg hover:bg-red-700 transition-colors text-center flex items-center justify-center gap-2"
+            >
+              <i class="fas fa-file-alt"></i>
+              <span>Report</span>
+            </a>
+            <a
+              href="https://blt.owasp.org/contributors/?contributor=3"
+              class="flex-1 border-2 border-[#e74c3c] text-[#e74c3c] py-2 px-4 rounded-lg hover:bg-[#e74c3c] hover:text-white transition-colors text-center flex items-center justify-center gap-2"
+            >
+              <i class="fas fa-user"></i>
+              <span>Profile</span>
+            </a>
+          </div>
+        </div>
+        <!-- Bishal Das -->
+        <div
+          class="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md border border-gray-100 dark:border-gray-800"
+        >
+          <div class="flex items-center gap-4 mb-6">
+            <div
+              class="w-16 h-16 bg-red-100 rounded-full flex items-center justify-center"
+            >
+              <i class="fas fa-graduation-cap text-[#e74c3c] text-2xl"></i>
+            </div>
+            <div>
+              <h3 class="text-2xl font-semibold">Bishal Das</h3>
+              <p class="text-gray-600 dark:text-gray-400">GSoC 2024</p>
+            </div>
+          </div>
+          <p class="text-gray-700 dark:text-gray-300 mb-6 text-lg">
+            GSoC Learning journey with OWASP BLT.
+          </p>
+          <div class="flex gap-4">
+            <a
+              href="https://bishaldas.hashnode.dev/gsoc-2024-a-summer-of-learning-coding-and-growth"
+              class="flex-1 hover:text-white bg-[#e74c3c] text-white py-2 px-4 rounded-lg hover:bg-red-700 transition-colors text-center flex items-center justify-center gap-2"
+            >
+              <i class="fas fa-book-open"></i>
+              <span>Read Blog</span>
+            </a>
+            <a
+              href="https://blt.owasp.org/contributors/?contributor=5"
+              class="flex-1 border-2 border-[#e74c3c] text-[#e74c3c] py-2 px-4 rounded-lg hover:bg-[#e74c3c] hover:text-white transition-colors text-center flex items-center justify-center gap-2"
+            >
+              <i class="fas fa-user"></i>
+              <span>Profile</span>
+            </a>
+          </div>
+        </div>
+        <!-- Shubham Palriwala -->
+        <div
+          class="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md border border-gray-100 dark:border-gray-800"
+        >
+          <div class="flex items-center gap-4 mb-6">
+            <div
+              class="w-16 h-16 bg-red-100 rounded-full flex items-center justify-center"
+            >
+              <i class="fas fa-flask text-[#e74c3c] text-2xl"></i>
+            </div>
+            <div>
+              <h3 class="text-2xl font-semibold">Shubham Palriwala</h3>
+              <p class="text-gray-600 dark:text-gray-400">OWASP Juice Shop</p>
+            </div>
+          </div>
+          <p class="text-gray-700 dark:text-gray-300 mb-6 text-lg">
+            OWASP Juice Shop Journey
+          </p>
+          <div class="flex gap-4">
+            <a
+              href="https://medium.com/@shubhampalriwala/google-summer-of-code-journey-with-owasp-juice-shop-c1ca15c8e170"
+              class="flex-1 hover:text-white bg-[#e74c3c] text-white py-2 px-4 rounded-lg hover:bg-red-700 transition-colors text-center flex items-center justify-center gap-2"
+            >
+              <i class="fas fa-book-open"></i>
+              <span>Read Blog</span>
+            </a>
+          </div>
+        </div>
+        <!-- Akshay Behl -->
+        <div
+          class="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md border border-gray-100 dark:border-gray-800"
+        >
+          <div class="flex items-center gap-4 mb-6">
+            <div
+              class="w-16 h-16 bg-red-100 rounded-full flex items-center justify-center"
+            >
+              <i class="fas fa-network-wired text-[#e74c3c] text-2xl"></i>
+            </div>
+            <div>
+              <h3 class="text-2xl font-semibold">Akshay Behl</h3>
+              <p class="text-gray-600 dark:text-gray-400">OWASP Nettacker</p>
+            </div>
+          </div>
+          <p class="text-gray-700 dark:text-gray-300 mb-6 text-lg">
+            OWASP Nettacker Experience
+          </p>
+          <div class="flex gap-4">
+            <a
+              href="https://medium.com/@akshaybehl231/diving-into-open-source-owasp-nettacker-gsoc24-e73114f37a11"
+              class="flex-1 hover:text-white bg-[#e74c3c] text-white py-2 px-4 rounded-lg hover:bg-red-700 transition-colors text-center flex items-center justify-center gap-2"
+            >
+              <i class="fas fa-book-open"></i>
+              <span>Read Blog</span>
+            </a>
+          </div>
+        </div>
+        <!-- Chakshu Gupta -->
+        <div
+          class="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md border border-gray-100 dark:border-gray-800"
+        >
+          <div class="flex items-center gap-4 mb-6">
+            <div
+              class="w-16 h-16 bg-red-100 rounded-full flex items-center justify-center"
+            >
+              <i class="fas fa-shield-alt text-[#e74c3c] text-2xl"></i>
+            </div>
+            <div>
+              <h3 class="text-2xl font-semibold">Chakshu Gupta</h3>
+              <p class="text-gray-600 dark:text-gray-400">
+                OWASP Honeypot Project
+              </p>
+            </div>
+          </div>
+          <p class="text-gray-700 dark:text-gray-300 mb-6 text-lg">
+            OWASP Honeypot Project Journey
+          </p>
+          <div class="flex gap-4">
+            <a
+              href="https://medium.com/@ChGDream/my-google-summer-of-code-2020-journey-with-owasp-b772c3e67c3f"
+              class="flex-1 hover:text-white bg-[#e74c3c] text-white py-2 px-4 rounded-lg hover:bg-red-700 transition-colors text-center flex items-center justify-center gap-2"
+            >
+              <i class="fas fa-book-open"></i>
+              <span>Read Blog</span>
+            </a>
+          </div>
+        </div>
+        <!-- Rishabh Keshan -->
+        <div
+          class="bg-white dark:bg-gray-800 rounded-xl p-6 shadow-md border border-gray-100 dark:border-gray-800"
+        >
+          <div class="flex items-center gap-4 mb-6">
+            <div
+              class="w-16 h-16 bg-red-100 rounded-full flex items-center justify-center"
+            >
+              <i class="fas fa-cube text-[#e74c3c] text-2xl"></i>
+            </div>
+            <div>
+              <h3 class="text-2xl font-semibold">Rishabh Keshan</h3>
+              <p class="text-gray-600 dark:text-gray-400">Web3 Juice Shop</p>
+            </div>
+          </div>
+          <p class="text-gray-700 dark:text-gray-300 mb-6 text-lg">
+            Web3 Journey with Juice Shop
+          </p>
+          <div class="flex gap-4">
+            <a
+              href="https://medium.com/@ChGDream/my-google-summer-of-code-2020-journey-with-owasp-b772c3e67c3f"
+              class="flex-1 hover:text-white bg-[#e74c3c] text-white py-2 px-4 rounded-lg hover:bg-red-700 transition-colors text-center flex items-center justify-center gap-2"
+            >
+              <i class="fas fa-book-open"></i>
+              <span>Read Blog</span>
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+    <!-- GSoC 2026 Students Section -->
+    <div class="mb-20">
+      <h2
+        class="text-3xl font-bold text-center text-gray-900 dark:text-gray-100 mb-2"
+      >
+        2026 Contributors
+      </h2>
+      <div class="w-20 h-1 bg-[#e74c3c] mx-auto mb-12 rounded-full"></div>
+      <div class="flex items-start space-x-6 mb-8">
+        <div class="bg-red-100 rounded-full p-3 flex-shrink-0">
+          <i class="fas fa-star text-[#e74c3c] text-xl"></i>
+        </div>
+        <div>
+          <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100 mb-2">
+            Lead Mentor
+          </h3>
+          <p class="text-lg text-gray-800 dark:text-gray-200 font-medium mb-1">
+            Donnie Brown (All years)
+          </p>
+        </div>
+      </div>
+      <div class="space-y-8">
+        <!-- Md Kaif Ansari -->
+        <div
+          class="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-100 dark:border-gray-800 p-8"
+        >
+          <div class="flex items-center gap-6 mb-6">
+            <div
+              class="w-20 h-20 bg-red-100 rounded-full flex items-center justify-center"
+            >
+              <i class="fab fa-github text-[#e74c3c] text-3xl"></i>
+            </div>
+            <div class="flex-1">
+              <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100">
+                Md Kaif Ansari
+              </h3>
+              <p class="text-lg text-gray-600 dark:text-gray-400 mb-2">
+                2026 Contributor
+              </p>
+              <div class="flex gap-4">
+                <a
+                  href="https://github.com/mdkaifansari04"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="inline-flex items-center px-4 py-2 bg-[#e74c3c] text-white rounded-lg hover:bg-red-700 transition-colors"
+                >
+                  <i class="fab fa-github mr-2"></i>
+                  GitHub Profile
+                </a>
+                <a
+                  href="https://mdkaifansari04.github.io/MY-GSOC-TOOL/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="inline-flex items-center px-4 py-2 border-2 border-[#e74c3c] text-[#e74c3c] rounded-lg hover:bg-[#e74c3c] hover:text-white transition-colors"
+                >
+                  <i class="fas fa-tools mr-2"></i>
+                  GSoC-Tool
+                </a>
+              </div>
+            </div>
+          </div>
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <!-- Rinkit Adhana -->
+            <div
+              class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4 border border-gray-200 dark:border-gray-700"
+            >
+              <div class="flex items-center gap-3 mb-3">
+                <div
+                  class="w-10 h-10 bg-red-100 rounded-full flex items-center justify-center"
+                >
+                  <i class="fas fa-code text-[#e74c3c] text-sm"></i>
+                </div>
+                <div>
+                  <h4
+                    class="text-lg font-bold text-gray-900 dark:text-gray-100"
+                  >
+                    Rinkit Adhana
+                  </h4>
+                  <p class="text-sm text-gray-600 dark:text-gray-400">
+                    Full Stack Development
+                  </p>
+                </div>
+              </div>
+              <div class="mentor-description-container">
+                <p
+                  class="text-gray-600 dark:text-gray-400 text-base leading-relaxed mentor-description-text"
+                >
+                  As a full stack engineer and active BLT contributor, I bring
+                  hands-on experience from both sides of the development
+                  process. Having participated in GSoC 2025, I understand the
+                  challenges new contributors face and can guide you through
+                  your open source journey. I specialize in helping developers
+                  build scalable web applications, navigate complex codebases,
+                  and contribute effectively to real-world projects. My goal is
+                  to share practical knowledge and help you grow as a developer
+                  while making meaningful contributions to BLT.
+                </p>
+              </div>
+            </div>
+            <!-- Raj Gupta -->
+            <div
+              class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4 border border-gray-200 dark:border-gray-700"
+            >
+              <div class="flex items-center gap-3 mb-3">
+                <div
+                  class="w-10 h-10 bg-red-100 rounded-full flex items-center justify-center"
+                >
+                  <i class="fas fa-code text-[#e74c3c] text-sm"></i>
+                </div>
+                <div>
+                  <h4
+                    class="text-lg font-bold text-gray-900 dark:text-gray-100"
+                  >
+                    Raj Gupta
+                  </h4>
+                  <p class="text-sm text-gray-600 dark:text-gray-400">
+                    Full Stack Development mentor
+                  </p>
+                </div>
+              </div>
+              <div class="mentor-description-container">
+                <p
+                  class="text-gray-600 dark:text-gray-400 text-base leading-relaxed mentor-description-text"
+                >
+                  I’m a full stack developer with prior Google Summer of Code
+                  (GSoC) experience and a strong passion for open source. Having
+                  worked as a contributor, I understand the challenges of
+                  getting started - from reading large codebases to making
+                  meaningful pull requests. As a mentor, I enjoy guiding
+                  contributors through best practices, code reviews, and
+                  real-world problem solving. I continue to actively contribute
+                  to open source because I believe collaboration and knowledge
+                  sharing are what truly drive impactful software.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+        <!-- Preetham -->
+        <div
+          class="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-100 dark:border-gray-800 p-8"
+        >
+          <div class="flex items-center gap-6 mb-6">
+            <div
+              class="w-20 h-20 bg-red-100 rounded-full flex items-center justify-center"
+            >
+              <i class="fab fa-github text-[#e74c3c] text-3xl"></i>
+            </div>
+            <div class="flex-1">
+              <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100">
+                Preetham
+              </h3>
+              <p class="text-lg text-gray-600 dark:text-gray-400 mb-2">
+                2026 Contributor
+              </p>
+              <div class="flex gap-4">
+                <a
+                  href="https://github.com/Pritz395"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="inline-flex items-center px-4 py-2 bg-[#e74c3c] text-white rounded-lg hover:bg-red-700 transition-colors"
+                >
+                  <i class="fab fa-github mr-2"></i>
+                  GitHub Profile
+                </a>
+                <a
+                  href="https://Pritz395.github.io/MY-GSOC-TOOL/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="inline-flex items-center px-4 py-2 border-2 border-[#e74c3c] text-[#e74c3c] rounded-lg hover:bg-[#e74c3c] hover:text-white transition-colors"
+                >
+                  <i class="fas fa-tools mr-2"></i>
+                  GSoC-Tool
+                </a>
+              </div>
+            </div>
+          </div>
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <!-- Vinamra Vaswani -->
+            <div
+              class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4 border border-gray-200 dark:border-gray-700"
+            >
+              <div class="flex items-center gap-3 mb-3">
+                <div
+                  class="w-10 h-10 bg-red-100 rounded-full flex items-center justify-center"
+                >
+                  <i class="fas fa-code text-[#e74c3c] text-sm"></i>
+                </div>
+                <div>
+                  <h4
+                    class="text-lg font-bold text-gray-900 dark:text-gray-100"
+                  >
+                    Vinamra Vaswani
+                  </h4>
+                  <p class="text-sm text-gray-600 dark:text-gray-400">
+                    Backend Systems
+                  </p>
+                </div>
+              </div>
+              <div class="mentor-description-container">
+                <p
+                  class="text-gray-600 dark:text-gray-400 text-base leading-relaxed mentor-description-text"
+                >
+                  I am a software engineer experienced in building
+                  production-grade backend systems using Python, FastAPI, and
+                  MongoDB, with a focus on clean architecture and real-world
+                  problem solving. Through open-source style projects and
+                  mentorship programs, I have guided juniors in working with
+                  real codebases, collaborative workflows, and maintainable
+                  engineering practices. As a GSoC mentor, my goal is to help
+                  students move from tutorials to confident real-world
+                  contributors, while giving back to open source by supporting
+                  their technical and professional growth in a learning-first
+                  environment.
+                </p>
+              </div>
+            </div>
+            <!-- Carla Voorhees -->
+            <div
+              class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4 border border-gray-200 dark:border-gray-700"
+            >
+              <div class="flex items-center gap-3 mb-3">
+                <div
+                  class="w-10 h-10 bg-red-100 rounded-full flex items-center justify-center"
+                >
+                  <i class="fas fa-code text-[#e74c3c] text-sm"></i>
+                </div>
+                <div>
+                  <h4
+                    class="text-lg font-bold text-gray-900 dark:text-gray-100"
+                  >
+                    Carla Voorhees
+                  </h4>
+                  <p class="text-sm text-gray-600 dark:text-gray-400">
+                    Technical Product Manager
+                  </p>
+                </div>
+              </div>
+              <div class="mentor-description-container">
+                <p
+                  class="text-gray-600 dark:text-gray-400 text-base leading-relaxed mentor-description-text"
+                >
+                  I am a technical product manager with a background in
+                  cybersecurity and data management. I have experience mentoring
+                  students, helping them navigate complex requirements and
+                  understand best practices. I focus on guiding students through
+                  the product development lifecycle, from ideation to
+                  deployment, while fostering a collaborative and inclusive
+                  learning environment. I help them to understand how to take
+                  requirements and designs and turn them into working code. My
+                  goal is to empower students to become confident contributors
+                  to open source communities.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+        <!-- Siddharth Bansal -->
+        <div
+          class="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-100 dark:border-gray-800 p-8"
+        >
+          <div class="flex items-center gap-6 mb-6">
+            <div
+              class="w-20 h-20 bg-red-100 rounded-full flex items-center justify-center"
+            >
+              <i class="fab fa-github text-[#e74c3c] text-3xl"></i>
+            </div>
+            <div class="flex-1">
+              <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100">
+                Siddharth Bansal
+              </h3>
+              <p class="text-lg text-gray-600 dark:text-gray-400 mb-2">
+                2026 Contributor
+              </p>
+              <div class="flex gap-4">
+                <a
+                  href="https://github.com/sidd190"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="inline-flex items-center px-4 py-2 bg-[#e74c3c] text-white rounded-lg hover:bg-red-700 transition-colors"
+                >
+                  <i class="fab fa-github mr-2"></i>
+                  GitHub Profile
+                </a>
+                <a
+                  href="https://sidd190.github.io/MY-GSOC-TOOL/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="inline-flex items-center px-4 py-2 border-2 border-[#e74c3c] text-[#e74c3c] rounded-lg hover:bg-[#e74c3c] hover:text-white transition-colors"
+                >
+                  <i class="fas fa-tools mr-2"></i>
+                  GSoC-Tool
+                </a>
+              </div>
+            </div>
+          </div>
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <!-- Jigyasu Rajput -->
+            <div
+              class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4 border border-gray-200 dark:border-gray-700"
+            >
+              <div class="flex items-center gap-3 mb-3">
+                <div
+                  class="w-10 h-10 bg-red-100 rounded-full flex items-center justify-center"
+                >
+                  <i class="fas fa-code text-[#e74c3c] text-sm"></i>
+                </div>
+                <div>
+                  <h4
+                    class="text-lg font-bold text-gray-900 dark:text-gray-100"
+                  >
+                    Jigyasu Rajput
+                  </h4>
+                  <p class="text-sm text-gray-600 dark:text-gray-400">
+                    Full Stack Development
+                  </p>
+                </div>
+              </div>
+              <div class="mentor-description-container">
+                <p
+                  class="text-gray-600 dark:text-gray-400 text-base leading-relaxed mentor-description-text"
+                >
+                  I'm a full-stack developer with prior GSoC experience and a
+                  deep love for open source. Having been a contributor myself, I
+                  know how overwhelming it can feel at the start — from
+                  understanding huge codebases to shipping your first meaningful
+                  PR. As a mentor, I focus on helping people build confidence
+                  through clean practices, thoughtful code reviews, and
+                  real-world problem solving. I stay active in open source
+                  because collaboration and shared learning are what actually
+                  move great software forward.
+                </p>
+              </div>
+            </div>
+            <!-- Rishab Kumar Jha -->
+            <div
+              class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4 border border-gray-200 dark:border-gray-700"
+            >
+              <div class="flex items-center gap-3 mb-3">
+                <div
+                  class="w-10 h-10 bg-red-100 rounded-full flex items-center justify-center"
+                >
+                  <i class="fas fa-code text-[#e74c3c] text-sm"></i>
+                </div>
+                <div>
+                  <h4
+                    class="text-lg font-bold text-gray-900 dark:text-gray-100"
+                  >
+                    Rishab Kumar Jha
+                  </h4>
+                  <p class="text-sm text-gray-600 dark:text-gray-400">
+                    Full Stack/Blockchain
+                  </p>
+                </div>
+              </div>
+              <div class="mentor-description-container">
+                <p
+                  class="text-gray-600 dark:text-gray-400 text-base leading-relaxed mentor-description-text"
+                >
+                  I'm a software developer interested in distributed systems,
+                  web3, cloud native technologies & deep-tech. As a past GSoC
+                  and LFX alumnus myself, I understand the pain points of new
+                  contributors. Happy to mentor and help mentees navigate
+                  open-source effectively.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+        <!-- Manahil Afzal -->
+        <div
+          class="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-100 dark:border-gray-800 p-8"
+        >
+          <div class="flex items-center gap-6 mb-6">
+            <div
+              class="w-20 h-20 bg-red-100 rounded-full flex items-center justify-center"
+            >
+              <i class="fab fa-github text-[#e74c3c] text-3xl"></i>
+            </div>
+            <div class="flex-1">
+              <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100">
+                Manahil Afzal
+              </h3>
+              <p class="text-lg text-gray-600 dark:text-gray-400 mb-2">
+                MERN Stack Engineer / 2026 Contributor
+              </p>
+              <p class="text-gray-600 dark:text-gray-400 mb-4 text-sm">
+                Passionate about building meaningful web applications. Exploring
+                cloud, AI, and open source programs like GSoC & Outreachy.
+                Interested in contributing to organizations like OWASP
+                Foundation & Apache.
+              </p>
+              <div class="flex gap-4">
+                <a
+                  href="https://github.com/Manahil-Afzal"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="inline-flex items-center px-4 py-2 bg-[#e74c3c] text-white rounded-lg hover:bg-red-700 transition-colors"
+                >
+                  <i class="fab fa-github mr-2"></i>
+                  GitHub Profile
+                </a>
+                <a
+                  href="https://manahil-afzal.github.io/MY-GSOC-TOOL/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="inline-flex items-center px-4 py-2 border-2 border-[#e74c3c] text-[#e74c3c] rounded-lg hover:bg-[#e74c3c] hover:text-white transition-colors"
+                >
+                  <i class="fas fa-tools mr-2"></i>
+                  GSoC Tool
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <!-- Sakshee Suman -->
+        <div
+          class="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-100 dark:border-gray-800 p-8"
+        >
+          <div class="flex items-center gap-6 mb-6">
+            <div
+              class="w-20 h-20 bg-red-100 rounded-full flex items-center justify-center"
+            >
+              <i class="fab fa-github text-[#e74c3c] text-3xl"></i>
+            </div>
+            <div class="flex-1">
+              <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100">
+                Sakshee Suman
+              </h3>
+              <p class="text-lg text-gray-600 dark:text-gray-400 mb-2">
+                2026 Contributor
+              </p>
+              <div class="flex gap-4">
+                <a
+                  href="https://github.com/e-esakman"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="inline-flex items-center px-4 py-2 bg-[#e74c3c] text-white rounded-lg hover:bg-red-700 transition-colors"
+                >
+                  <i class="fab fa-github mr-2"></i>
+                  GitHub Profile
+                </a>
+                <a
+                  href="https://e-esakman.github.io/MY-GSOC-TOOL/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="inline-flex items-center px-4 py-2 border-2 border-[#e74c3c] text-[#e74c3c] rounded-lg hover:bg-[#e74c3c] hover:text-white transition-colors"
+                >
+                  <i class="fas fa-tools mr-2"></i>
+                  GSoC-Tool
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <!-- Arnav Kirti -->
+        <div
+          class="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-100 dark:border-gray-800 p-8"
+        >
+          <div class="flex items-center gap-6 mb-6">
+            <div
+              class="w-20 h-20 bg-red-100 rounded-full flex items-center justify-center"
+            >
+              <i class="fab fa-github text-[#e74c3c] text-3xl"></i>
+            </div>
+            <div class="flex-1">
+              <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100">
+                Arnav Kirti
+              </h3>
+              <p class="text-lg text-gray-600 dark:text-gray-400 mb-2">
+                2026 Contributor
+              </p>
+              <div class="flex gap-4">
+                <a
+                  href="https://github.com/arnavkirti"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="inline-flex items-center px-4 py-2 bg-[#e74c3c] text-white rounded-lg hover:bg-red-700 transition-colors"
+                >
+                  <i class="fab fa-github mr-2"></i>
+                  GitHub Profile
+                </a>
+                <a
+                  href="https://arnavkirti.github.io/MY-GSOC-TOOL/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="inline-flex items-center px-4 py-2 border-2 border-[#e74c3c] text-[#e74c3c] rounded-lg hover:bg-[#e74c3c] hover:text-white transition-colors"
+                >
+                  <i class="fas fa-tools mr-2"></i>
+                  GSoC-Tool
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <!-- Savio D'souza -->
+        <div
+          class="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-100 dark:border-gray-800 p-8"
+        >
+          <div class="flex items-center gap-6 mb-6">
+            <div
+              class="w-20 h-20 bg-red-100 rounded-full flex items-center justify-center"
+            >
+              <i class="fab fa-github text-[#e74c3c] text-3xl"></i>
+            </div>
+            <div class="flex-1">
+              <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100">
+                Savio D'souza
+              </h3>
+              <p class="text-lg text-gray-600 dark:text-gray-400 mb-2">
+                2026 Contributor
+              </p>
+              <div class="flex gap-4">
+                <a
+                  href="https://github.com/S3DFX-CYBER"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="inline-flex items-center px-4 py-2 bg-[#e74c3c] text-white rounded-lg hover:bg-red-700 transition-colors"
+                >
+                  <i class="fab fa-github mr-2"></i>
+                  GitHub Profile
+                </a>
+                <a
+                  href="https://S3DFX-CYBER.github.io/MY-GSOC-TOOL/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="inline-flex items-center px-4 py-2 border-2 border-[#e74c3c] text-[#e74c3c] rounded-lg hover:bg-[#e74c3c] hover:text-white transition-colors"
+                >
+                  <i class="fas fa-tools mr-2"></i>
+                  GSoC-Tool
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <!-- Jayant Malvi -->
+        <div
+          class="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-100 dark:border-gray-800 p-8"
+        >
+          <div class="flex items-center gap-6 mb-6">
+            <div
+              class="w-20 h-20 bg-red-100 rounded-full flex items-center justify-center"
+            >
+              <i class="fab fa-github text-[#e74c3c] text-3xl"></i>
+            </div>
+            <div class="flex-1">
+              <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100">
+                Jayant Malvi
+              </h3>
+              <p class="text-lg text-gray-600 dark:text-gray-400 mb-2">
+                2026 Contributor
+              </p>
+              <div class="flex gap-4">
+                <a
+                  href="https://github.com/Jayant2908"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="inline-flex items-center px-4 py-2 bg-[#e74c3c] text-white rounded-lg hover:bg-red-700 transition-colors"
+                >
+                  <i class="fab fa-github mr-2"></i>
+                  GitHub Profile
+                </a>
+                <a
+                  href="https://Jayant2908.github.io/MY-GSOC-TOOL/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="inline-flex items-center px-4 py-2 border-2 border-[#e74c3c] text-[#e74c3c] rounded-lg hover:bg-[#e74c3c] hover:text-white transition-colors"
+                >
+                  <i class="fas fa-tools mr-2"></i>
+                  GSoC-Tool
+                </a>
+              </div>
+            </div>
+          </div>
+          <!-- Mentors grid -->
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <!-- Manikandan Chandran -->
+            <div
+              class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4 border border-gray-200 dark:border-gray-700"
+            >
+              <div class="flex items-center gap-3 mb-3">
+                <div
+                  class="w-10 h-10 bg-red-100 rounded-full flex items-center justify-center"
+                >
+                  <i class="fas fa-code text-[#e74c3c] text-sm"></i>
+                </div>
+                <div>
+                  <h4
+                    class="text-lg font-bold text-gray-900 dark:text-gray-100"
+                  >
+                    Manikandan Chandran
+                  </h4>
+                  <p class="text-sm text-gray-600 dark:text-gray-400">
+                    React/OAuth/REST API
+                  </p>
+                </div>
+              </div>
+              <div class="mentor-description-container">
+                <p
+                  class="text-gray-600 dark:text-gray-400 text-base leading-relaxed mentor-description-text"
+                >
+                  Mentors teams on building secure React apps with real-world
+                  OAuth flows and robust REST APIs.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <!-- Available Mentors Section -->
+      <div
+        class="mt-16 bg-gray-50 dark:bg-gray-900 rounded-xl p-8 border border-gray-200 dark:border-gray-700"
+      >
+        <h3
+          class="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-6 text-center"
+        >
+          Available Mentors for Future Students
+        </h3>
+        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          <!-- Manikandan Chandran -->
+          <div
+            class="bg-white dark:bg-gray-800 rounded-lg p-6 border border-gray-200 dark:border-gray-700"
+          >
+            <div class="flex items-center gap-3 mb-3">
+              <div
+                class="w-12 h-12 bg-red-100 rounded-full flex items-center justify-center"
+              >
+                <i class="fas fa-chalkboard-teacher text-[#e74c3c] text-lg"></i>
+              </div>
+              <div>
+                <h4 class="text-lg font-bold text-gray-900 dark:text-gray-100">
+                  Manikandan Chandran
+                </h4>
+                <p class="text-sm text-gray-600 dark:text-gray-400">
+                  React/OAuth/REST API
+                </p>
+              </div>
+            </div>
+            <p class="text-gray-600 dark:text-gray-400 text-sm">
+              Mentors teams on building secure React apps with real-world OAuth
+              flows and robust REST APIs.
+            </p>
+          </div>
+          <!-- Ahmed ElSheikh -->
+          <div
+            class="bg-white dark:bg-gray-800 rounded-lg p-6 border border-gray-200 dark:border-gray-700"
+          >
+            <div class="flex items-center gap-3 mb-3">
+              <div
+                class="w-12 h-12 bg-red-100 rounded-full flex items-center justify-center"
+              >
+                <i class="fas fa-chalkboard-teacher text-[#e74c3c] text-lg"></i>
+              </div>
+              <div>
+                <h4 class="text-lg font-bold text-gray-900 dark:text-gray-100">
+                  Ahmed ElSheikh
+                </h4>
+                <p class="text-sm text-gray-600 dark:text-gray-400">
+                  React/OAuth/REST API
+                </p>
+              </div>
+            </div>
+            <p class="text-gray-600 dark:text-gray-400 text-sm">
+              Cybersecurity analyst and AI security engineer specializing in
+              secure system design.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+    <!-- Past Mentors Section -->
+    <div
+      class="bg-white dark:bg-gray-800 rounded-xl shadow-lg transition-all duration-300 p-8 mb-20 border border-gray-100 dark:border-gray-800"
+    >
+      <h2
+        class="text-3xl font-bold text-gray-900 dark:text-gray-100 text-center mb-2"
+      >
+        Past GSoC Mentors
+      </h2>
+      <div class="w-20 h-1 bg-[#e74c3c] mx-auto mb-8 rounded-full"></div>
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
+        <div
+          class="bg-gray-50 dark:bg-gray-900 rounded-lg p-6 border border-gray-200 dark:border-gray-700"
+        >
+          <h4
+            class="text-lg font-bold text-gray-900 dark:text-gray-100 mb-3 flex items-center"
+          >
+            <i
+              aria-hidden="true"
+              class="fas fa-calendar-alt text-[#e74c3c] mr-2"
+            ></i
+            >2025
+          </h4>
+          <ul class="space-y-2 text-gray-700 dark:text-gray-300">
+            <li class="flex items-start">
+              <i class="fas fa-user-tie text-[#e74c3c] mt-1 mr-2"></i>
+              <span
+                >Rahul Negi
+                <span class="text-gray-500 dark:text-gray-500"
+                  >(Python/Django Mentor)</span
+                ></span
+              >
+            </li>
+            <li class="flex items-start">
+              <i class="fas fa-user-tie text-[#e74c3c] mt-1 mr-2"></i>
+              <span
+                >Bishal Das
+                <span class="text-gray-500 dark:text-gray-500"
+                  >(Django & UI/UX Mentor)</span
+                ></span
+              >
+            </li>
+            <li class="flex items-start">
+              <i class="fas fa-user-tie text-[#e74c3c] mt-1 mr-2"></i>
+              <span
+                >Sudhir Palavalasa
+                <span class="text-gray-500 dark:text-gray-500"
+                  >(Backend and OAuth mentor)</span
+                ></span
+              >
+            </li>
+          </ul>
+        </div>
+        <div
+          class="bg-gray-50 dark:bg-gray-900 rounded-lg p-6 border border-gray-200 dark:border-gray-700"
+        >
+          <h4
+            class="text-lg font-bold text-gray-900 dark:text-gray-100 mb-3 flex items-center"
+          >
+            <i
+              aria-hidden="true"
+              class="fas fa-calendar-alt text-[#e74c3c] mr-2"
+            ></i
+            >2024
+          </h4>
+          <ul class="space-y-2 text-gray-700 dark:text-gray-300">
+            <li class="flex items-start">
+              <i class="fas fa-user-tie text-[#e74c3c] mt-1 mr-2"></i>
+              <span
+                >Swapnil Shinde
+                <span class="text-gray-500 dark:text-gray-500"
+                  >(Django and blockchain mentor)</span
+                ></span
+              >
+            </li>
+            <li class="flex items-start">
+              <i class="fas fa-user-tie text-[#e74c3c] mt-1 mr-2"></i>
+              <span
+                >Arkadii Yakovets
+                <span class="text-gray-500 dark:text-gray-500"
+                  >(Python/Django mentor)</span
+                ></span
+              >
+            </li>
+          </ul>
+        </div>
+        <div
+          class="bg-gray-50 dark:bg-gray-900 rounded-lg p-6 border border-gray-200 dark:border-gray-700"
+        >
+          <h4
+            class="text-lg font-bold text-gray-900 dark:text-gray-100 mb-3 flex items-center"
+          >
+            <i
+              aria-hidden="true"
+              class="fas fa-calendar-alt text-[#e74c3c] mr-2"
+            ></i
+            >2023
+          </h4>
+          <ul class="space-y-2 text-gray-700 dark:text-gray-300">
+            <li class="flex items-start">
+              <i class="fas fa-user-tie text-[#e74c3c] mt-1 mr-2"></i>
+              <span
+                >Aryan Ranjan
+                <span class="text-gray-500 dark:text-gray-500"
+                  >(Flutter and Django Mentor)</span
+                ></span
+              >
+            </li>
+          </ul>
+        </div>
+        <div
+          class="bg-gray-50 dark:bg-gray-900 rounded-lg p-6 border border-gray-200 dark:border-gray-700"
+        >
+          <h4
+            class="text-lg font-bold text-gray-900 dark:text-gray-100 mb-3 flex items-center"
+          >
+            <i
+              aria-hidden="true"
+              class="fas fa-calendar-alt text-[#e74c3c] mr-2"
+            ></i
+            >2022
+          </h4>
+          <ul class="space-y-2 text-gray-700 dark:text-gray-300">
+            <li class="flex items-start">
+              <i class="fas fa-user-tie text-[#e74c3c] mt-1 mr-2"></i>
+              <span
+                >Sourav Badami
+                <span class="text-gray-500 dark:text-gray-500"
+                  >(Django Mentor)</span
+                ></span
+              >
+            </li>
+            <li class="flex items-start">
+              <i class="fas fa-user-tie text-[#e74c3c] mt-1 mr-2"></i>
+              <span
+                >Rahul Badami
+                <span class="text-gray-500 dark:text-gray-500"
+                  >(Payments Mentor)</span
+                ></span
+              >
+            </li>
+            <li class="flex items-start">
+              <i class="fas fa-user-tie text-[#e74c3c] mt-1 mr-2"></i>
+              <span
+                >Ankit Choudhary
+                <span class="text-gray-500 dark:text-gray-500"
+                  >(Flutter Mentor)</span
+                ></span
+              >
+            </li>
+            <li class="flex items-start">
+              <i class="fas fa-user-tie text-[#e74c3c] mt-1 mr-2"></i>
+              <span
+                >Sparsh Agrawal
+                <span class="text-gray-500 dark:text-gray-500"
+                  >(Flutter Mentor)</span
+                ></span
+              >
+            </li>
+          </ul>
+        </div>
+        <div
+          class="bg-gray-50 dark:bg-gray-900 rounded-lg p-6 border border-gray-200 dark:border-gray-700"
+        >
+          <h4
+            class="text-lg font-bold text-gray-900 dark:text-gray-100 mb-3 flex items-center"
+          >
+            <i
+              aria-hidden="true"
+              class="fas fa-calendar-alt text-[#e74c3c] mr-2"
+            ></i
+            >2020-2021
+          </h4>
+          <ul class="space-y-2 text-gray-700 dark:text-gray-300">
+            <li class="flex items-start">
+              <i class="fas fa-user-tie text-[#e74c3c] mt-1 mr-2"></i>
+              <span
+                >Sourav Badami
+                <span class="text-gray-500 dark:text-gray-500"
+                  >(Django Mentor)</span
+                ></span
+              >
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock content %}


### PR DESCRIPTION

Enhancements include:
- GitHub profile link
- Live GSoC Tool link
- Short bio with interests
- Improved card styling for new contributor visibility
Highlighting myself as a new contributor. 

As u can see Live preview: 
![Mentee gsoc&#39;26](https://github.com/user-attachments/assets/aa7367bf-367d-4fa2-ba28-e10d193bf8f1)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a mentor profile card to the GSoC page (avatar, name, title, description, and action links); the card was inserted in two places (duplicate).
* **Chores**
  * Updated hosting/security configuration to allow all hosts and trust common local/dev origins for site access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->