### PR TITLE
fix: handle ValueError in page/per_page query parameters

### DIFF
--- a/website/views/core.py
+++ b/website/views/core.py
@@ -2276,7 +2276,10 @@ def template_list(request):
     filter_by = request.GET.get("filter", "all")
     sort = request.GET.get("sort", "name")
     direction = request.GET.get("dir", "asc")
-    page = int(request.GET.get("page", 1))
+    try:
+        page = int(request.GET.get("page", 1))
+    except (ValueError, TypeError):
+        page = 1
     per_page = 20
 
     def extract_template_info(template_path):

--- a/website/views/organization.py
+++ b/website/views/organization.py
@@ -807,9 +807,15 @@ def load_more_issues(request):
     """
     AJAX handler for loading more GitHub issues with pagination support
     """
-    page = int(request.GET.get("page", 1))
+    try:
+        page = int(request.GET.get("page", 1))
+    except (ValueError, TypeError):
+        page = 1
     state = request.GET.get("state", "open")
-    per_page = int(request.GET.get("per_page", 10))
+    try:
+        per_page = int(request.GET.get("per_page", 10))
+    except (ValueError, TypeError):
+        per_page = 10
 
     # Validate inputs
     if page < 1:


### PR DESCRIPTION
## Description\n\n`template_list` in `core.py` and `load_more_issues` in `organization.py` call `int()` directly on query parameters without `try/except`. Passing a non-numeric value (e.g., `?page=abc`) causes an unhandled `ValueError`, resulting in a 500 Internal Server Error.\n\n## Bug\n\nReproduction: visit any URL with `?page=abc` or `?per_page=xyz` for these endpoints. The `int()` call raises `ValueError` which is not caught.\n\n## Fix\n\nWrapped the `int()` calls in `try/except (ValueError, TypeError)` to fall back to default values (page=1, per_page=10) on invalid input.