### PR TITLE
fix(issue): prevent data loss in UpdateIssue when email fails

### DIFF
--- a/website/views/issue.py
+++ b/website/views/issue.py
@@ -430,11 +430,14 @@ def UpdateIssue(request):
             )
             subject = issue.domain.name + " bug # " + str(issue.id) + " opened by " + request.user.username
 
+        else:
+            return HttpResponse("invalid action")
+
+        issue.save()
         mailer = settings.EMAIL_TO_STRING
         email_to = issue.user.email
-        send_mail(subject, msg_plain, mailer, [email_to], html_message=msg_html)
-        send_mail(subject, msg_plain, mailer, [issue.domain.email], html_message=msg_html)
-        issue.save()
+        send_mail(subject, msg_plain, mailer, [email_to], html_message=msg_html, fail_silently=True)
+        send_mail(subject, msg_plain, mailer, [issue.domain.email], html_message=msg_html, fail_silently=True)
         return HttpResponse("Updated")
 
     elif request.method == "POST":


### PR DESCRIPTION
## Description

`UpdateIssue` has two bugs in its close/reopen flow that can cause data loss and crashes.

### Bug 1: Email failure prevents issue.save()

`send_mail()` at lines 435-436 is called **without** `fail_silently=True` and is **not** inside a `try/except`. If the SMTP server is down or unreachable, `send_mail` raises an exception (`SMTPException`, `ConnectionRefusedError`, `socket.gaierror`).

**Critical**: `issue.save()` at line 437 **never executes**, so the issue status change (close/reopen) is **silently lost** even though the user intended to update it. The user sees a 500 error and doesn't know if their action took effect.

Other views in the same file (lines 873, 940) correctly handle this by wrapping `send_mail` in try/except or using `fail_silently=True`.

### Bug 2: NameError for unrecognized action

If `request.POST.get(\"action\")` is neither `\"close\"` nor `\"open\"` (e.g., empty string, typo, or unexpected value), neither the `if` nor the `elif` branch executes. The variables `subject`, `msg_plain`, and `msg_html` are **never defined**, but line 435 tries to use them, causing a `NameError` crash.

### Fix

1. Move `issue.save()` **before** `send_mail()` so the status change always persists
2. Add `fail_silently=True` to both `send_mail()` calls
3. Add early return for unrecognized action values to prevent `NameError`