### PR TITLE
fix(organization): catch Decimal.InvalidOperation in hunt creation

### DIFF
--- a/website/views/organization.py
+++ b/website/views/organization.py
@@ -6,7 +6,7 @@ import re
 import time
 from collections import defaultdict
 from datetime import datetime, timedelta
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation
 from smtplib import SMTPException
 from urllib.parse import quote_plus, urlparse
 
@@ -1414,7 +1414,7 @@ class CreateHunt(TemplateView):
                 return HttpResponse("success")
             else:
                 return HttpResponse("failed")
-        except (OrganizationAdmin.DoesNotExist, Domain.DoesNotExist, ValueError, KeyError) as e:
+        except (OrganizationAdmin.DoesNotExist, Domain.DoesNotExist, ValueError, KeyError, InvalidOperation) as e:
             logger.error("Error managing organization: %s", e)
             return HttpResponse("An error occurred while processing your request.")
 


### PR DESCRIPTION
## Description

### Bug Fixed

The hunt creation POST handler (`OrganizationDashboardHuntView.post()`) has an exception handler that catches `KeyError`, `ValueError`, `Domain.DoesNotExist`, and `OrganizationAdmin.DoesNotExist`. However, the `Decimal()` calls for `prize_winner`, `prize_runner`, and `prize_second_runner` can raise `decimal.InvalidOperation` when given non-numeric input (e.g., `"abc"`).

`InvalidOperation` is a subclass of `ArithmeticError`, not `ValueError`, so it escapes the existing exception handler and causes an unhandled 500 error.

### How to Reproduce

1. Navigate to the hunt creation form
2. Enter non-numeric text (e.g., `"abc"`) in any prize field
3. Submit the form
4. Server crashes with `decimal.InvalidOperation`

### Changes

- Import `InvalidOperation` from the `decimal` module
- Add `InvalidOperation` to the existing except clause alongside the other handled exceptions