### PR TITLE
Fixed contributor card in gsoc page

### DIFF
--- a/website/templates/gsoc.html
+++ b/website/templates/gsoc.html
@@ -1037,22 +1037,12 @@
                                         <p class="text-sm text-gray-600 dark:text-gray-400">React/OAuth/REST API</p>
                                     </div>
                                 </div>
-                                <div>
-                                    <h3 class="text-2xl font-bold text-gray-900 dark:text-gray-100">Rinkit Adhana</h3>
-                                    <span class="text-sm font-medium text-gray-500 dark:text-gray-500 bg-gray-100 dark:bg-gray-800 px-3 py-1 rounded-full">Full Stack Development mentor</span>
+                                <div class="mentor-description-container">
+                                    <p class="text-gray-600 dark:text-gray-400 text-base leading-relaxed mentor-description-text">
+                                        Mentors teams on building secure React apps with real-world OAuth flows and robust REST APIs.
+                                    </p>
                                 </div>
                             </div>
-                            <p class="text-gray-700 dark:text-gray-300 leading-relaxed mb-6">
-                                As a full stack engineer and active BLT contributor, I bring
-                                hands-on experience from both sides of the development process.
-                                Having participated in GSoC 2025, I understand the challenges new
-                                contributors face and can guide you through your open source
-                                journey. I specialize in helping developers build scalable web
-                                applications, navigate complex codebases, and contribute
-                                effectively to real-world projects. My goal is to share practical
-                                knowledge and help you grow as a developer while making meaningful
-                                contributions to BLT.
-                            </p>
                         </div>
                     </div>
                     <!-- Manahil Afzal -->


### PR DESCRIPTION
Some contributor might have mistakenly changed my card while adding theirs, so adding a fix for it.

Before:-
<img width="1467" height="588" alt="Screenshot 2026-02-25 101944" src="https://github.com/user-attachments/assets/5f99987f-05f8-4372-8554-afd00a0df5f1" />


After:-
<img width="1479" height="397" alt="Screenshot 2026-02-25 102439" src="https://github.com/user-attachments/assets/6b86bf9d-4f9a-47cd-b2e8-e65105bea213" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Simplified a GSoC mentor entry: removed the separate name header and role badge, replacing the long biography with a single concise mentor description.
  * Updated mentor presentation for a cleaner, more uniform listing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->