### PR TITLE
fix(org): restrict access to inactive organizations in OrganizationDetailView

### DIFF
--- a/website/tests/test_organization.py
+++ b/website/tests/test_organization.py
@@ -262,3 +262,73 @@ class SizzleCheckInViewTests(TestCase):
         self.assertContains(response, "Last check-in was on")
         self.assertContains(response, "Fill from Last Check-in")
         self.assertContains(response, "fillFromLastCheckinBtn")
+        
+        
+class OrganizationDetailViewAccessTests(TestCase):
+    def setUp(self):
+        self.client = Client()
+
+        # Users
+        self.regular_user = User.objects.create_user(
+            username="regular", password="pass123"
+        )
+
+        self.superuser = User.objects.create_superuser(
+            username="super", email="super@test.com", password="pass123"
+        )
+
+        # Inactive organization
+        self.inactive_org = Organization.objects.create(
+            name="Inactive Org",
+            slug="inactive-org",
+            description="Inactive",
+            url="https://inactive.example.com",
+            is_active=False,
+        )
+
+        self.active_org = Organization.objects.create(
+            name="Active Org",
+            slug="active-org",
+            description="Active",
+            url="https://active.example.com",
+            is_active=True,
+        )
+
+    def test_anonymous_user_cannot_access_inactive_org(self):
+        url = reverse("organization_detail", kwargs={"slug": self.inactive_org.slug})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 404)
+
+    def test_regular_user_cannot_access_inactive_org(self):
+        self.client.login(username="regular", password="pass123")
+        url = reverse("organization_detail", kwargs={"slug": self.inactive_org.slug})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 404)
+
+    def test_superuser_can_access_inactive_org(self):
+        self.client.login(username="super", password="pass123")
+        url = reverse("organization_detail", kwargs={"slug": self.inactive_org.slug})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_admin_can_access_their_inactive_org(self):
+        self.inactive_org.admin = self.regular_user
+        self.inactive_org.save()
+
+        self.client.login(username="regular", password="pass123")
+        url = reverse("organization_detail", kwargs={"slug": self.inactive_org.slug})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_manager_can_access_their_inactive_org(self):
+        self.inactive_org.managers.add(self.regular_user)
+
+        self.client.login(username="regular", password="pass123")
+        url = reverse("organization_detail", kwargs={"slug": self.inactive_org.slug})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_active_org_accessible_to_all(self):
+        url = reverse("organization_detail", kwargs={"slug": self.active_org.slug})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)

--- a/website/tests/test_organization.py
+++ b/website/tests/test_organization.py
@@ -262,20 +262,16 @@ class SizzleCheckInViewTests(TestCase):
         self.assertContains(response, "Last check-in was on")
         self.assertContains(response, "Fill from Last Check-in")
         self.assertContains(response, "fillFromLastCheckinBtn")
-        
-        
+
+
 class OrganizationDetailViewAccessTests(TestCase):
     def setUp(self):
         self.client = Client()
 
         # Users
-        self.regular_user = User.objects.create_user(
-            username="regular", password="pass123"
-        )
+        self.regular_user = User.objects.create_user(username="regular", password="pass123")
 
-        self.superuser = User.objects.create_superuser(
-            username="super", email="super@test.com", password="pass123"
-        )
+        self.superuser = User.objects.create_superuser(username="super", email="super@test.com", password="pass123")
 
         # Inactive organization
         self.inactive_org = Organization.objects.create(

--- a/website/views/organization.py
+++ b/website/views/organization.py
@@ -2479,13 +2479,7 @@ class OrganizationDetailView(DetailView):
         if not obj.is_active:
             user = self.request.user
 
-            allowed = (
-                user.is_authenticated and (
-                    user.is_superuser
-                    or obj.is_admin(user)
-                    or obj.is_manager(user)
-                )
-            )
+            allowed = user.is_authenticated and (user.is_superuser or obj.is_admin(user) or obj.is_manager(user))
 
             if not allowed:
                 raise Http404("Organization not found")

--- a/website/views/organization.py
+++ b/website/views/organization.py
@@ -2472,6 +2472,26 @@ class OrganizationDetailView(DetailView):
             )
         )
 
+    def get_object(self, queryset=None):
+        obj = super().get_object(queryset)
+
+        # 🔒 Restrict access to inactive organizations
+        if not obj.is_active:
+            user = self.request.user
+
+            allowed = (
+                user.is_authenticated and (
+                    user.is_superuser
+                    or obj.is_admin(user)
+                    or obj.is_manager(user)
+                )
+            )
+
+            if not allowed:
+                raise Http404("Organization not found")
+
+        return obj
+
     def get_leaderboard_data(self, organization):
         """
         Get leaderboard data for all organization repositories.


### PR DESCRIPTION
## Summary

This PR adds access control for inactive organizations in `OrganizationDetailView`.

Previously, inactive organizations could still be accessed directly via their URL. With this change:

- Inactive organizations return 404 for unauthorized users.
- Access is allowed only for:
  - Superusers
  - Organization admin
  - Organization managers

This ensures inactive organizations are not publicly accessible while preserving intended access for authorized users.

## Technical Details

- Override `get_object()` in `OrganizationDetailView`
- Perform permission check after fetching object
- Return `Http404` for unauthorized access

## Testing

- Full test suite executed locally (313 tests)
- All tests passed successfully
- No regressions introduced

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inactive organizations are now restricted—only superusers and organization admins/managers can view them.
  * Active organizations remain accessible to all users.

* **Tests**
  * Added comprehensive test coverage for organization access control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->