### PR TITLE
fix: require authentication for start_thread view

### DIFF
--- a/website/views/user.py
+++ b/website/views/user.py
@@ -1770,6 +1770,7 @@ def messaging_home(request):
     return render(request, "messaging.html", {"threads": threads})
 
 
+@login_required
 def start_thread(request, user_id):
     if request.method == "POST":
         other_user = get_object_or_404(User, id=user_id)


### PR DESCRIPTION
## Description

`start_thread` in `user.py` creates encrypted chat threads and sends email notifications but is missing the `@login_required` decorator. All other thread-related views in the same file require authentication:

- `view_thread` (line 1818) — has `@login_required`
- `delete_thread` (line 1827) — has `@login_required`
- `get_public_key` (line 1842) — has `@login_required`
- `set_public_key` (line 1866) — has `@login_required`
- **`start_thread` (line 1773) — missing `@login_required`**

Without authentication, an anonymous POST to `/messaging/start-thread/<user_id>/` crashes because `AnonymousUser` has no valid `pk` for the `Thread.objects.filter(participants=request.user)` query.

## Changes

- Added `@login_required` decorator to `start_thread`

## Testing

- Anonymous users now get redirected to login instead of crashing with 500
- Authenticated users can start threads as before