### PR TITLE
Adding myself as mentee for GSOC'26

### DIFF
--- a/website/templates/gsoc.html
+++ b/website/templates/gsoc.html
@@ -1030,34 +1030,34 @@
                             </div>
                         </div>
                     </div>
-<!-- Manahil Afzal -->
-<div class="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-100 dark:border-gray-800 p-8">
-    <div class="flex items-center gap-6 mb-6">
-        <div class="w-20 h-20 bg-red-100 rounded-full flex items-center justify-center">
-            <i class="fab fa-github text-[#e74c3c] text-3xl"></i>
-        </div>
-        <div class="flex-1">
-            <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100">Manahil Afzal</h3>
-            <p class="text-lg text-gray-600 dark:text-gray-400 mb-2">2026 Contributor</p>
-            <div class="flex gap-4">
-                <a href="https://github.com/Manahil-Afzal"
-                   target="_blank"
-                   rel="noopener noreferrer"
-                   class="inline-flex items-center px-4 py-2 bg-[#e74c3c] text-white rounded-lg hover:bg-red-700 transition-colors">
-                    <i class="fab fa-github mr-2"></i>
-                    GitHub Profile
-                </a>
-                <a href="https://manahil-afzal.github.io/MY-GSOC-TOOL/"
-                   target="_blank"
-                   rel="noopener noreferrer"
-                   class="inline-flex items-center px-4 py-2 border-2 border-[#e74c3c] text-[#e74c3c] rounded-lg hover:bg-[#e74c3c] hover:text-white transition-colors">
-                    <i class="fas fa-tools mr-2"></i>
-                    GSoC-Tool
-                </a>
-            </div>
-        </div>
-    </div>
-</div>
+                    <!-- Manahil Afzal -->
+                    <div class="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-100 dark:border-gray-800 p-8">
+                        <div class="flex items-center gap-6 mb-6">
+                            <div class="w-20 h-20 bg-red-100 rounded-full flex items-center justify-center">
+                                <i class="fab fa-github text-[#e74c3c] text-3xl"></i>
+                            </div>
+                            <div class="flex-1">
+                                <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100">Manahil Afzal</h3>
+                                <p class="text-lg text-gray-600 dark:text-gray-400 mb-2">2026 Contributor</p>
+                                <div class="flex gap-4">
+                                    <a href="https://github.com/Manahil-Afzal"
+                                       target="_blank"
+                                       rel="noopener noreferrer"
+                                       class="inline-flex items-center px-4 py-2 bg-[#e74c3c] text-white rounded-lg hover:bg-red-700 transition-colors">
+                                        <i class="fab fa-github mr-2"></i>
+                                        GitHub Profile
+                                    </a>
+                                    <a href="https://manahil-afzal.github.io/MY-GSOC-TOOL/"
+                                       target="_blank"
+                                       rel="noopener noreferrer"
+                                       class="inline-flex items-center px-4 py-2 border-2 border-[#e74c3c] text-[#e74c3c] rounded-lg hover:bg-[#e74c3c] hover:text-white transition-colors">
+                                        <i class="fas fa-tools mr-2"></i>
+                                        GSoC-Tool
+                                    </a>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
                 </div>
                 <!-- Available Mentors Section -->
                 <div class="mt-16 bg-gray-50 dark:bg-gray-900 rounded-xl p-8 border border-gray-200 dark:border-gray-700">

--- a/website/templates/gsoc.html
+++ b/website/templates/gsoc.html
@@ -1008,34 +1008,6 @@
                                     </a>
                                 </div>
                             </div>
