### PR TITLE
fix: validate int() on query params to prevent ValueError crashes

### DIFF
--- a/website/views/core.py
+++ b/website/views/core.py
@@ -2276,7 +2276,10 @@ def template_list(request):
     filter_by = request.GET.get("filter", "all")
     sort = request.GET.get("sort", "name")
     direction = request.GET.get("dir", "asc")
-    page = int(request.GET.get("page", 1))
+    try:
+        page = int(request.GET.get("page", 1))
+    except (ValueError, TypeError):
+        page = 1
     per_page = 20
 
     def extract_template_info(template_path):

--- a/website/views/education.py
+++ b/website/views/education.py
@@ -232,7 +232,10 @@ def add_section(request, course_id):
 
     # Sanitize user input
     title = request.POST.get("title")
-    order = int(request.POST.get("order", 0))
+    try:
+        order = int(request.POST.get("order", 0))
+    except (ValueError, TypeError):
+        order = 0
 
     section = Section.objects.create(course=course, title=title, order=order)
     messages.success(request, f"Section '{title}' was added successfully!")
@@ -290,7 +293,10 @@ def add_lecture(request, section_id):
     title = request.POST.get("title")
     content_type = request.POST.get("content_type")
     description = request.POST.get("description")
-    order = int(request.POST.get("order", 0))
+    try:
+        order = int(request.POST.get("order", 0))
+    except (ValueError, TypeError):
+        order = 0
     duration = request.POST.get("duration") or None
 
     lecture = Lecture(

--- a/website/views/organization.py
+++ b/website/views/organization.py
@@ -807,9 +807,15 @@ def load_more_issues(request):
     """
     AJAX handler for loading more GitHub issues with pagination support
     """
-    page = int(request.GET.get("page", 1))
+    try:
+        page = int(request.GET.get("page", 1))
+    except (ValueError, TypeError):
+        page = 1
     state = request.GET.get("state", "open")
-    per_page = int(request.GET.get("per_page", 10))
+    try:
+        per_page = int(request.GET.get("per_page", 10))
+    except (ValueError, TypeError):
+        per_page = 10
 
     # Validate inputs
     if page < 1:


### PR DESCRIPTION
## Description

Bare `int()` calls on `request.GET`/`request.POST` parameters crash with `ValueError` when non-numeric values are sent (e.g., `?page=abc`), causing unhandled 500 errors.

### Bug

```python
# Before: crashes with ValueError on ?page=abc
page = int(request.GET.get("page", 1))
```

### Fix

Wrapped `int()` conversions in `try/except (ValueError, TypeError)` blocks with safe fallback defaults:

- **`organization.py`**: `load_more_issues()` — `page` and `per_page` parameters
- **`core.py`**: `template_list()` — `page` parameter
- **`education.py`**: `add_section()` and `add_lecture()` — `order` parameter

### How to reproduce

Visit any affected endpoint with a non-numeric query param:
```
/load_more_issues/?page=abc
/template_list/?page=xyz
```

Before this fix: **500 Internal Server Error**
After this fix: Falls back to default value (page=1, per_page=10, order=0)