### PR TITLE
fix(issue): add authentication to change_bid_status

### DIFF
--- a/website/views/issue.py
+++ b/website/views/issue.py
@@ -647,18 +647,21 @@ def generate_bid_image(request, bid_amount):
     return HttpResponse(byte_io, content_type="image/png")
 
 
+@login_required(login_url="/accounts/login")
+@require_POST
 def change_bid_status(request):
-    if request.method == "POST":
-        try:
-            data = json.loads(request.body)
-            bid_id = data.get("id")
-            bid = Bid.objects.get(id=bid_id)
-            bid.status = "Selected"
-            bid.save()
-            return JsonResponse({"success": True})
-        except Bid.DoesNotExist:
-            return JsonResponse({"success": False, "error": "Bid not found"})
-    return HttpResponse(status=405)
+    try:
+        data = json.loads(request.body)
+    except json.JSONDecodeError:
+        return JsonResponse({"success": False, "error": "Invalid JSON"}, status=400)
+    bid_id = data.get("id")
+    try:
+        bid = Bid.objects.get(id=bid_id)
+    except Bid.DoesNotExist:
+        return JsonResponse({"success": False, "error": "Bid not found"}, status=404)
+    bid.status = "Selected"
+    bid.save()
+    return JsonResponse({"success": True})
 
 
 def get_unique_issues(request):


### PR DESCRIPTION
## Description\n\n`change_bid_status` has **no authentication** — any anonymous user can POST to change any bid's status to \"Selected\". Since bid selection has financial implications (it determines which bid wins a bounty), this is a critical authorization gap.\n\n## Bugs Fixed\n\n| Bug | Impact |\n|-----|--------|\n| No `@login_required` | Anonymous users can select bids |\n| Manual `if request.method == \"POST\"` check | Should use `@require_POST` decorator |\n| No `json.JSONDecodeError` handling | Malformed JSON body returns 500 |\n\n## Fix\n\n- Added `@login_required(login_url=\"/accounts/login\")` to require authentication\n- Added `@require_POST` to enforce POST-only access (replaces manual method check)\n- Added explicit `json.JSONDecodeError` handling with 400 response\n- Added proper HTTP status codes (404 for missing bid, 400 for invalid JSON)\n\n## Testing\n\n- Anonymous POST → redirects to login\n- Authenticated POST with valid bid ID → bid status changed to \"Selected\"\n- Invalid JSON body → 400 Bad Request\n- Non-existent bid ID → 404 Not Found