### PR TITLE
fix(education): add missing auth to add_lecture and fix int() crashes

### DIFF
--- a/website/views/education.py
+++ b/website/views/education.py
@@ -232,7 +232,10 @@ def add_section(request, course_id):
 
     # Sanitize user input
     title = request.POST.get("title")
-    order = int(request.POST.get("order", 0))
+    try:
+        order = int(request.POST.get("order", 0))
+    except (ValueError, TypeError):
+        order = 0
 
     section = Section.objects.create(course=course, title=title, order=order)
     messages.success(request, f"Section '{title}' was added successfully!")
@@ -277,6 +280,7 @@ def delete_section(request, section_id):
 
 
 # Lecture CRUD operations
+@login_required
 @require_POST
 def add_lecture(request, section_id):
     """Add a new lecture to a section, else standalone"""
@@ -290,7 +294,10 @@ def add_lecture(request, section_id):
     title = request.POST.get("title")
     content_type = request.POST.get("content_type")
     description = request.POST.get("description")
-    order = int(request.POST.get("order", 0))
+    try:
+        order = int(request.POST.get("order", 0))
+    except (ValueError, TypeError):
+        order = 0
     duration = request.POST.get("duration") or None
 
     lecture = Lecture(


### PR DESCRIPTION
## Description

### Bugs Fixed

1. **Missing `@login_required` on `add_lecture`** — The `add_lecture` view only had `@require_POST` but no authentication decorator. An anonymous user could POST to `/education/instructor_dashboard/sections/<id>/lectures/add/` and trigger an `AttributeError` crash at `request.user.userprofile` (since `AnonymousUser` has no `userprofile` relation). All other lecture CRUD operations (`edit_lecture`, `delete_lecture`) already have `@instructor_required`.

2. **`ValueError` crash in `add_section`** — `int(request.POST.get("order", 0))` at line 235 crashes with `ValueError` if the `order` field contains non-numeric input (e.g., `"abc"`).

3. **`ValueError` crash in `add_lecture`** — Same `int(request.POST.get("order", 0))` pattern at line 293 with the same crash vector.

### Changes

- Added `@login_required` decorator to `add_lecture` to prevent anonymous access
- Wrapped `int()` conversion of `order` field in try/except (ValueError, TypeError) with fallback to 0 in both `add_section` and `add_lecture`