### PR TITLE
fix(issue): close leaked file handle in form_valid screenshot upload

### DIFF
--- a/website/views/issue.py
+++ b/website/views/issue.py
@@ -836,13 +836,16 @@ class IssueBaseCreate(object):
             extension = filename.split(".")[-1]
             self.request.POST["screenshot-hash"] = filename[:99] + str(uuid.uuid4()) + "." + extension
 
-            reopen = default_storage.open("uploads\/" + self.request.POST.get("screenshot-hash") + ".png", "rb")
-            django_file = File(reopen)
-            obj.screenshot.save(
-                self.request.POST.get("screenshot-hash") + ".png",
-                django_file,
-                save=True,
-            )
+            reopen = default_storage.open("uploads/" + self.request.POST.get("screenshot-hash") + ".png", "rb")
+            try:
+                django_file = File(reopen)
+                obj.screenshot.save(
+                    self.request.POST.get("screenshot-hash") + ".png",
+                    django_file,
+                    save=True,
+                )
+            finally:
+                reopen.close()
 
         obj.user_agent = self.request.META.get("HTTP_USER_AGENT")
         obj.save()


### PR DESCRIPTION
## Description

### Bug Fixed

**Leaked file handle in `IssueCreate.form_valid()`** — `default_storage.open()` at line 839 opens a file handle (`reopen`) that is never closed after use. This leaks the file descriptor, which can exhaust the OS file descriptor limit under load.

The same screenshot upload pattern in `process_issue()` (lines 1512-1521) was already properly fixed with `try/finally: reopen.close()`. This PR applies the same fix to `form_valid()`.

### Changes

- Wrapped the screenshot save block in `try/finally` to ensure `reopen.close()` is called even if `obj.screenshot.save()` raises an exception
- Replaced escaped path separator `"uploads\/"` with clean `"uploads/"` for consistency