### PR TITLE
fix: migrate deprecated allauth account settings to ACCOUNT_SIGNUP_FIELDS

### DIFF
--- a/blt/settings.py
+++ b/blt/settings.py
@@ -368,8 +368,7 @@ else:
             "NAME": ":memory:",
         }
 
-ACCOUNT_EMAIL_REQUIRED = True
-ACCOUNT_USERNAME_REQUIRED = True
+ACCOUNT_SIGNUP_FIELDS = ["email*", "username*", "password1*", "password2*"]
 ACCOUNT_EMAIL_VERIFICATION = "mandatory"
 ACCOUNT_FORMS = {"signup": "website.forms.SignupFormWithCaptcha"}
 # Security: Do not send emails to unknown accounts during password reset


### PR DESCRIPTION
## Summary
Migrates deprecated django-allauth settings to the new 
`ACCOUNT_SIGNUP_FIELDS` format introduced in allauth 0.61.0.

## Problem
Running `python manage.py check` shows deprecation warnings:
```
?: settings.ACCOUNT_EMAIL_REQUIRED is deprecated
?: settings.ACCOUNT_USERNAME_REQUIRED is deprecated
```

## Solution
Replaced the deprecated individual settings:
```python
ACCOUNT_EMAIL_REQUIRED = True
ACCOUNT_USERNAME_REQUIRED = True
```

With the new unified setting:
```python
ACCOUNT_SIGNUP_FIELDS = ["email*", "username*", "password1*", "password2*"]
```

The `*` suffix indicates required fields, maintaining identical behavior.

## Testing
- `python manage.py check` — deprecation warnings resolved (0 issues vs 9 before)
- Signup form still requires both email and username

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined account signup field configuration by consolidating settings into a unified field list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->