### PR TITLE
fix(education): add @require_POST to delete_lecture and fix standalone crash

### DIFF
--- a/website/views/education.py
+++ b/website/views/education.py
@@ -385,21 +385,25 @@ def edit_lecture(request, lecture_id):
 
 
 @instructor_required
+@require_POST
 def delete_lecture(request, lecture_id):
     """Delete a lecture"""
     lecture = get_object_or_404(Lecture, id=lecture_id)
     section = lecture.section
-    course_id = section.course.id
+    lecture_title = lecture.title
 
     lecture.delete()
 
-    for i, lec in enumerate(Lecture.objects.filter(section=section), 1):
-        lec.order = i
-        lec.save()
+    if section:
+        for i, lec in enumerate(Lecture.objects.filter(section=section), 1):
+            lec.order = i
+            lec.save()
 
-    messages.success(request, f"Lecture '{lecture.title}' was deleted successfully!")
+        messages.success(request, f"Lecture '{lecture_title}' was deleted successfully!")
+        return redirect("course_content_management", course_id=section.course.id)
 
-    return redirect("course_content_management", course_id=course_id)
+    messages.success(request, f"Lecture '{lecture_title}' was deleted successfully!")
+    return redirect("instructor_dashboard")
 
 
 @instructor_required


### PR DESCRIPTION
## Description

### Bugs Fixed

1. **CSRF vulnerability via GET** — `delete_lecture` was accessible via GET requests, allowing CSRF attacks through crafted links or image tags (e.g., `<img src="/education/.../lectures/42/delete/">`). Django's CSRF middleware only protects POST/PUT/PATCH/DELETE, so GET-accessible state-changing operations bypass CSRF protection entirely. The sibling view `delete_section` already has `@require_POST`.

2. **`AttributeError` on standalone lectures** — When `lecture.section` is `None` (standalone lecture with no parent section), `section.course.id` at line 392 crashes with `AttributeError: 'NoneType' object has no attribute 'course'`. The URL pattern accepts any `lecture_id`, so standalone lectures can be deleted through this view.

### Changes

- Added `@require_POST` decorator to enforce POST-only access, matching `delete_section`
- Added `None` check for `section` to handle standalone lectures
- Standalone lecture deletion now redirects to `instructor_dashboard` instead of crashing
- Saved `lecture.title` before deletion to avoid accessing deleted object in success message

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lecture deletion with consistent success messages displaying the lecture title.
  * Enhanced redirect logic after deletion—navigates to the relevant page based on whether the lecture belonged to a section.
  * Added safeguards for lecture reordering during deletion operations.

* **Security**
  * Restricted delete lecture action to POST requests only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->