### PR TITLE
fix: add missing @login_required to education views

### DIFF
--- a/website/views/education.py
+++ b/website/views/education.py
@@ -277,6 +277,7 @@ def delete_section(request, section_id):
 
 
 # Lecture CRUD operations
+@login_required(login_url="/accounts/login")
 @require_POST
 def add_lecture(request, section_id):
     """Add a new lecture to a section, else standalone"""
@@ -514,6 +515,7 @@ def get_course_content(request, course_id):
         )
 
 
+@login_required(login_url="/accounts/login")
 @require_POST
 def create_or_update_course(request):
     try:


### PR DESCRIPTION
## Description

`add_lecture` and `create_or_update_course` in `education.py` have `@require_POST` but no authentication decorator. Anonymous POST requests to these endpoints crash with `AttributeError` when accessing `request.user.userprofile`.

### Bug

```python
# add_lecture — only has @require_POST, no auth check
@require_POST
def add_lecture(request, section_id):
    user_profile = request.user.userprofile  # AttributeError for AnonymousUser
```

An anonymous user sending a POST request to `/education/section/1/lecture/add/` would get a 500 error instead of being redirected to login.

### Fix

Added `@login_required(login_url="/accounts/login")` to both functions, matching the pattern used by all other education CRUD views in the same file (lines 50, 73, 98, 108, 114, 122, 175).