### PR TITLE
fix(views): prevent ValueError crash on non-numeric pagination params

### DIFF
--- a/website/views/core.py
+++ b/website/views/core.py
@@ -2276,7 +2276,10 @@ def template_list(request):
     filter_by = request.GET.get("filter", "all")
     sort = request.GET.get("sort", "name")
     direction = request.GET.get("dir", "asc")
-    page = int(request.GET.get("page", 1))
+    try:
+        page = int(request.GET.get("page", 1))
+    except (ValueError, TypeError):
+        page = 1
     per_page = 20
 
     def extract_template_info(template_path):

--- a/website/views/organization.py
+++ b/website/views/organization.py
@@ -807,9 +807,15 @@ def load_more_issues(request):
     """
     AJAX handler for loading more GitHub issues with pagination support
     """
-    page = int(request.GET.get("page", 1))
+    try:
+        page = int(request.GET.get("page", 1))
+    except (ValueError, TypeError):
+        page = 1
     state = request.GET.get("state", "open")
-    per_page = int(request.GET.get("per_page", 10))
+    try:
+        per_page = int(request.GET.get("per_page", 10))
+    except (ValueError, TypeError):
+        per_page = 10
 
     # Validate inputs
     if page < 1:


### PR DESCRIPTION
## Summary\n\n`load_more_issues` in organization.py and the sitemap/template explorer in core.py use `int(request.GET.get(\"page\", 1))` without try/except. Passing `?page=abc` or `?per_page=xyz` in the URL causes a 500 crash with `ValueError`.\n\n## Changes\n- Wrap `int()` conversions in try/except for `ValueError` and `TypeError`\n- Fall back to safe defaults (page=1, per_page=10/20) on invalid input\n- Existing validation logic (page < 1, per_page bounds) remains unchanged