### PR TITLE
fix: require authentication for change_bid_status

### DIFF
--- a/website/tests/test_bidding.py
+++ b/website/tests/test_bidding.py
@@ -179,17 +179,14 @@ class ChangeBidStatusTests(TestCase):
             status="Open",
         )
 
-    def test_unauthenticated_post_succeeds(self):
-        """Unauthenticated POST to change_bid_status currently returns 200.
-
-        Note: change_bid_status does not have @login_required yet.
-        """
+    def test_unauthenticated_post_redirects(self):
+        """Unauthenticated POST to change_bid_status should redirect to login."""
         response = self.client.post(
             reverse("change_bid_status"),
             json.dumps({"id": self.bid.id}),
             content_type="application/json",
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 302)
 
     def test_authenticated_changes_status(self):
         """Authenticated POST should change bid status to Selected."""

--- a/website/views/issue.py
+++ b/website/views/issue.py
@@ -647,6 +647,7 @@ def generate_bid_image(request, bid_amount):
     return HttpResponse(byte_io, content_type="image/png")
 
 
+@login_required
 def change_bid_status(request):
     if request.method == "POST":
         try:
@@ -658,6 +659,8 @@ def change_bid_status(request):
             return JsonResponse({"success": True})
         except Bid.DoesNotExist:
             return JsonResponse({"success": False, "error": "Bid not found"})
+        except json.JSONDecodeError:
+            return JsonResponse({"success": False, "error": "Invalid JSON"}, status=400)
     return HttpResponse(status=405)
 
 


### PR DESCRIPTION
## Description

`change_bid_status` in `issue.py` allows **any anonymous user** to change bid statuses by POSTing to `/change_bid_status/`. This means unauthenticated users can modify bid selection without logging in.

The existing test suite even documents this as a known issue:
```python
def test_unauthenticated_post_succeeds(self):
    """Unauthenticated POST to change_bid_status currently returns 200.
    Note: change_bid_status does not have @login_required yet.
    """
```

Additionally, `json.loads(request.body)` is called without catching `json.JSONDecodeError`, so submitting invalid JSON causes an unhandled 500 error. Compare with `get_unique_issues` in the same file which properly handles this.

## Changes

- Added `@login_required` decorator to `change_bid_status`
- Added `except json.JSONDecodeError` handler matching the pattern in `get_unique_issues`
- Updated the test to expect a 302 redirect for unauthenticated requests

## Testing

- Unauthenticated POST to `/change_bid_status/` now redirects to login (302 instead of 200)
- Authenticated users can still change bid status as before
- Invalid JSON now returns a 400 with error message instead of crashing with 500