### PR TITLE
fix(slack): handle JSONDecodeError in Events API handler

### DIFF
--- a/website/views/slack_handlers.py
+++ b/website/views/slack_handlers.py
@@ -260,7 +260,10 @@ def slack_events(request):
 
         elif request.content_type == "application/json":
             # Handle Events API requests
-            data = json.loads(request.body)
+            try:
+                data = json.loads(request.body)
+            except json.JSONDecodeError:
+                return JsonResponse({"error": "Invalid JSON"}, status=400)
 
             # Check if this is a retry event
             is_retry = request.headers.get("X-Slack-Retry-Num")


### PR DESCRIPTION
The `application/json` branch of `slack_events()` calls `json.loads(request.body)` without catching `JSONDecodeError`. A malformed JSON request body (from network corruption or invalid clients) causes an unhandled 500 error.\n\nThe `application/x-www-form-urlencoded` branch already has this handling (line 258), but the JSON branch was missing it.