### PR TITLE
fix: remove Jigyasu Rajput from GSoC 2026 mentors list

### DIFF
--- a/website/templates/gsoc.html
+++ b/website/templates/gsoc.html
@@ -846,31 +846,6 @@
                             </div>
                         </div>
                         <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-                            <!-- Jigyasu Rajput -->
-                            <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4 border border-gray-200 dark:border-gray-700">
-                                <div class="flex items-center gap-3 mb-3">
-                                    <div class="w-10 h-10 bg-red-100 rounded-full flex items-center justify-center">
-                                        <i class="fas fa-code text-[#e74c3c] text-sm"></i>
-                                    </div>
-                                    <div>
-                                        <h4 class="text-lg font-bold text-gray-900 dark:text-gray-100">Jigyasu Rajput</h4>
-                                        <p class="text-sm text-gray-600 dark:text-gray-400">Full Stack Development</p>
-                                    </div>
-                                </div>
-                                <div class="mentor-description-container">
-                                    <p class="text-gray-600 dark:text-gray-400 text-base leading-relaxed mentor-description-text">
-                                        I'm a full-stack developer with prior GSoC experience and a
-                                        deep love for open source. Having been a contributor myself, I
-                                        know how overwhelming it can feel at the start — from
-                                        understanding huge codebases to shipping your first meaningful
-                                        PR. As a mentor, I focus on helping people build confidence
-                                        through clean practices, thoughtful code reviews, and
-                                        real-world problem solving. I stay active in open source
-                                        because collaboration and shared learning are what actually
-                                        move great software forward.
-                                    </p>
-                                </div>
-                            </div>
                             <!-- Rishab Kumar Jha -->
                             <div class="bg-gray-50 dark:bg-gray-900 rounded-lg p-4 border border-gray-200 dark:border-gray-700">
                                 <div class="flex items-center gap-3 mb-3">


### PR DESCRIPTION
This pull request removes the mentor profile for Jigyasu Rajput from the GSoC mentors section on the website. No other changes are included.

* Removed the entire mentor profile block for Jigyasu Rajput from the `website/templates/gsoc.html` file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the 2026 Contributors mentor grid by removing a mentor entry from the display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->