### PR TITLE
fix(comments): replace bare except to prevent swallowing system exits

### DIFF
--- a/comments/views.py
+++ b/comments/views.py
@@ -85,7 +85,7 @@ def delete_comment(request):
         comment = Comment.objects.get(pk=int(request.POST["comment_pk"]))
         try:
             show = comment.parent.pk
-        except:
+        except Exception as e:
             show = -1
         if request.user.username != comment.author:
             return HttpResponse("Cannot delete this comment")


### PR DESCRIPTION
Replaced a bare except: clause with except Exception as e: to comply with PEP 8 and ensure system-level exceptions (like KeyboardInterrupt) are not accidentally swallowed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved error handling robustness in the comments functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->