### PR TITLE
Fix Duplicate quality tags

### DIFF
--- a/.github/workflows/manage_quality_labels.yml
+++ b/.github/workflows/manage_quality_labels.yml
@@ -1,8 +1,6 @@
 name: Manage Quality Labels
 
 on:
-  issues:
-    types: [labeled]
   pull_request_target:
     types: [labeled]
 
@@ -14,6 +12,9 @@ permissions:
 jobs:
   manage_quality_labels:
     runs-on: ubuntu-latest
+    concurrency:
+      group: quality-labels-${{ github.event.issue.number || github.event.pull_request.number }}
+      cancel-in-progress: false
     steps:
       - name: Remove Conflicting Quality Labels
         uses: actions/github-script@v7

--- a/.github/workflows/manage_quality_labels.yml
+++ b/.github/workflows/manage_quality_labels.yml
@@ -1,0 +1,89 @@
+name: Manage Quality Labels (Reusable)
+
+on:
+  workflow_call:
+    inputs:
+      quality_labels:
+        description: 'Array of quality label names'
+        required: false
+        type: string
+        default: '["quality: high", "quality: medium", "quality: low"]'
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  manage_quality_labels:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove Conflicting Quality Labels
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            let itemNumber;
+            let itemType;
+            
+            if (context.payload.pull_request) {
+              itemNumber = context.payload.pull_request.number;
+              itemType = 'PR';
+            } else if (context.payload.issue) {
+              itemNumber = context.payload.issue.number;
+              itemType = context.payload.issue.pull_request ? 'PR' : 'Issue';
+            } else {
+              core.info('No pull_request or issue in context. Skipping.');
+              return;
+            }
+
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            
+            const qualityLabels = JSON.parse('${{ inputs.quality_labels }}');
+            const newLabel = context.payload.label.name;
+            
+            if (!qualityLabels.includes(newLabel)) {
+              core.info(`Label "${newLabel}" is not a quality label. Skipping.`);
+              return;
+            }
+            
+            core.info(`Quality label "${newLabel}" added to ${itemType} #${itemNumber}`);
+            core.info('Checking for conflicting quality labels to remove...');
+
+            const { data: current } = await github.rest.issues.listLabelsOnIssue({ 
+              owner, 
+              repo, 
+              issue_number: itemNumber, 
+              per_page: 100 
+            });
+            
+            const conflictingLabels = current
+              .map(l => l.name)
+              .filter(name => qualityLabels.includes(name) && name !== newLabel);
+            
+            if (conflictingLabels.length === 0) {
+              core.info('No conflicting quality labels found.');
+              return;
+            }
+            
+            let removedCount = 0;
+            for (const labelName of conflictingLabels) {
+              try {
+                await github.rest.issues.removeLabel({ 
+                  owner, 
+                  repo, 
+                  issue_number: itemNumber, 
+                  name: labelName
+                });
+                core.info(`  Removed label: ${labelName}`);
+                removedCount++;
+              } catch (err) {
+                if (err.status !== 404) {
+                  core.warning(`  Failed to remove label ${labelName}: ${err.message}`);
+                }
+              }
+            }
+            
+            core.info(`✅ Successfully removed ${removedCount} conflicting quality label(s) from ${itemType} #${itemNumber}`);
+            core.info(`Active quality label: ${newLabel}`);

--- a/.github/workflows/manage_quality_labels.yml
+++ b/.github/workflows/manage_quality_labels.yml
@@ -1,6 +1,8 @@
 name: Manage Quality Labels
 
 on:
+  issues:
+    types: [labeled]
   pull_request_target:
     types: [labeled]
 

--- a/.github/workflows/manage_quality_labels.yml
+++ b/.github/workflows/manage_quality_labels.yml
@@ -5,7 +5,6 @@ on:
     types: [labeled]
 
 permissions:
-  contents: read
   pull-requests: write
   issues: write
 
@@ -27,9 +26,6 @@ jobs:
             if (context.payload.pull_request) {
               itemNumber = context.payload.pull_request.number;
               itemType = 'PR';
-            } else if (context.payload.issue) {
-              itemNumber = context.payload.issue.number;
-              itemType = context.payload.issue.pull_request ? 'PR' : 'Issue';
             } else {
               core.info('No pull_request or issue in context. Skipping.');
               return;

--- a/.github/workflows/manage_quality_labels.yml
+++ b/.github/workflows/manage_quality_labels.yml
@@ -1,13 +1,8 @@
-name: Manage Quality Labels (Reusable)
+name: Manage Quality Labels
 
 on:
-  workflow_call:
-    inputs:
-      quality_labels:
-        description: 'Array of quality label names'
-        required: false
-        type: string
-        default: '["quality: high", "quality: medium", "quality: low"]'
+  pull_request_target:
+    types: [labeled]
 
 permissions:
   contents: read
@@ -40,7 +35,9 @@ jobs:
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             
-            const qualityLabels = JSON.parse('${{ inputs.quality_labels }}');
+            // Define quality labels (note: using "quality: " prefix based on your repo's label format)
+            const qualityLabels = ['quality: high', 'quality: medium', 'quality: low'];
+            
             const newLabel = context.payload.label.name;
             
             if (!qualityLabels.includes(newLabel)) {


### PR DESCRIPTION
Fixes #5533  

CodeRabbit does NOT support mutually exclusive labels, When CodeRabbit adds a new quality label, it won't remove the previous ones. So this workflow will automatically remove old quality labels whenever a new one is added (whether by CodeRabbit, manually, or any other method).

Tested the workflow on the fork locally.
Screenshots:-
<img width="634" height="159" alt="Screenshot 2026-02-17 191036" src="https://github.com/user-attachments/assets/32b7ef5f-c87a-4cfa-87b8-e3bd6f2513ab" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * New automated workflow enforces quality labels on pull requests and issues: when a quality label (quality: high / medium / low) is added, any conflicting quality labels are automatically removed so only one quality label remains; actions are logged for traceability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->