### PR TITLE
fix(slackbot): add timeout to GitHub API requests

### DIFF
--- a/website/views/slackbot.py
+++ b/website/views/slackbot.py
@@ -162,7 +162,7 @@ if app:
                     logger.debug(f"Could not join channel: {channel_error}")
 
                 try:
-                    gh_response = requests.get("https://api.github.com/orgs/OWASP-BLT/repos")
+                    gh_response = requests.get("https://api.github.com/orgs/OWASP-BLT/repos", timeout=10)
                     if gh_response.status_code == 200:
                         repos = gh_response.json()
                         if not repos:
@@ -239,7 +239,7 @@ if app:
             logger.debug(f"User {user_id} selected repository: {selected_repo}")
 
             # Fetch latest issues from the selected GitHub repository
-            issues_response = requests.get(f"https://api.github.com/repos/{selected_repo}/issues")
+            issues_response = requests.get(f"https://api.github.com/repos/{selected_repo}/issues", timeout=10)
             if issues_response.status_code == 200:
                 issues = issues_response.json()
                 issues = [issue for issue in issues if "pull_request" not in issue]


### PR DESCRIPTION
## Description

Two `requests.get()` calls to the GitHub API in `slackbot.py` (lines 165 and 242) have no `timeout` parameter. Without a timeout, if the GitHub API is slow or unresponsive, these calls block indefinitely, tying up a server worker.

### Bug

- **Line 165**: `requests.get("https://api.github.com/orgs/OWASP-BLT/repos")` — fetches org repos with no timeout
- **Line 242**: `requests.get(f"https://api.github.com/repos/{selected_repo}/issues")` — fetches repo issues with no timeout

Both are called from Slack command handlers, so a hanging request would leave the Slack user with no response and consume server resources.

### Fix

Add `timeout=10` to both `requests.get()` calls, consistent with the timeout values used in other views (e.g., `project.py` line 634).