### PR TITLE
fix(views): prevent AttributeError from .get().replace() on None

### DIFF
--- a/website/views/issue.py
+++ b/website/views/issue.py
@@ -1007,7 +1007,7 @@ class IssueCreate(IssueBaseCreate, CreateView):
         return initial
 
     def post(self, request, *args, **kwargs):
-        url = request.POST.get("url").replace("www.", "").replace("https://", "")
+        url = (request.POST.get("url") or "").replace("www.", "").replace("https://", "")
 
         request.POST._mutable = True
         request.POST.update(url=url)
@@ -2279,7 +2279,7 @@ class GithubIssueView(TemplateView):
         title = request.POST.get("issue_title")
         description = request.POST.get("description")
 
-        repository = request.POST.get("repository_url").replace("https://github.com/", "").replace(".git", "")
+        repository = (request.POST.get("repository_url") or "").replace("https://github.com/", "").replace(".git", "")
         labels = request.POST.get("labels")
         labels_list = [label.strip() for label in labels.split(",")] if labels else []
         try:

--- a/website/views/organization.py
+++ b/website/views/organization.py
@@ -1211,9 +1211,10 @@ class HuntCreate(CreateView):
         self.object = form.save(commit=False)
         self.object.user = self.request.user
 
+        hunt_url = self.request.POST.get("url") or ""
         domain, created = Domain.objects.get_or_create(
-            name=self.request.POST.get("url").replace("www.", ""),
-            defaults={"url": "http://" + self.request.POST.get("url").replace("www.", "")},
+            name=hunt_url.replace("www.", ""),
+            defaults={"url": "http://" + hunt_url.replace("www.", "")},
         )
         self.object.domain = domain
 


### PR DESCRIPTION
## Summary\n\nThree views call `.replace()` directly on `request.POST.get()` results without a default value. When the POST key is missing, `.get()` returns `None`, and `None.replace()` raises `AttributeError` (500 crash):\n\n- `IssueBaseCreate.post()` (issue.py): `request.POST.get(\"url\").replace(\"www.\", \"\")`\n- `GithubIssueView.post()` (issue.py): `request.POST.get(\"repository_url\").replace(\"https://github.com/\", \"\")`\n- `HuntCreate.form_valid()` (organization.py): `self.request.POST.get(\"url\").replace(\"www.\", \"\")`\n\n## Changes\n- Use `(value or \"\")` pattern to safely default to empty string before calling `.replace()`\n- Extract repeated `self.request.POST.get(\"url\")` call in HuntCreate into a local variable to avoid double lookup