### PR TITLE
fix: replace bare except clauses with specific exception types

### DIFF
--- a/website/api/views.py
+++ b/website/api/views.py
@@ -391,7 +391,7 @@ class LeaderboardApiViewSet(APIView):
 
             try:
                 date = datetime(int(year), int(month), 1)
-            except:
+            except (ValueError, TypeError):
                 return Response("Invalid month or year passed", status=400)
 
         queryset = global_leaderboard.get_leaderboard(month, year, api=True)

--- a/website/consumers.py
+++ b/website/consumers.py
@@ -349,16 +349,16 @@ class ChatConsumer(AsyncWebsocketConsumer):
                 await self.send(
                     text_data=json.dumps({"type": "connection_status", "status": "disconnected", "code": close_code})
                 )
-            except:
+            except Exception:
                 pass
-        except:
+        except Exception:
             pass
 
     @database_sync_to_async
     def check_room_exists(self):
         try:
             return Room.objects.filter(id=self.room_id).exists()
-        except:
+        except Exception:
             return False
 
     @database_sync_to_async


### PR DESCRIPTION
## Description

Bare `except:` clauses catch `SystemExit` and `KeyboardInterrupt` in addition to regular exceptions, which prevents graceful shutdown and makes debugging harder. This violates PEP 8 and triggers ruff B001.

### Changes

- **`consumers.py`**: `except:` → `except Exception:` in `disconnect()` and `check_room_exists()` — these are WebSocket cleanup handlers where catching all regular exceptions is appropriate, but `SystemExit`/`KeyboardInterrupt` should propagate
- **`api/views.py`**: `except:` → `except (ValueError, TypeError):` in leaderboard date parsing — only `datetime()` construction can fail here with invalid int values

### Why this matters

```python
# Before: catches SystemExit, KeyboardInterrupt — prevents graceful shutdown
except:
    pass

# After: only catches regular exceptions
except Exception:
    pass
```