-<!-- Manahil Afzal -->
-<div class="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-100 dark:border-gray-800 p-8">
-    <div class="flex items-center gap-6 mb-6">
-        <div class="w-20 h-20 bg-red-100 rounded-full flex items-center justify-center">
-            <i class="fab fa-github text-[#e74c3c] text-3xl"></i>
-        </div>
-        <div class="flex-1">
-            <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100">Manahil Afzal</h3>
-            <p class="text-lg text-gray-600 dark:text-gray-400 mb-2">2026 Contributor</p>
-            <div class="flex gap-4">
-                <a href="https://github.com/Manahil-Afzal"
-                   target="_blank"
-                   rel="noopener noreferrer"
-                   class="inline-flex items-center px-4 py-2 bg-[#e74c3c] text-white rounded-lg hover:bg-red-700 transition-colors">
-                    <i class="fab fa-github mr-2"></i>
-                    GitHub Profile
-                </a>
-                <a href="https://manahil-afzal.github.io/MY-GSOC-TOOL/"
-                   target="_blank"
-                   rel="noopener noreferrer"
-                   class="inline-flex items-center px-4 py-2 border-2 border-[#e74c3c] text-[#e74c3c] rounded-lg hover:bg-[#e74c3c] hover:text-white transition-colors">
-                    <i class="fas fa-tools mr-2"></i>
-                    GSoC-Tool
-                </a>
-            </div>
-        </div>
-    </div>
-</div>
                         </div>
                         <!-- Mentors grid -->
                         <div class="grid grid-cols-1 md:grid-cols-2 gap-6">

--- a/website/templates/gsoc.html
+++ b/website/templates/gsoc.html
@@ -898,34 +898,6 @@
                             </div>
                         </div>
                     </div>
-                <!-- Manahil Afzal -->
-<div class="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-100 dark:border-gray-800 p-8">
-    <div class="flex items-center gap-6 mb-6">
-        <div class="w-20 h-20 bg-red-100 rounded-full flex items-center justify-center">
-            <i class="fab fa-github text-[#e74c3c] text-3xl"></i>
-        </div>
-        <div class="flex-1">
-            <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100">Manahil Afzal</h3>
-            <p class="text-lg text-gray-600 dark:text-gray-400 mb-2">GSoC 2026 Contributor</p>
-            <div class="flex gap-4">
-                <a href="https://github.com/Manahil-Afzal"
-                   target="_blank"
-                   rel="noopener noreferrer"
-                   class="inline-flex items-center px-4 py-2 bg-[#e74c3c] text-white rounded-lg hover:bg-red-700 transition-colors">
-                    <i class="fab fa-github mr-2"></i>
-                    GitHub Profile
-                </a>
-                <a href="https://manahil-afzal.github.io/MY-GSOC-TOOL/"
-                   target="_blank"
-                   rel="noopener noreferrer"
-                   class="inline-flex items-center px-4 py-2 border-2 border-[#e74c3c] text-[#e74c3c] rounded-lg hover:bg-[#e74c3c] hover:text-white transition-colors">
-                    <i class="fas fa-tools mr-2"></i>
-                    GSoC-Tool
-                </a>
-            </div>
-        </div>
-    </div>
-</div>
                     <!-- Sakshee Suman -->
                     <div class="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-100 dark:border-gray-800 p-8">
                         <div class="flex items-center gap-6 mb-6">
@@ -1036,6 +1008,34 @@
                                     </a>
                                 </div>
                             </div>
+<!-- Manahil Afzal -->
+<div class="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-100 dark:border-gray-800 p-8">
+    <div class="flex items-center gap-6 mb-6">
+        <div class="w-20 h-20 bg-red-100 rounded-full flex items-center justify-center">
+            <i class="fab fa-github text-[#e74c3c] text-3xl"></i>
+        </div>
+        <div class="flex-1">
+            <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100">Manahil Afzal</h3>
+            <p class="text-lg text-gray-600 dark:text-gray-400 mb-2">2026 Contributor</p>
+            <div class="flex gap-4">
+                <a href="https://github.com/Manahil-Afzal"
+                   target="_blank"
+                   rel="noopener noreferrer"
+                   class="inline-flex items-center px-4 py-2 bg-[#e74c3c] text-white rounded-lg hover:bg-red-700 transition-colors">
+                    <i class="fab fa-github mr-2"></i>
+                    GitHub Profile
+                </a>
+                <a href="https://manahil-afzal.github.io/MY-GSOC-TOOL/"
+                   target="_blank"
+                   rel="noopener noreferrer"
+                   class="inline-flex items-center px-4 py-2 border-2 border-[#e74c3c] text-[#e74c3c] rounded-lg hover:bg-[#e74c3c] hover:text-white transition-colors">
+                    <i class="fas fa-tools mr-2"></i>
+                    GSoC-Tool
+                </a>
+            </div>
+        </div>
+    </div>
+</div>
                         </div>
                         <!-- Mentors grid -->
                         <div class="grid grid-cols-1 md:grid-cols-2 gap-6">

