### PR TITLE
fix(comments): switch edit_comment from GET to POST (CSRF fix)

### DIFF
--- a/website/static/js/issue.js
+++ b/website/static/js/issue.js
@@ -96,12 +96,13 @@ $(function () {
         var comment = $(this).prev().find('textarea').val();
         if (comment == '') return;
         $.ajax({
-            type: 'GET',
+            type: 'POST',
             url: '/issue/' + issue_id + '/comment/edit/',
             data: {
                 comment_pk: comment_id,
                 text_comment: comment,
                 issue_pk: issue_id,
+                csrfmiddlewaretoken: $('input[name=csrfmiddlewaretoken]').val(),
             },
             success: function (data) {
                 $('#target_div').html(data);


### PR DESCRIPTION
## Description

`edit_comment` modifies data (updates comment text) via GET request. This is a CSRF vulnerability — an attacker can trick a logged-in user into editing their own comment by embedding a crafted URL:

```html
<img src=\"/issue/123/comment/edit/?comment_pk=456&text_comment=hacked&issue_pk=123\">\n```

### Additional bugs fixed

| Bug | Impact |\n|-----|--------|\n| Bare `Issue.objects.get(pk=request.GET[\"issue_pk\"])` | `KeyError` if param missing, `DoesNotExist` if invalid |\n| Bare `Comment.objects.get(pk=request.GET[\"comment_pk\"])` | Same |\n| No author ownership check | Any logged-in user can edit any comment |\n| `all_comment` undefined on POST/PUT/etc | `NameError` crash since it's only defined inside `if request.method == \"GET\"` |\n\n## Fix\n\n**Backend (`comments/views.py`):**\n- Added `@require_POST` decorator\n- Switched from `request.GET` to `request.POST`\n- Replaced `.objects.get()` with `get_object_or_404()`\n- Added author ownership check (returns 403 if user doesn't own the comment)\n\n**Frontend (`issue.js`):**\n- Changed AJAX from `type: 'GET'` to `type: 'POST'`\n- Added `csrfmiddlewaretoken` to the request data\n\n## Testing\n\n- GET request → 405 Method Not Allowed\n- POST by comment owner → comment edited successfully\n- POST by different user → 403 Forbidden\n- Invalid issue_pk or comment_pk → 404 Not Found