### PR TITLE
fix: replace bare except clauses with specific exceptions

### DIFF
--- a/website/api/views.py
+++ b/website/api/views.py
@@ -391,7 +391,7 @@ class LeaderboardApiViewSet(APIView):
 
             try:
                 date = datetime(int(year), int(month), 1)
-            except:
+            except (ValueError, OverflowError):
                 return Response("Invalid month or year passed", status=400)
 
         queryset = global_leaderboard.get_leaderboard(month, year, api=True)

--- a/website/consumers.py
+++ b/website/consumers.py
@@ -349,16 +349,16 @@ class ChatConsumer(AsyncWebsocketConsumer):
                 await self.send(
                     text_data=json.dumps({"type": "connection_status", "status": "disconnected", "code": close_code})
                 )
-            except:
+            except Exception:
                 pass
-        except:
+        except Exception:
             pass
 
     @database_sync_to_async
     def check_room_exists(self):
         try:
             return Room.objects.filter(id=self.room_id).exists()
-        except:
+        except Exception:
             return False
 
     @database_sync_to_async


### PR DESCRIPTION
## Summary
Replaces bare `except:` clauses with specific exception types to 
improve error handling and code quality.

## Problem
Bare `except:` clauses catch **all** exceptions, including 
`SystemExit`, `KeyboardInterrupt`, and `GeneratorExit`. This is a 
well-known Python anti-pattern that:
- Hides real bugs and makes debugging difficult
- Can prevent proper program termination
- Violates PEP 8 guidelines

Found 4 instances across 2 files:
- `website/api/views.py` (line 394)
- `website/consumers.py` (lines 352, 354, 361)

## Solution

**`website/api/views.py`** — Date parsing:
```python
# Before
except:
    return Response("Invalid month or year passed", status=400)

# After  
except (ValueError, OverflowError):
    return Response("Invalid month or year passed", status=400)
```

**`website/consumers.py`** — WebSocket operations:
```python
# Before
except:
    pass

# After
except Exception:
    pass
```

## Why These Specific Exceptions?
- `ValueError`/`OverflowError`: The only exceptions `datetime()` 
  constructor raises for invalid input
- `Exception`: Base class that excludes `SystemExit`, 
  `KeyboardInterrupt`, and `GeneratorExit` — appropriate for 
  WebSocket error handling where we want to catch operational 
  errors but not system-level signals

## Testing
- `python manage.py check` passes
- No behavioral changes — same error handling logic, just more 
  precise exception catching

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved error handling practices across core modules for enhanced code reliability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->