### PR TITLE
fix(issue): prevent IssueEdit crashes and add missing @login_required

### DIFF
--- a/website/views/issue.py
+++ b/website/views/issue.py
@@ -2232,10 +2232,16 @@ def assign_issue_to_user(request, user, **kwargs):
         assigner.process_issue(user, issue, created, domain)
 
 
+@login_required(login_url="/accounts/login")
 def IssueEdit(request):
     if request.method == "POST":
-        issue = Issue.objects.get(pk=request.POST.get("issue_pk"))
-        uri = request.POST.get("domain")
+        try:
+            issue = Issue.objects.get(pk=request.POST.get("issue_pk"))
+        except (Issue.DoesNotExist, ValueError, TypeError):
+            return HttpResponse("Issue not found")
+        uri = request.POST.get("domain", "")
+        if not uri:
+            return HttpResponse("Domain is required")
         link = uri.replace("www.", "")
         if request.user == issue.user or request.user.is_superuser:
             domain, created = Domain.objects.get_or_create(name=link, defaults={"url": "http://" + link})


### PR DESCRIPTION
## Summary\n\n`IssueEdit` had multiple crash vectors:\n\n- `Issue.objects.get(pk=request.POST.get(\"issue_pk\"))` without try/except — crashes with `DoesNotExist` if issue_pk is invalid, or `TypeError` if issue_pk is missing (None)\n- `uri = request.POST.get(\"domain\")` then `uri.replace(\"www.\", \"\")` — crashes with `AttributeError` when domain key is missing (`None.replace()` is not callable)\n- No `@login_required` — unauthenticated users trigger the `.objects.get()` crash before reaching the authorization check\n\n## Changes\n- Add `@login_required` decorator\n- Wrap `Issue.objects.get()` in try/except for `DoesNotExist`, `ValueError`, and `TypeError`\n- Check for empty/missing domain before calling `.replace()`, return error message