### PR TITLE
Fix: Flaky Docker Test

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,9 +36,9 @@ COPY pyproject.toml poetry.lock* ./
 RUN pip uninstall -y httpx || true
 RUN pip install --upgrade pip
 # Install dependencies with Poetry
-RUN poetry install --no-root --no-interaction -vvv || \
+RUN poetry install --no-root --no-interaction || \
     (echo "First attempt failed, clearing Poetry cache..." && \
-     poetry cache clear pypi --all && \
+     poetry cache clear pypi --all -n && \
      sleep 5 && \
      poetry install --no-root --no-interaction -vvv) || \
     (echo "Second attempt failed, final retry..." && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,8 +36,14 @@ COPY pyproject.toml poetry.lock* ./
 RUN pip uninstall -y httpx || true
 RUN pip install --upgrade pip
 # Install dependencies with Poetry
-RUN poetry install --no-root --no-interaction
-
+RUN poetry install --no-root --no-interaction -vvv || \
+    (echo "First attempt failed, clearing Poetry cache..." && \
+     poetry cache clear pypi --all && \
+     sleep 5 && \
+     poetry install --no-root --no-interaction -vvv) || \
+    (echo "Second attempt failed, final retry..." && \
+     sleep 10 && \
+     poetry install --no-root --no-interaction -vvv)
 # Install additional Python packages
 RUN pip install opentelemetry-api opentelemetry-instrumentation
 


### PR DESCRIPTION
```bash
#18 14.87   - Installing whitenoise (6.9.0)
#18 14.97   - Installing wsproto (1.2.0)
#18 15.00   - Installing yarl (1.18.3)
#18 ERROR: process "/bin/sh -c poetry install --no-root --no-interaction" did not complete successfully: exit code: 1
------
 > [builder 10/11] RUN poetry install --no-root --no-interaction:
14.64   - Installing uvicorn (0.34.0)
14.66   - Downgrading virtualenv (20.37.0 -> 20.36.1)
14.66   - Installing watchfiles (1.0.4)
14.76   - Installing webdriver-manager (4.0.2)
14.80   - Installing webencodings (0.5.1)
14.86   - Installing websocket-client (1.8.0)
14.87   - Installing websockets (15.0.1)
14.87   - Installing whitenoise (6.9.0)
14.97   - Installing wsproto (1.2.0)
15.00   - Installing yarl (1.18.3)
------
Dockerfile:39
--------------------
  37 |     RUN pip install --upgrade pip
  38 |     # Install dependencies with Poetry
  39 | >>> RUN poetry install --no-root --no-interaction
  40 |     
  41 |     # Install additional Python packages
--------------------
ERROR: failed to build: failed to solve: process "/bin/sh -c poetry install --no-root --no-interaction" did not complete successfully: exit code: 1
Error: Process completed with exit code 1.
```
Attempt to fix the flaky Docker test. 
Testing: Triggered the workflow 15 times with 0 Docker test failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved build dependency installation with automatic multi-stage retries, cache clearing on failure, verbose retry logging, and staggered retry delays — increases resilience to transient install failures, reduces build flakiness, and improves CI reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->