### PR TITLE
fix(comments): fix broken send_mail call in comment mention notification

### DIFF
--- a/comments/views.py
+++ b/comments/views.py
@@ -63,7 +63,8 @@ def add_comment(request):
             send_mail(
                 "You have been mentioned in a comment",
                 msg_plain,
-                settings.EMAIL_TO_STRING[obj.email],
+                settings.EMAIL_TO_STRING,
+                [obj.email],
                 html_message=msg_html,
             )
 


### PR DESCRIPTION
## Description\n\nThe `send_mail` call in `add_comment` (for @mention email notifications) has been broken since it was written — mentioning a user in a comment crashes instead of sending an email.\n\n### Bug 1: `TypeError` on string subscript\n```python\nsettings.EMAIL_TO_STRING[obj.email]  # e.g. \"noreply@blt.com\"[\"user@example.com\"]\n```\n`EMAIL_TO_STRING` is a string. Subscripting a string with another string raises `TypeError: string indices must be integers`.\n\n### Bug 2: Missing `recipient_list`\nDjango's `send_mail` signature: `send_mail(subject, message, from_email, recipient_list, ...)`\n\nThe call passes only 3 positional arguments — `recipient_list` is missing entirely.\n\n## Fix\n\nChanged to match the pattern used in every other `send_mail` call in the codebase:\n```python\nsend_mail(\n    \"You have been mentioned in a comment\",\n    msg_plain,\n    settings.EMAIL_TO_STRING,   # from_email\n    [obj.email],                 # recipient_list (was missing)\n    html_message=msg_html,\n)\n```\n\n## Testing\n\n- @mentioning a user in a comment now sends the notification email instead of crashing\n- The fix is consistent with `issue.py:156-161`, `issue.py:341-346`, and all other `send_mail` calls