### PR TITLE
fix(issue): fix missing raise in base64 decode error handling

### DIFF
--- a/website/views/issue.py
+++ b/website/views/issue.py
@@ -986,7 +986,7 @@ class IssueCreate(IssueBaseCreate, CreateView):
                     try:
                         decoded_file = base64.b64decode(data)
                     except TypeError:
-                        TypeError("invalid_image")
+                        raise TypeError("invalid_image")
 
                     file_name = str(uuid.uuid4())[:12]
                     extension = imghdr.what(file_name, decoded_file)
@@ -1971,7 +1971,10 @@ def submit_bug(request, pk, template="hunt_submittion.html"):
                     try:
                         decoded_file = base64.b64decode(data)
                     except TypeError:
-                        TypeError("invalid_image")
+                        issue_list = Issue.objects.filter(user=request.user, hunt=hunt).exclude(
+                            Q(is_hidden=True) & ~Q(user_id=request.user.id)
+                        )
+                        return render(request, template, {"hunt": hunt, "issue_list": issue_list})
 
                     file_name = str(uuid.uuid4())[:12]
                     extension = imghdr.what(file_name, decoded_file)


### PR DESCRIPTION
## Description

### Bug Fixed

Two `except TypeError` blocks create `TypeError` instances without raising them:

```python
except TypeError:
    TypeError("invalid_image")  # missing 'raise' keyword
```

This is effectively a no-op — the error is silently swallowed, and execution continues to the next line where `decoded_file` is used but was never assigned, causing a `NameError`.

### Affected Locations

1. **`IssueCreate` CBV (line 989)** — The `NameError` from undefined `decoded_file` propagates to the outer `except Exception:` block at line 1002, which silently swallows it. The intended error message `"invalid_image"` is never raised.
   - **Fix**: Added `raise` keyword so the `TypeError` properly propagates to the existing outer exception handler.

2. **`submit_bug` function (line 1974)** — There is no outer `except` block, so the `NameError` on undefined `decoded_file` causes an unhandled 500 error.
   - **Fix**: Return to the hunt form on invalid base64 data, matching the error handling pattern used elsewhere in the same view (e.g., lines 1996-1999).