### PR TITLE
fix(issue): prevent KeyError crash in submit_bug view

### DIFF
--- a/website/views/issue.py
+++ b/website/views/issue.py
@@ -1941,8 +1941,8 @@ def submit_bug(request, pk, template="hunt_submittion.html"):
             messages.error(request, "Hunt has ended")
             return redirect("index")
         else:
-            url = request.POST["url"]
-            description = request.POST["description"]
+            url = request.POST.get("url", "")
+            description = request.POST.get("description", "")
             if url == "" or description == "":
                 issue_list = Issue.objects.filter(user=request.user, hunt=hunt).exclude(
                     Q(is_hidden=True) & ~Q(user_id=request.user.id)
@@ -1957,7 +1957,7 @@ def submit_bug(request, pk, template="hunt_submittion.html"):
                     Q(is_hidden=True) & ~Q(user_id=request.user.id)
                 )
                 return render(request, template, {"hunt": hunt, "issue_list": issue_list})
-            label = request.POST["label"]
+            label = request.POST.get("label", "")
             if request.POST.get("file"):
                 if isinstance(request.POST.get("file"), six.string_types):
                     import imghdr


### PR DESCRIPTION
## Description

### Bug Fixed

The `submit_bug` view uses `request.POST["url"]`, `request.POST["description"]`, and `request.POST["label"]` with bracket access (lines 1944, 1945, 1960). If any of these fields are missing from the POST data, it raises an unhandled `KeyError` causing a 500 error.

### How to Reproduce

1. Submit a POST request to `/hunt/<pk>/` without the `url`, `description`, or `label` field
2. Server crashes with `KeyError: 'url'`

### Changes

Replaced `request.POST["key"]` with `request.POST.get("key", "")` for all three fields. The existing empty-string validation at line 1946 (`if url == "" or description == ""`) already handles the case where url or description are blank, so the behavior is preserved — missing fields now get treated as empty strings rather than crashing.