### PR TITLE
feat: add management command to delete unverified users

### DIFF
--- a/website/management/commands/delete_unverified_users.py
+++ b/website/management/commands/delete_unverified_users.py
@@ -1,0 +1,60 @@
+from datetime import timedelta
+
+from django.contrib.auth.models import User
+from django.core.management.base import BaseCommand
+from django.utils import timezone
+
+
+class Command(BaseCommand):
+    help = "Delete user accounts that have not verified their email address within the specified period"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--days",
+            type=int,
+            default=30,
+            help="Delete unverified users older than this many days (default: 30)",
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Show what would be deleted without actually deleting",
+        )
+
+    def handle(self, *_, **options):
+        days = options["days"]
+        dry_run = options["dry_run"]
+        cutoff_date = timezone.now() - timedelta(days=days)
+
+        # Find users who joined before the cutoff and have no verified email.
+        # Uses django-allauth's EmailAddress model via reverse relation.
+        # Staff and superusers are always preserved as a safety measure.
+        unverified_users = User.objects.filter(
+            date_joined__lt=cutoff_date,
+            is_staff=False,
+            is_superuser=False,
+        ).exclude(
+            emailaddress__verified=True,
+        )
+
+        count = unverified_users.count()
+
+        if dry_run:
+            self.stdout.write(
+                self.style.WARNING(
+                    f"DRY RUN: Would delete {count} unverified users who joined more than {days} days ago"
+                )
+            )
+            if count > 0:
+                self.stdout.write("Users that would be deleted:")
+                for user in unverified_users[:10]:
+                    self.stdout.write(f"  - {user.username} (joined: {user.date_joined})")
+                if count > 10:
+                    self.stdout.write(f"  ... and {count - 10} more")
+        else:
+            unverified_users.delete()
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"Successfully deleted {count} unverified users who joined more than {days} days ago"
+                )
+            )

--- a/website/tests/test_delete_unverified_users.py
+++ b/website/tests/test_delete_unverified_users.py
@@ -1,0 +1,131 @@
+from datetime import timedelta
+from io import StringIO
+
+from allauth.account.models import EmailAddress
+from django.contrib.auth.models import User
+from django.core.management import call_command
+from django.test import TestCase
+from django.utils import timezone
+
+
+class DeleteUnverifiedUsersCommandTest(TestCase):
+    def setUp(self):
+        old_date = timezone.now() - timedelta(days=60)
+
+        # Old unverified user (should be deleted with default 30-day threshold)
+        self.old_unverified = User.objects.create_user(
+            username="old_unverified", email="old@example.com", password="testpass"
+        )
+        self.old_unverified.date_joined = old_date
+        self.old_unverified.save(update_fields=["date_joined"])
+        EmailAddress.objects.create(user=self.old_unverified, email="old@example.com", verified=False, primary=True)
+
+        # Old verified user (should NOT be deleted)
+        self.old_verified = User.objects.create_user(
+            username="old_verified", email="verified@example.com", password="testpass"
+        )
+        self.old_verified.date_joined = old_date
+        self.old_verified.save(update_fields=["date_joined"])
+        EmailAddress.objects.create(
+            user=self.old_verified, email="verified@example.com", verified=True, primary=True
+        )
+
+        # Recent unverified user (should NOT be deleted -- not past cutoff)
+        self.recent_unverified = User.objects.create_user(
+            username="recent_unverified", email="recent@example.com", password="testpass"
+        )
+        EmailAddress.objects.create(
+            user=self.recent_unverified, email="recent@example.com", verified=False, primary=True
+        )
+
+        # Staff user with unverified email (should NOT be deleted)
+        self.staff_user = User.objects.create_user(
+            username="staff_user", email="staff@example.com", password="testpass", is_staff=True
+        )
+        self.staff_user.date_joined = old_date
+        self.staff_user.save(update_fields=["date_joined"])
+        EmailAddress.objects.create(user=self.staff_user, email="staff@example.com", verified=False, primary=True)
+
+        # Superuser with unverified email (should NOT be deleted)
+        self.superuser = User.objects.create_superuser(
+            username="admin_user", email="admin@example.com", password="testpass"
+        )
+        self.superuser.date_joined = old_date
+        self.superuser.save(update_fields=["date_joined"])
+        EmailAddress.objects.create(user=self.superuser, email="admin@example.com", verified=False, primary=True)
+
+    def test_deletes_old_unverified_users(self):
+        """Should delete users with unverified email who joined before the cutoff."""
+        call_command("delete_unverified_users")
+        self.assertFalse(User.objects.filter(username="old_unverified").exists())
+
+    def test_preserves_verified_users(self):
+        """Should preserve users who have a verified email address."""
+        call_command("delete_unverified_users")
+        self.assertTrue(User.objects.filter(username="old_verified").exists())
+
+    def test_preserves_recent_unverified_users(self):
+        """Should preserve unverified users who joined within the cutoff period."""
+        call_command("delete_unverified_users")
+        self.assertTrue(User.objects.filter(username="recent_unverified").exists())
+
+    def test_preserves_staff_users(self):
+        """Should never delete staff users regardless of verification status."""
+        call_command("delete_unverified_users")
+        self.assertTrue(User.objects.filter(username="staff_user").exists())
+
+    def test_preserves_superusers(self):
+        """Should never delete superusers regardless of verification status."""
+        call_command("delete_unverified_users")
+        self.assertTrue(User.objects.filter(username="admin_user").exists())
+
+    def test_dry_run_does_not_delete(self):
+        """Dry run should report candidates without actually deleting them."""
+        out = StringIO()
+        call_command("delete_unverified_users", dry_run=True, stdout=out)
+        self.assertTrue(User.objects.filter(username="old_unverified").exists())
+        self.assertIn("DRY RUN", out.getvalue())
+
+    def test_custom_days_argument(self):
+        """Should respect the --days argument for cutoff calculation."""
+        call_command("delete_unverified_users", days=90)
+        # 60-day-old user should NOT be deleted with 90-day threshold
+        self.assertTrue(User.objects.filter(username="old_unverified").exists())
+
+    def test_deletes_users_with_no_email_record(self):
+        """Users with no EmailAddress record have no verified email and should be deleted."""
+        old_date = timezone.now() - timedelta(days=60)
+        no_email = User.objects.create_user(username="no_email_record", password="testpass")
+        no_email.date_joined = old_date
+        no_email.save(update_fields=["date_joined"])
+
+        call_command("delete_unverified_users")
+        self.assertFalse(User.objects.filter(username="no_email_record").exists())
+
+    def test_preserves_user_with_at_least_one_verified_email(self):
+        """User with multiple emails where at least one is verified should be preserved."""
+        old_date = timezone.now() - timedelta(days=60)
+        multi_email = User.objects.create_user(
+            username="multi_email", email="primary@example.com", password="testpass"
+        )
+        multi_email.date_joined = old_date
+        multi_email.save(update_fields=["date_joined"])
+        EmailAddress.objects.create(user=multi_email, email="primary@example.com", verified=False, primary=True)
+        EmailAddress.objects.create(user=multi_email, email="secondary@example.com", verified=True, primary=False)
+
+        call_command("delete_unverified_users")
+        self.assertTrue(User.objects.filter(username="multi_email").exists())
+
+    def test_output_message_on_success(self):
+        """Should print a success message with the count of deleted users."""
+        out = StringIO()
+        call_command("delete_unverified_users", stdout=out)
+        output = out.getvalue()
+        self.assertIn("Successfully deleted", output)
+        self.assertIn("1 unverified users", output)
+
+    def test_dry_run_shows_usernames(self):
+        """Dry run should list usernames of users that would be deleted."""
+        out = StringIO()
+        call_command("delete_unverified_users", dry_run=True, stdout=out)
+        self.assertIn("old_unverified", out.getvalue())


