### PR TITLE
fix: switch reply_comment from GET to POST and add input validation

### DIFF
--- a/website/static/js/issue.js
+++ b/website/static/js/issue.js
@@ -123,13 +123,14 @@ $(function () {
         var comment = $(this).prev().find('textarea').val();
         if (comment == '') return;
         $.ajax({
-            type: 'GET',
+            type: 'POST',
             url: '/issue/' + issue_id + '/comment/reply/',
             data: {
                 comment_pk: comment_id,
                 text_comment: comment,
                 issue_pk: issue_id,
                 parent_id: parent_id,
+                csrfmiddlewaretoken: $('input[name=csrfmiddlewaretoken]').val(),
             },
             success: function (data) {
                 $('#target_div').html(data);


### PR DESCRIPTION
## Description

`reply_comment` in `comments/views.py` creates new comments via GET requests, which is vulnerable to CSRF attacks since GET requests can be triggered by image tags or link prefetching.

### Bugs Fixed

1. **CSRF vulnerability**: GET requests that create comments can be triggered by `<img src=\"/issue/1/comment/reply/?text_comment=spam&parent_id=1&issue_pk=1\">` — switched to POST with CSRF token
2. **ValueError crash**: Bare `int(parent_id)` crashes with 500 on non-numeric input — added try/except validation
3. **DoesNotExist crash**: Bare `.objects.get()` calls crash with 500 on missing records — replaced with `get_object_or_404`
4. **Windows path bug**: `os.path.join(\"/profile/\", username)` produces backslashes on Windows — replaced with f-string
5. **UnboundLocalError**: `all_comment` and `show` variables used outside the `if` block were undefined when request method was not GET — fixed by using `@require_POST`

### Changes

- **`comments/views.py`**: Added `@require_POST`, input validation, `get_object_or_404`, f-string URL
- **`website/static/js/issue.js`**: Changed AJAX from GET to POST with `csrfmiddlewaretoken`