### PR TITLE
Chore: Added myself as mentee for GSOC'26

### DIFF
--- a/website/templates/gsoc.html
+++ b/website/templates/gsoc.html
@@ -898,6 +898,34 @@
                             </div>
                         </div>
                     </div>
+                <!-- Manahil Afzal -->
+<div class="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-100 dark:border-gray-800 p-8">
+    <div class="flex items-center gap-6 mb-6">
+        <div class="w-20 h-20 bg-red-100 rounded-full flex items-center justify-center">
+            <i class="fab fa-github text-[#e74c3c] text-3xl"></i>
+        </div>
+        <div class="flex-1">
+            <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100">Manahil Afzal</h3>
+            <p class="text-lg text-gray-600 dark:text-gray-400 mb-2">GSoC 2026 Contributor</p>
+            <div class="flex gap-4">
+                <a href="https://github.com/Manahil-Afzal"
+                   target="_blank"
+                   rel="noopener noreferrer"
+                   class="inline-flex items-center px-4 py-2 bg-[#e74c3c] text-white rounded-lg hover:bg-red-700 transition-colors">
+                    <i class="fab fa-github mr-2"></i>
+                    GitHub Profile
+                </a>
+                <a href="https://manahil-afzal.github.io/MY-GSOC-TOOL/"
+                   target="_blank"
+                   rel="noopener noreferrer"
+                   class="inline-flex items-center px-4 py-2 border-2 border-[#e74c3c] text-[#e74c3c] rounded-lg hover:bg-[#e74c3c] hover:text-white transition-colors">
+                    <i class="fas fa-tools mr-2"></i>
+                    GSoC-Tool
+                </a>
+            </div>
+        </div>
+    </div>
+</div>
                     <!-- Sakshee Suman -->
                     <div class="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-100 dark:border-gray-800 p-8">
                         <div class="flex items-center gap-6 mb-6">


### PR DESCRIPTION
Enhancements include:
- GitHub profile link
- Live GSoC Tool link
- Improved card styling for new contributor visibility
Highlighting myself as a new contributor. 

As u can see Live preview: 
![gsoc&#39;26](https://github.com/user-attachments/assets/24372584-6635-4a8f-8942-b1ba29685ee7)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new team member profile cards featuring contact information and quick-access links across the mentors and 2026 contributors sections for improved team visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->