### PR TITLE
fix(company): add missing @login_required to state-changing views

### DIFF
--- a/website/views/company.py
+++ b/website/views/company.py
@@ -2603,6 +2603,7 @@ class OrganizationDashboardManageBughuntView(View):
         return render(request, "organization/bughunt/organization_manage_bughunts.html", context)
 
 
+@login_required(login_url="/accounts/login")
 @require_http_methods(["DELETE"])
 def delete_prize(request, prize_id, organization_id):
     if not request.user.organization_set.filter(id=organization_id).exists():
@@ -2615,6 +2616,7 @@ def delete_prize(request, prize_id, organization_id):
         return JsonResponse({"success": False, "error": "Prize not found"})
 
 
+@login_required(login_url="/accounts/login")
 @require_http_methods(["PUT"])
 def edit_prize(request, prize_id, organization_id):
     if not request.user.organization_set.filter(id=organization_id).exists():
@@ -2636,6 +2638,7 @@ def edit_prize(request, prize_id, organization_id):
     return JsonResponse({"success": True})
 
 
+@login_required(login_url="/accounts/login")
 def accept_bug(request, issue_id, reward_id=None):
     with transaction.atomic():
         issue = get_object_or_404(Issue, id=issue_id)
@@ -2665,6 +2668,7 @@ def accept_bug(request, issue_id, reward_id=None):
         return redirect("show_bughunt", pk=issue.hunt.id)
 
 
+@login_required(login_url="/accounts/login")
 @require_http_methods(["DELETE"])
 def delete_manager(request, manager_id, domain_id):
     try:


### PR DESCRIPTION
## Description

Four state-changing views in `company.py` are missing `@login_required`, allowing anonymous users to trigger server errors or perform unauthorized actions:

| View | Has | Missing | Impact |
|------|-----|---------|--------|
| `delete_prize` | `@require_http_methods(["DELETE"])` | `@login_required` | `AttributeError` — `AnonymousUser` has no `organization_set` |
| `edit_prize` | `@require_http_methods(["PUT"])` | `@login_required` | `AttributeError` — same crash |
| `accept_bug` | *(none)* | `@login_required` | **Anyone can verify issues and set reward amounts** |
| `delete_manager` | `@require_http_methods(["DELETE"])` | `@login_required` | `AttributeError` on admin comparison |

## Fix

Added `@login_required(login_url="/accounts/login")` to all four views. The decorator is placed outermost so it runs first, redirecting anonymous users to the login page before the view logic executes.

## How to Reproduce

1. Log out of the application
2. Send a DELETE request to `/organization/<id>/prize/<id>/delete/`
3. Observe 500 error: `AttributeError: 'AnonymousUser' object has no attribute 'organization_set'`

## Testing

- Anonymous requests now redirect to `/accounts/login` instead of crashing
- Authenticated requests continue to work as before
- No changes to the view logic itself