### PR TITLE
fix: handle JSONDecodeError on unprotected json.loads(request.body)

### DIFF
--- a/website/views/company.py
+++ b/website/views/company.py
@@ -2625,7 +2625,10 @@ def edit_prize(request, prize_id, organization_id):
     except HuntPrize.DoesNotExist:
         return JsonResponse({"success": False, "error": "Prize not found"})
 
-    data = json.loads(request.body)
+    try:
+        data = json.loads(request.body)
+    except json.JSONDecodeError:
+        return JsonResponse({"success": False, "error": "Invalid JSON"}, status=400)
     prize.name = data.get("prize_name", prize.name)
     prize.value = data.get("cash_value", prize.value)
     prize.no_of_eligible_projects = data.get("number_of_winning_projects", prize.no_of_eligible_projects)

--- a/website/views/issue.py
+++ b/website/views/issue.py
@@ -656,6 +656,8 @@ def change_bid_status(request):
             bid.status = "Selected"
             bid.save()
             return JsonResponse({"success": True})
+        except json.JSONDecodeError:
+            return JsonResponse({"success": False, "error": "Invalid JSON"}, status=400)
         except Bid.DoesNotExist:
             return JsonResponse({"success": False, "error": "Bid not found"})
     return HttpResponse(status=405)
@@ -766,8 +768,11 @@ def SaveBiddingData(request):
 
 def fetch_current_bid(request):
     if request.method == "POST":
+        try:
+            data = json.loads(request.body)
+        except json.JSONDecodeError:
+            return JsonResponse({"error": "Invalid JSON"}, status=400)
         unique_issue_links = Bid.objects.values_list("issue_url", flat=True).distinct()
-        data = json.loads(request.body)
         issue_url = data.get("issue_url")
         bid = Bid.objects.filter(issue_url=issue_url).order_by("-created").first()
         if bid is not None:

--- a/website/views/slack_handlers.py
+++ b/website/views/slack_handlers.py
@@ -260,7 +260,10 @@ def slack_events(request):
 
         elif request.content_type == "application/json":
             # Handle Events API requests
-            data = json.loads(request.body)
+            try:
+                data = json.loads(request.body)
+            except json.JSONDecodeError:
+                return JsonResponse({"error": "Invalid JSON"}, status=400)
 
             # Check if this is a retry event
             is_retry = request.headers.get("X-Slack-Retry-Num")


### PR DESCRIPTION
## Description

Several endpoints call `json.loads(request.body)` without catching `json.JSONDecodeError`, causing unhandled 500 errors when clients send malformed JSON bodies.

### Bug

```python
# Before: crashes with json.JSONDecodeError on malformed body
data = json.loads(request.body)
```

Sending `{invalid json` or an empty body to these endpoints produces a 500 Internal Server Error instead of a proper 400 Bad Request response.

### Fix

Added `try/except json.JSONDecodeError` with appropriate 400 error responses in:

- **`issue.py`**: `change_bid_status()` — try block only caught `Bid.DoesNotExist`, not `JSONDecodeError`
- **`issue.py`**: `fetch_current_bid()` — no try/except at all
- **`company.py`**: `edit_prize()` — `json.loads` was outside the existing try block
- **`slack_handlers.py`**: Events API handler — `json.loads` was in an `elif` branch outside the try/except that handled the previous `if` branch