### PR TITLE
fix: add missing timeout to GitHub API request in PR fetch loop

### DIFF
--- a/website/views/hackathon.py
+++ b/website/views/hackathon.py
@@ -589,7 +589,7 @@ def _refresh_repository_pull_requests(hackathon, repo):
 
     while page <= max_pages:
         params["page"] = page
-        response = requests.get(api_url, headers=headers, params=params)
+        response = requests.get(api_url, headers=headers, params=params, timeout=GITHUB_API_TIMEOUT)
         response.raise_for_status()  # Raise exception for HTTP errors
 
         page_data = response.json()


### PR DESCRIPTION
## Description

`refresh_pr_data()` in `hackathon.py` calls `requests.get()` inside a while loop that can iterate up to 100 times, but the request has **no timeout**. Each request can hang indefinitely, potentially blocking the server worker for a very long time.

The `GITHUB_API_TIMEOUT` constant is already defined in the same file (line 39) and used by other API calls in the file (e.g., the org repos fetch at line 785), but was missed for this particular request.

## Changes

- Added `timeout=GITHUB_API_TIMEOUT` to the `requests.get()` call in the PR fetch loop

## Testing

- If the GitHub API is slow or unreachable, the request now times out after the configured limit instead of hanging indefinitely
- Normal API responses are unaffected since they complete well within the timeout