### PR DESCRIPTION
## Summary\n\nCloses #3387\n\nAdds a `delete_unverified_users` Django management command that removes user accounts which have not verified their email address (via django-allauth's `EmailAddress` model) within a configurable time period.\n\n## Changes\n\n### New: `website/management/commands/delete_unverified_users.py`\n\n- Queries users who joined before a cutoff date and have **no verified email** in allauth's `EmailAddress` table\n- `--days` flag to configure the cutoff threshold (default: 30 days)\n- `--dry-run` flag to preview which users would be deleted without executing\n- **Safety**: staff and superuser accounts are always excluded from deletion\n- Handles edge cases: users with no `EmailAddress` record at all, users with multiple email addresses where at least one is verified\n\n### New: `website/tests/test_delete_unverified_users.py`\n\n11 test cases covering:\n- Deletes old unverified users past the cutoff\n- Preserves verified users\n- Preserves recent (within cutoff) unverified users\n- Preserves staff users\n- Preserves superusers\n- Dry run does not delete\n- Custom `--days` argument works correctly\n- Users with no `EmailAddress` record are treated as unverified\n- Users with at least one verified email among multiple are preserved\n- Success output message\n- Dry run output shows usernames\n\n### Modified: `website/management/commands/run_weekly.py`\n\n- Registered `delete_unverified_users` in the weekly scheduler with `days=30`\n\n## Usage\n\n```bash\n# Preview what would be deleted\npython manage.py delete_unverified_users --dry-run\n\n# Delete unverified users older than 30 days (default)\npython manage.py delete_unverified_users\n\n# Delete unverified users older than 60 days\npython manage.py delete_unverified_users --days 60\n```\n\n## Design Decisions\n\n- Uses `BaseCommand` (matching `cleanup_sample_invites.py` pattern)\n- Queries via `.exclude(emailaddress__verified=True)` to catch both unverified emails and missing `EmailAddress` records\n- Staff/superuser exclusion is a hard safety check, not configurable\n- Follows the existing cleanup command patterns in the codebase"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automated cleanup for unverified user accounts older than a configurable threshold (default 30 days), with a preview mode to review changes before execution.
  * Enhanced weekly maintenance task tracking with detailed per-task success/failure reporting and aggregated summary logging.

* **Tests**
  * Added comprehensive test coverage for the account cleanup feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->