### PR TITLE
fix(organization): handle invalid subscription name in org creation

### DIFF
--- a/website/views/organization.py
+++ b/website/views/organization.py
@@ -477,9 +477,12 @@ class Joinorganization(TemplateView):
             url = request.POST["url"]
             email = request.POST["email"]
             product = request.POST["product"]
-            sub = Subscription.objects.get(name=product)
             if name == "" or url == "" or email == "" or product == "":
                 return JsonResponse({"error": "Empty Fields"})
+            try:
+                sub = Subscription.objects.get(name=product)
+            except Subscription.DoesNotExist:
+                return JsonResponse({"error": "Invalid subscription plan"})
             paymentType = request.POST["paymentType"]
             if paymentType == "wallet":
                 wallet, created = Wallet.objects.get_or_create(user=request.user)


### PR DESCRIPTION
`Subscription.objects.get(name=product)` crashes with `Subscription.DoesNotExist` if an invalid subscription name is submitted during organization creation. The exception is not caught by the surrounding `Organization.DoesNotExist` handler, causing a 500 error.\n\nAlso moves the empty fields validation before the subscription lookup, since submitting an empty product name would crash on the `.get()` call before the empty check could reject it.