### PR TITLE
fix(issue): prevent assign_issue_to_user signal from crashing login

### DIFF
--- a/website/views/issue.py
+++ b/website/views/issue.py
@@ -2221,8 +2221,12 @@ def assign_issue_to_user(request, user, **kwargs):
             logger.exception("Failed to clear session keys in assign_issue_to_user")
         request.session.modified = True
 
-        issue = Issue.objects.get(id=issue_id)
-        domain = Domain.objects.get(id=domain_id)
+        try:
+            issue = Issue.objects.get(id=issue_id)
+            domain = Domain.objects.get(id=domain_id)
+        except (Issue.DoesNotExist, Domain.DoesNotExist):
+            logger.warning("Stale session data: issue %s or domain %s no longer exists", issue_id, domain_id)
+            return
 
         issue.user = user
         issue.save()


### PR DESCRIPTION
## Summary\n\nThe `user_logged_in` signal handler `assign_issue_to_user` calls `Issue.objects.get(id=issue_id)` and `Domain.objects.get(id=domain_id)` using IDs stored in the session. If the issue or domain was deleted between session creation and login, these raise `DoesNotExist` and crash the entire login flow with a 500 error.\n\nThis is particularly dangerous because:\n- It runs as a signal handler on every login\n- A stale session (e.g. user bookmarked a login page days ago) can contain references to deleted objects\n- The crash happens after session data is already cleared, so the user gets stuck in a crash loop until the session expires\n\n## Changes\n- Wrap both `.objects.get()` calls in try/except for `DoesNotExist`\n- Log a warning with the stale IDs for debugging\n- Return early instead of crashing