### PR TITLE
fix(views): handle ValueError in pagination parameter parsing

### DIFF
--- a/website/views/core.py
+++ b/website/views/core.py
@@ -2276,7 +2276,10 @@ def template_list(request):
     filter_by = request.GET.get("filter", "all")
     sort = request.GET.get("sort", "name")
     direction = request.GET.get("dir", "asc")
-    page = int(request.GET.get("page", 1))
+    try:
+        page = int(request.GET.get("page", 1))
+    except (ValueError, TypeError):
+        page = 1
     per_page = 20
 
     def extract_template_info(template_path):

--- a/website/views/organization.py
+++ b/website/views/organization.py
@@ -807,9 +807,15 @@ def load_more_issues(request):
     """
     AJAX handler for loading more GitHub issues with pagination support
     """
-    page = int(request.GET.get("page", 1))
+    try:
+        page = int(request.GET.get("page", 1))
+    except (ValueError, TypeError):
+        page = 1
     state = request.GET.get("state", "open")
-    per_page = int(request.GET.get("per_page", 10))
+    try:
+        per_page = int(request.GET.get("per_page", 10))
+    except (ValueError, TypeError):
+        per_page = 10
 
     # Validate inputs
     if page < 1:


### PR DESCRIPTION
`int(request.GET.get('page', 1))` and `int(request.GET.get('per_page', 10))` crash with `ValueError` when non-numeric query parameters are passed (e.g. `?page=abc`). This causes unhandled 500 errors.\n\nFixed in:\n- `organization.py` `load_more_issues()`: `page` and `per_page` parameters\n- `core.py` template explorer view: `page` parameter