### PR TITLE
fix(organization): prevent update_role crashes from unprotected .get() calls

### DIFF
--- a/website/views/organization.py
+++ b/website/views/organization.py
@@ -1931,36 +1931,47 @@ def add_role(request):
 @login_required(login_url="/accounts/login")
 def update_role(request):
     if request.method == "POST":
-        domain_admin = OrganizationAdmin.objects.get(user=request.user)
-        if domain_admin.role == 0 and domain_admin.is_active:
+        try:
+            requesting_admin = OrganizationAdmin.objects.get(user=request.user)
+        except OrganizationAdmin.DoesNotExist:
+            return HttpResponse("failed")
+        if requesting_admin.role == 0 and requesting_admin.is_active:
             for key, value in request.POST.items():
                 if key.startswith("user@"):
-                    user = User.objects.get(username=value)
-                    if domain_admin.organization.admin == request.user:
-                        pass
-                    domain_admin = OrganizationAdmin.objects.get(user=user)
-                    if request.POST["role@" + value] != "9":
-                        domain_admin.role = request.POST["role@" + value]
-                    elif request.POST["role@" + value] == "9":
-                        domain_admin.is_active = False
-                    if request.POST["domain@" + value] != "":
-                        domain_admin.domain = Domain.objects.get(pk=request.POST["domain@" + value])
+                    try:
+                        user = User.objects.get(username=value)
+                        target_admin = OrganizationAdmin.objects.get(user=user)
+                    except (User.DoesNotExist, OrganizationAdmin.DoesNotExist):
+                        continue
+                    role_value = request.POST.get("role@" + value, "")
+                    if role_value == "9":
+                        target_admin.is_active = False
+                    elif role_value:
+                        target_admin.role = role_value
+                    domain_value = request.POST.get("domain@" + value, "")
+                    if domain_value:
+                        try:
+                            target_admin.domain = Domain.objects.get(pk=domain_value)
+                        except (Domain.DoesNotExist, ValueError):
+                            continue
                     else:
-                        domain_admin.domain = None
-                    domain_admin.save()
+                        target_admin.domain = None
+                    target_admin.save()
             return HttpResponse("success")
-        elif domain_admin.role == 1 and domain_admin.is_active:
+        elif requesting_admin.role == 1 and requesting_admin.is_active:
             for key, value in request.POST.items():
                 if key.startswith("user@"):
-                    user = User.objects.get(username=value)
-                    if domain_admin.organization.admin == request.user:
-                        pass
-                    domain_admin = OrganizationAdmin.objects.get(user=user)
-                    if request.POST["role@" + value] == "1":
-                        domain_admin.role = request.POST["role@" + value]
-                    elif request.POST["role@" + value] == "9":
-                        domain_admin.is_active = False
-                    domain_admin.save()
+                    try:
+                        user = User.objects.get(username=value)
+                        target_admin = OrganizationAdmin.objects.get(user=user)
+                    except (User.DoesNotExist, OrganizationAdmin.DoesNotExist):
+                        continue
+                    role_value = request.POST.get("role@" + value, "")
+                    if role_value == "1":
+                        target_admin.role = role_value
+                    elif role_value == "9":
+                        target_admin.is_active = False
+                    target_admin.save()
             return HttpResponse("success")
         else:
             return HttpResponse("failed")


### PR DESCRIPTION
## Summary\n\n`update_role` had six unprotected `.objects.get()` calls that would crash with 500 errors:\n\n- `OrganizationAdmin.objects.get(user=request.user)` at function entry — crashes if user has no admin record\n- `User.objects.get(username=value)` inside loop — crashes if username does not exist\n- `OrganizationAdmin.objects.get(user=user)` inside loop — crashes if target user has no admin record\n- `Domain.objects.get(pk=...)` inside loop — crashes on invalid pk or missing domain\n\nAlso fixed:\n- `request.POST[\"role@...\"]` and `request.POST[\"domain@...\"]` bracket access replaced with `.get()` to prevent KeyError on malformed POST data\n- Renamed shadowed variable: `domain_admin` was reused for both the requesting admin and the target admin being modified, causing confusion\n\n## Changes\n- Wrap outer `OrganizationAdmin.objects.get()` in try/except, return \"failed\" on DoesNotExist\n- Wrap inner `User.objects.get()` and `OrganizationAdmin.objects.get()` in try/except, skip invalid entries with continue\n- Wrap `Domain.objects.get()` in try/except catching DoesNotExist and ValueError\n- Replace all bracket POST access with `.get()` defaults\n- Rename `domain_admin` to `requesting_admin` and loop variable to `target_admin` for clarity