### PR TITLE
fix(education): add missing @login_required to create_or_update_course

### DIFF
--- a/website/views/education.py
+++ b/website/views/education.py
@@ -514,6 +514,7 @@ def get_course_content(request, course_id):
         )
 
 
+@login_required
 @require_POST
 def create_or_update_course(request):
     try:


### PR DESCRIPTION
## Description

### Bug Fixed

**Missing `@login_required` on `create_or_update_course`** — The view only had `@require_POST` but no authentication decorator. An anonymous user could POST to the course creation endpoint, which would fail at `UserProfile.objects.get(user=user)` with a `DoesNotExist` exception (caught by the broad `except Exception`), returning a generic 500 error instead of a proper login redirect.

The view accesses `request.user` at line 546 and sets `course.instructor = user_profile` at line 560, so authentication is required.

### Changes

- Added `@login_required` decorator to `create_or_update_course` to prevent anonymous access and return a proper login redirect instead of a generic error