### PR TITLE
fix(company): add @login_required to prize views and handle JSONDecodeError

### DIFF
--- a/website/views/company.py
+++ b/website/views/company.py
@@ -2603,6 +2603,7 @@ class OrganizationDashboardManageBughuntView(View):
         return render(request, "organization/bughunt/organization_manage_bughunts.html", context)
 
 
+@login_required
 @require_http_methods(["DELETE"])
 def delete_prize(request, prize_id, organization_id):
     if not request.user.organization_set.filter(id=organization_id).exists():
@@ -2615,6 +2616,7 @@ def delete_prize(request, prize_id, organization_id):
         return JsonResponse({"success": False, "error": "Prize not found"})
 
 
+@login_required
 @require_http_methods(["PUT"])
 def edit_prize(request, prize_id, organization_id):
     if not request.user.organization_set.filter(id=organization_id).exists():
@@ -2625,7 +2627,10 @@ def edit_prize(request, prize_id, organization_id):
     except HuntPrize.DoesNotExist:
         return JsonResponse({"success": False, "error": "Prize not found"})
 
-    data = json.loads(request.body)
+    try:
+        data = json.loads(request.body)
+    except json.JSONDecodeError:
+        return JsonResponse({"success": False, "error": "Invalid JSON"}, status=400)
     prize.name = data.get("prize_name", prize.name)
     prize.value = data.get("cash_value", prize.value)
     prize.no_of_eligible_projects = data.get("number_of_winning_projects", prize.no_of_eligible_projects)


### PR DESCRIPTION
`delete_prize` and `edit_prize` access `request.user.organization_set` without `@login_required`. An unauthenticated request causes `AttributeError` on `AnonymousUser` since it lacks ORM relations — resulting in a 500 error.\n\n`edit_prize` also calls `json.loads(request.body)` without catching `JSONDecodeError`, causing a 500 error on malformed JSON input.\n\n**Changes:**\n- Add `@login_required` decorator to both `delete_prize` and `edit_prize`\n- Wrap `json.loads(request.body)` in `try/except json.JSONDecodeError` returning 400

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prize modification endpoints now properly validate JSON requests and return clear error messages for invalid payloads.
  * Prize management operations are now protected by authentication requirements, preventing unauthorized access to prize deletion and modification features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->