### PR TITLE
fix: restrict access to hidden issues in IssueView

### DIFF
--- a/website/views/issue.py
+++ b/website/views/issue.py
@@ -2044,39 +2044,57 @@ class IssueView(DetailView):
     template_name = "issue.html"
 
     def get(self, request, *args, **kwargs):
-        ipdetails = IP()
         try:
-            id = int(self.kwargs["slug"])
+            issue_id = int(self.kwargs["slug"])
         except ValueError:
             return HttpResponseNotFound("Invalid ID: ID must be an integer")
 
-        self.object = get_object_or_404(Issue, id=self.kwargs["slug"])
-        ipdetails.user = self.request.user.username if self.request.user.is_authenticated else None
+        self.object = get_object_or_404(Issue, id=issue_id)
+
+        # 🔒 Private / hidden issue protection
+        if self.object.is_hidden:
+            if not request.user.is_authenticated:
+                raise Http404("Issue not found")
+
+            allowed = (
+                request.user.is_superuser
+                or request.user == self.object.user
+                or request.user.is_staff
+            )
+
+            if not allowed:
+                raise Http404("Issue not found")
+
+        # ✅ Only reach here if allowed
+        ipdetails = IP()
+        ipdetails.user = request.user.username if request.user.is_authenticated else None
         ipdetails.address = get_client_ip(request)
         ipdetails.issuenumber = self.object.id
         ipdetails.path = request.path
-        ipdetails.agent = request.META["HTTP_USER_AGENT"]
-        ipdetails.referer = request.META.get("HTTP_REFERER", None)
+        ipdetails.agent = request.META.get("HTTP_USER_AGENT")
+        ipdetails.referer = request.META.get("HTTP_REFERER")
 
         try:
-            if self.request.user.is_authenticated:
-                # Check if IP record already exists for this authenticated user and issue
-                if not IP.objects.filter(user=self.request.user.username, issuenumber=self.object.id).exists():
-                    # First time this user is viewing this issue
+            if request.user.is_authenticated:
+                if not IP.objects.filter(
+                    user=request.user.username,
+                    issuenumber=self.object.id
+                ).exists():
                     ipdetails.save()
                     self.object.views = (self.object.views or 0) + 1
                     self.object.save()
             else:
-                # Check if IP record already exists for this address and issue
-                if not IP.objects.filter(address=get_client_ip(request), issuenumber=self.object.id).exists():
-                    # First time this IP is viewing this issue
+                if not IP.objects.filter(
+                    address=get_client_ip(request),
+                    issuenumber=self.object.id
+                ).exists():
                     ipdetails.save()
                     self.object.views = (self.object.views or 0) + 1
                     self.object.save()
         except Exception as e:
             logger.error(f"Error tracking IP view for issue {self.object.id}: {e}")
-            pass  # Continue loading the page even if view tracking fails
-        return super(IssueView, self).get(request, *args, **kwargs)
+
+        return super().get(request, *args, **kwargs)
 
     def get_context_data(self, **kwargs):
         context = super(IssueView, self).get_context_data(**kwargs)

--- a/website/views/issue.py
+++ b/website/views/issue.py
@@ -2081,8 +2081,9 @@ class IssueView(DetailView):
                     ipdetails.save()
                     self.object.views = (self.object.views or 0) + 1
                     self.object.save()
-        except Exception as e:
-            logger.error(f"Error tracking IP view for issue {self.object.id}: {e}")
+        except Exception:
+            logger.exception("Error tracking IP view for issue %s", self.object.id)
+
 
         return super().get(request, *args, **kwargs)
 

--- a/website/views/issue.py
+++ b/website/views/issue.py
@@ -2056,11 +2056,7 @@ class IssueView(DetailView):
             if not request.user.is_authenticated:
                 raise Http404("Issue not found")
 
-            allowed = (
-                request.user.is_superuser
-                or request.user == self.object.user
-                or request.user.is_staff
-            )
+            allowed = request.user.is_superuser or request.user == self.object.user or request.user.is_staff
 
             if not allowed:
                 raise Http404("Issue not found")
@@ -2076,18 +2072,12 @@ class IssueView(DetailView):
 
         try:
             if request.user.is_authenticated:
-                if not IP.objects.filter(
-                    user=request.user.username,
-                    issuenumber=self.object.id
-                ).exists():
+                if not IP.objects.filter(user=request.user.username, issuenumber=self.object.id).exists():
                     ipdetails.save()
                     self.object.views = (self.object.views or 0) + 1
                     self.object.save()
             else:
-                if not IP.objects.filter(
-                    address=get_client_ip(request),
-                    issuenumber=self.object.id
-                ).exists():
+                if not IP.objects.filter(address=get_client_ip(request), issuenumber=self.object.id).exists():
                     ipdetails.save()
                     self.object.views = (self.object.views or 0) + 1
                     self.object.save()

--- a/website/views/issue.py
+++ b/website/views/issue.py
@@ -2084,7 +2084,6 @@ class IssueView(DetailView):
         except Exception:
             logger.exception("Error tracking IP view for issue %s", self.object.id)
 
-
         return super().get(request, *args, **kwargs)
 
     def get_context_data(self, **kwargs):


### PR DESCRIPTION
This PR adds proper access control for hidden issues in IssueView. Previously, a hidden issue could still be accessed directly via its URL if someone knew the ID. With this change, hidden issues now return a 404 for unauthenticated users, and only the issue owner, staff, or superusers are allowed to view them. This ensures private or moderation-pending reports are not exposed unintentionally while keeping the behavior consistent with how hidden issues are treated in list and search views.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid issue identifiers now return 404.
  * Enforced access control for private/hidden issues so only authorized users can view them; unauthorized requests return not-found.
  * Visitor-tracking errors are logged and no longer interrupt page loads.
  * View counts now distinguish authenticated vs anonymous visits more reliably; request-derived info is captured more safely.

* **Refactor**
  * Visibility checks run before ancillary processing; visitor tracking is deferred until access is confirmed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->