### PR TITLE
fix: handle Wallet.DoesNotExist in issue and organization views

### DIFF
--- a/website/views/issue.py
+++ b/website/views/issue.py
@@ -628,7 +628,10 @@ def search_issues(request, template="search.html"):
         }
 
     if request.user.is_authenticated:
-        context["wallet"] = Wallet.objects.get(user=request.user)
+        try:
+            context["wallet"] = Wallet.objects.get(user=request.user)
+        except Wallet.DoesNotExist:
+            context["wallet"] = None
     issues = serializers.serialize("json", context["issues"])
     issues = json.loads(issues)
     return HttpResponse(json.dumps({"issues": issues}), content_type="application/json")
@@ -1654,7 +1657,10 @@ class IssueCreate(IssueBaseCreate, CreateView):
         context["activities"] = Issue.objects.exclude(Q(is_hidden=True) & ~Q(user_id=self.request.user.id))[0:10]
         context["captcha_form"] = CaptchaForm()
         if self.request.user.is_authenticated:
-            context["wallet"] = Wallet.objects.get(user=self.request.user)
+            try:
+                context["wallet"] = Wallet.objects.get(user=self.request.user)
+            except Wallet.DoesNotExist:
+                context["wallet"] = None
         context["leaderboard"] = (
             User.objects.filter(
                 points__created__month=timezone.now().month,
@@ -1714,7 +1720,10 @@ class AllIssuesView(ListView):
         page = self.request.GET.get("page")
 
         if self.request.user.is_authenticated:
-            context["wallet"] = Wallet.objects.get(user=self.request.user)
+            try:
+                context["wallet"] = Wallet.objects.get(user=self.request.user)
+            except Wallet.DoesNotExist:
+                context["wallet"] = None
         try:
             activities_paginated = paginator.page(page)
         except PageNotAnInteger:
@@ -1790,7 +1799,10 @@ class SpecificIssuesView(ListView):
         page = self.request.GET.get("page")
 
         if self.request.user.is_authenticated:
-            context["wallet"] = Wallet.objects.get(user=self.request.user)
+            try:
+                context["wallet"] = Wallet.objects.get(user=self.request.user)
+            except Wallet.DoesNotExist:
+                context["wallet"] = None
         try:
             activities_paginated = paginator.page(page)
         except PageNotAnInteger:
@@ -1867,7 +1879,10 @@ class IssueView(DetailView):
             context["users_score"] = 0
 
         if self.request.user.is_authenticated:
-            context["wallet"] = Wallet.objects.get(user=self.request.user)
+            try:
+                context["wallet"] = Wallet.objects.get(user=self.request.user)
+            except Wallet.DoesNotExist:
+                context["wallet"] = None
 
         context["issue_count"] = Issue.objects.filter(url__contains=self.object.domain_name).count()
         context["all_comment"] = self.object.comments.all()

--- a/website/views/organization.py
+++ b/website/views/organization.py
@@ -1093,7 +1093,10 @@ class DomainDetailView(ListView):
             )
 
             if self.request.user.is_authenticated:
-                context["wallet"] = Wallet.objects.get(user=self.request.user)
+                try:
+                    context["wallet"] = Wallet.objects.get(user=self.request.user)
+                except Wallet.DoesNotExist:
+                    context["wallet"] = None
 
             # Handle pagination for open issues
             open_paginator = Paginator(open_issues, self.paginate_by)


### PR DESCRIPTION
## Description

Multiple views crash with `Wallet.DoesNotExist` (500 error) when an authenticated user has no Wallet record. The correct pattern (`try/except Wallet.DoesNotExist`) is already used in `core.py:847-850` but was missing from 5 places in `issue.py` and 1 in `organization.py`.

## Bug

When an authenticated user without a Wallet record visits any of these pages, the unhandled `Wallet.DoesNotExist` exception causes a 500 Internal Server Error:

- `search_issues` (issue.py line 631)
- `IssueCreate.get_context_data` (issue.py line 1660)
- `AllIssuesView.get_context_data` (issue.py line 1723)
- `SpecificIssuesView.get_context_data` (issue.py line 1799)
- `IssueDetailView.get_context_data` (issue.py line 1882)
- `OrganizationDashboard.get_context_data` (organization.py line 1096)

## Fix

Added `try/except Wallet.DoesNotExist` around each `Wallet.objects.get(user=request.user)` call, matching the existing pattern in `core.py:847-850`.