--- a/website/templates/gsoc.html
+++ b/website/templates/gsoc.html
@@ -898,6 +898,34 @@
                             </div>
                         </div>
                     </div>
+                <!-- Manahil Afzal -->
+<div class="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-100 dark:border-gray-800 p-8">
+    <div class="flex items-center gap-6 mb-6">
+        <div class="w-20 h-20 bg-red-100 rounded-full flex items-center justify-center">
+            <i class="fab fa-github text-[#e74c3c] text-3xl"></i>
+        </div>
+        <div class="flex-1">
+            <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100">Manahil Afzal</h3>
+            <p class="text-lg text-gray-600 dark:text-gray-400 mb-2">GSoC 2026 Contributor</p>
+            <div class="flex gap-4">
+                <a href="https://github.com/Manahil-Afzal"
+                   target="_blank"
+                   rel="noopener noreferrer"
+                   class="inline-flex items-center px-4 py-2 bg-[#e74c3c] text-white rounded-lg hover:bg-red-700 transition-colors">
+                    <i class="fab fa-github mr-2"></i>
+                    GitHub Profile
+                </a>
+                <a href="https://manahil-afzal.github.io/MY-GSOC-TOOL/"
+                   target="_blank"
+                   rel="noopener noreferrer"
+                   class="inline-flex items-center px-4 py-2 border-2 border-[#e74c3c] text-[#e74c3c] rounded-lg hover:bg-[#e74c3c] hover:text-white transition-colors">
+                    <i class="fas fa-tools mr-2"></i>
+                    GSoC-Tool
+                </a>
+            </div>
+        </div>
+    </div>
+</div>
                     <!-- Sakshee Suman -->
                     <div class="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-100 dark:border-gray-800 p-8">
                         <div class="flex items-center gap-6 mb-6">

--- a/website/templates/gsoc.html
+++ b/website/templates/gsoc.html
@@ -1058,6 +1058,34 @@
                             </div>
                         </div>
                     </div>
+<!-- Manahil Afzal -->
+<div class="bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-100 dark:border-gray-800 p-8">
+    <div class="flex items-center gap-6 mb-6">
+        <div class="w-20 h-20 bg-red-100 rounded-full flex items-center justify-center">
+            <i class="fab fa-github text-[#e74c3c] text-3xl"></i>
+        </div>
+        <div class="flex-1">
+            <h3 class="text-xl font-bold text-gray-900 dark:text-gray-100">Manahil Afzal</h3>
+            <p class="text-lg text-gray-600 dark:text-gray-400 mb-2">2026 Contributor</p>
+            <div class="flex gap-4">
+                <a href="https://github.com/Manahil-Afzal"
+                   target="_blank"
+                   rel="noopener noreferrer"
+                   class="inline-flex items-center px-4 py-2 bg-[#e74c3c] text-white rounded-lg hover:bg-red-700 transition-colors">
+                    <i class="fab fa-github mr-2"></i>
+                    GitHub Profile
+                </a>
+                <a href="https://manahil-afzal.github.io/MY-GSOC-TOOL/"
+                   target="_blank"
+                   rel="noopener noreferrer"
+                   class="inline-flex items-center px-4 py-2 border-2 border-[#e74c3c] text-[#e74c3c] rounded-lg hover:bg-[#e74c3c] hover:text-white transition-colors">
+                    <i class="fas fa-tools mr-2"></i>
+                    GSoC-Tool
+                </a>
+            </div>
+        </div>
+    </div>
+</div>
                 </div>
                 <!-- Available Mentors Section -->
                 <div class="mt-16 bg-gray-50 dark:bg-gray-900 rounded-xl p-8 border border-gray-200 dark:border-gray-700">


### PR DESCRIPTION
Enhancements include:
* GitHub profile link
* Live GSoC Tool link
* Improved card styling for new contributor visibility
Highlighting myself as a new contributor. 

As u can see Live preview: 
![gsoc&#39;26](https://github.com/user-attachments/assets/19db5a52-beac-4ac8-8b54-20c8ef8641d3)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a visible mentor profile for Manahil Afzal to the GSoC 2026 mentors page (name, role, links, bio).
  * The mentor card appears twice on the mentors page, resulting in an unintended duplicate entry in the mentor grid.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->