### PR TITLE
docs: fix broken markdown formatting in uv setup section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,11 +140,14 @@ From the project root, run:
 
 ```bash
 uv sync
+```
 
 To start the development server:
 
+```bash
 uv run python manage.py migrate
 uv run python manage.py runserver
+```
 
 Open your browser at:
 http://localhost:8000


### PR DESCRIPTION
This PR fixes broken markdown formatting in the uv setup section of CONTRIBUTING.md.

The bash code block was not properly closed, which caused rendering issues in the documentation. This change improves readability and clarity for contributors setting up the project using uv.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Python Virtual Environment Setup instructions with additional uv-based commands for database migration and local server configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->