### PR TITLE
fix: catch Decimal InvalidOperation in hunt prize validation

### DIFF
--- a/website/views/organization.py
+++ b/website/views/organization.py
@@ -6,7 +6,7 @@ import re
 import time
 from collections import defaultdict
 from datetime import datetime, timedelta
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation
 from smtplib import SMTPException
 from urllib.parse import quote_plus, urlparse
 
@@ -1414,7 +1414,7 @@ class CreateHunt(TemplateView):
                 return HttpResponse("success")
             else:
                 return HttpResponse("failed")
-        except (OrganizationAdmin.DoesNotExist, Domain.DoesNotExist, ValueError, KeyError) as e:
+        except (OrganizationAdmin.DoesNotExist, Domain.DoesNotExist, ValueError, KeyError, InvalidOperation) as e:
             logger.error("Error managing organization: %s", e)
             return HttpResponse("An error occurred while processing your request.")
 


### PR DESCRIPTION
## Description

In `CreateHunt.post()`, prize values from POST data are converted using `Decimal(request.POST["prize_winner"])` etc. When a user submits non-numeric text (e.g., `"abc"`), `Decimal()` raises `decimal.InvalidOperation`.

The existing `except` clause at the end of the try block catches `ValueError`, but `decimal.InvalidOperation` inherits from `ArithmeticError`, **not** `ValueError`:

```
decimal.InvalidOperation → decimal.DecimalException → ArithmeticError → Exception
```

So the exception goes uncaught, resulting in a 500 error.

## Changes

- Added `InvalidOperation` to the import: `from decimal import Decimal, InvalidOperation`
- Added `InvalidOperation` to the existing except clause

## Testing

- Submitting `"abc"` as a prize value now returns the error response instead of crashing
- Valid decimal values continue to work as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened error handling for decimal operations. The application now gracefully manages edge cases and invalid decimal arithmetic, preventing crashes and improving stability when processing numerical values and calculations throughout the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->