### PR TITLE
fix: handle JSONDecodeError in edit_prize view

### DIFF
--- a/website/views/company.py
+++ b/website/views/company.py
@@ -2625,7 +2625,11 @@ def edit_prize(request, prize_id, organization_id):
     except HuntPrize.DoesNotExist:
         return JsonResponse({"success": False, "error": "Prize not found"})
 
-    data = json.loads(request.body)
+    try:
+        data = json.loads(request.body)
+    except json.JSONDecodeError:
+        return JsonResponse({"success": False, "error": "Invalid JSON"}, status=400)
+
     prize.name = data.get("prize_name", prize.name)
     prize.value = data.get("cash_value", prize.value)
     prize.no_of_eligible_projects = data.get("number_of_winning_projects", prize.no_of_eligible_projects)


### PR DESCRIPTION
## Description\n\n`edit_prize` in `company.py` calls `json.loads(request.body)` without `try/except`, causing an unhandled `json.JSONDecodeError` (500 Internal Server Error) when the request body contains malformed JSON.\n\n## Bug\n\nSending a PUT request with invalid JSON to the edit prize endpoint produces a 500 error instead of a proper 400 response.\n\n## Fix\n\nWrapped `json.loads(request.body)` in `try/except json.JSONDecodeError` to return a 400 JSON error response, matching the error handling pattern used throughout the codebase (e.g., `bounty.py:37-40`, `user.py:1870-1872`).