### PR TITLE
fix(organization): add timeout to USPTO trademark API requests

### DIFF
--- a/website/views/organization.py
+++ b/website/views/organization.py
@@ -1647,7 +1647,7 @@ def trademark_detailview(request, slug):
         "x-rapidapi-host": "uspto-trademark.p.rapidapi.com",
         "x-rapidapi-key": settings.USPTO_API,
     }
-    trademark_available_response = requests.get(trademark_available_url, headers=headers)
+    trademark_available_response = requests.get(trademark_available_url, headers=headers, timeout=10)
     ta_data = trademark_available_response.json()
 
     if trademark_available_response.status_code == 429:
@@ -1660,7 +1660,7 @@ def trademark_detailview(request, slug):
 
     if ta_data[0].get("available") == "no":
         trademark_search_url = "https://uspto-trademark.p.rapidapi.com/v1/trademarkSearch/%s/active" % (slug)
-        trademark_search_response = requests.get(trademark_search_url, headers=headers)
+        trademark_search_response = requests.get(trademark_search_url, headers=headers, timeout=10)
         ts_data = trademark_search_response.json()
         context = {"count": ts_data.get("count"), "items": ts_data.get("items"), "query": slug}
     else:


### PR DESCRIPTION
## Description

Two `requests.get()` calls to the USPTO trademark API in `organization.py` have no `timeout` parameter. Without a timeout, if the RapidAPI USPTO service is slow or unresponsive, these calls block indefinitely, tying up a server worker.

### Bug

- **Line 1650**: `requests.get(trademark_available_url, headers=headers)` — checks trademark availability with no timeout
- **Line 1663**: `requests.get(trademark_search_url, headers=headers)` — searches trademark details with no timeout

All other `requests.get()` calls in the same file already correctly use `timeout=5` or `timeout=10` (lines 103, 734, 2758, 2804, 2869, 3260, etc.).

### Fix

Add `timeout=10` to both calls, consistent with the timeout values used elsewhere in the same file.