### PR TITLE
feat: add safe delete_unverified_users management command with tests

### DIFF
--- a/website/management/commands/delete_unverified_users.py
+++ b/website/management/commands/delete_unverified_users.py
@@ -1,0 +1,94 @@
+from datetime import timedelta
+
+from allauth.account.models import EmailAddress
+from django.contrib.auth import get_user_model
+from django.utils import timezone
+
+from website.management.base import LoggedBaseCommand
+
+
+class Command(LoggedBaseCommand):
+    help = "List or delete users who have no verified email and are older than a threshold"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--days",
+            type=int,
+            default=30,
+            help="Minimum account age in days before a user is considered for deletion (default: 30)",
+        )
+        parser.add_argument(
+            "--limit",
+            type=int,
+            default=0,
+            help="Maximum number of users to process (default: 0 = no limit)",
+        )
+        parser.add_argument(
+            "--execute",
+            action="store_true",
+            help="Actually delete users. Without this flag, command runs in dry-run mode.",
+        )
+        parser.add_argument(
+            "--include-staff",
+            action="store_true",
+            help="Include staff users in results (excluded by default).",
+        )
+
+    def handle(self, *_args, **options):
+        days = options["days"]
+        limit = options["limit"]
+        execute = options["execute"]
+        include_staff = options["include_staff"]
+
+        if days < 0:
+            self.stderr.write(self.style.ERROR("--days must be >= 0"))
+            return
+
+        if limit < 0:
+            self.stderr.write(self.style.ERROR("--limit must be >= 0"))
+            return
+
+        user_model = get_user_model()
+        cutoff = timezone.now() - timedelta(days=days)
+
+        verified_user_ids = EmailAddress.objects.filter(verified=True).values_list("user_id", flat=True)
+
+        queryset = user_model.objects.filter(date_joined__lt=cutoff).exclude(id__in=verified_user_ids).exclude(
+            is_superuser=True
+        )
+
+        if not include_staff:
+            queryset = queryset.exclude(is_staff=True)
+
+        queryset = queryset.order_by("date_joined", "id")
+        if limit > 0:
+            queryset = queryset[:limit]
+
+        users = list(queryset)
+
+        mode = "EXECUTE" if execute else "DRY-RUN"
+        self.stdout.write(f"Mode: {mode}")
+        self.stdout.write(
+            f"Candidates with no verified email and older than {days} day(s): {len(users)}"
+        )
+
+        if not users:
+            self.stdout.write("No matching users found.")
+            return
+
+        for user in users:
+            email = user.email or "(no email)"
+            self.stdout.write(
+                f"- id={user.id} username={user.username} email={email} joined={user.date_joined.isoformat()}"
+            )
+
+        if not execute:
+            self.stdout.write("Dry-run only. Re-run with --execute to delete these users.")
+            return
+
+        deleted_count = 0
+        for user in users:
+            user.delete()
+            deleted_count += 1
+
+        self.stdout.write(self.style.SUCCESS(f"Deleted {deleted_count} user(s)."))

--- a/website/tests/test_delete_unverified_users_command.py
+++ b/website/tests/test_delete_unverified_users_command.py
@@ -1,0 +1,125 @@
+from datetime import timedelta
+from io import StringIO
+
+from allauth.account.models import EmailAddress
+from django.contrib.auth.models import User
+from django.core.management import call_command
+from django.test import TestCase
+from django.utils import timezone
+
+
+class DeleteUnverifiedUsersCommandTestCase(TestCase):
+    def setUp(self):
+        old_date = timezone.now() - timedelta(days=60)
+
+        self.verified_user = User.objects.create_user(
+            username="verified_user",
+            email="verified@example.com",
+            password="testpass123",
+        )
+        EmailAddress.objects.create(
+            user=self.verified_user,
+            email=self.verified_user.email,
+            verified=True,
+            primary=True,
+        )
+
+        self.unverified_user = User.objects.create_user(
+            username="unverified_user",
+            email="unverified@example.com",
+            password="testpass123",
+        )
+        EmailAddress.objects.create(
+            user=self.unverified_user,
+            email=self.unverified_user.email,
+            verified=False,
+            primary=True,
+        )
+
+        self.unverified_no_record = User.objects.create_user(
+            username="no_record_user",
+            email="norecord@example.com",
+            password="testpass123",
+        )
+
+        self.recent_unverified = User.objects.create_user(
+            username="recent_user",
+            email="recent@example.com",
+            password="testpass123",
+        )
+        EmailAddress.objects.create(
+            user=self.recent_unverified,
+            email=self.recent_unverified.email,
+            verified=False,
+            primary=True,
+        )
+
+        self.staff_unverified = User.objects.create_user(
+            username="staff_user",
+            email="staff@example.com",
+            password="testpass123",
+            is_staff=True,
+        )
+        EmailAddress.objects.create(
+            user=self.staff_unverified,
+            email=self.staff_unverified.email,
+            verified=False,
+            primary=True,
+        )
+
+        for user in [
+            self.verified_user,
+            self.unverified_user,
+            self.unverified_no_record,
+            self.staff_unverified,
+        ]:
+            User.objects.filter(id=user.id).update(date_joined=old_date)
+
+    def test_dry_run_is_default_and_does_not_delete(self):
+        out = StringIO()
+        call_command("delete_unverified_users", "--days=30", stdout=out)
+
+        output = out.getvalue()
+        self.assertIn("Mode: DRY-RUN", output)
+        self.assertIn("unverified_user", output)
+        self.assertIn("no_record_user", output)
+        self.assertIn("Dry-run only", output)
+
+        self.assertTrue(User.objects.filter(username="unverified_user").exists())
+        self.assertTrue(User.objects.filter(username="no_record_user").exists())
+
+    def test_execute_deletes_only_matching_non_staff_users(self):
+        out = StringIO()
+        call_command("delete_unverified_users", "--days=30", "--execute", stdout=out)
+
+        output = out.getvalue()
+        self.assertIn("Mode: EXECUTE", output)
+        self.assertIn("Deleted 2 user(s).", output)
+
+        self.assertTrue(User.objects.filter(username="verified_user").exists())
+        self.assertFalse(User.objects.filter(username="unverified_user").exists())
+        self.assertFalse(User.objects.filter(username="no_record_user").exists())
+        self.assertTrue(User.objects.filter(username="recent_user").exists())
+        self.assertTrue(User.objects.filter(username="staff_user").exists())
+
+    def test_limit_applies_to_candidates(self):
+        out = StringIO()
+        call_command("delete_unverified_users", "--days=30", "--execute", "--limit=1", stdout=out)
+
+        self.assertIn("Deleted 1 user(s).", out.getvalue())
+
+        remaining = User.objects.filter(username__in=["unverified_user", "no_record_user"]).count()
+        self.assertEqual(remaining, 1)
+
+    def test_include_staff_flag_allows_staff_deletion(self):
+        out = StringIO()
+        call_command(
+            "delete_unverified_users",
+            "--days=30",
+            "--execute",
+            "--include-staff",
+            stdout=out,
+        )
+
+        self.assertIn("Deleted 3 user(s).", out.getvalue())
+        self.assertFalse(User.objects.filter(username="staff_user").exists())


### PR DESCRIPTION
### **Summary**


- Adds a new management command to identify and safely remove users without verified email addresses.

- Default behavior is dry-run to prevent accidental deletions; destructive action requires explicit [--execute]

- Includes focused tests for command behavior and safety checks.


**### Changes**

- Added command: [delete_unverified_users.py]

- Added tests: [test_delete_unverified_users_command.py]

**### Command Behavior**

- [--days] (default 30): minimum account age threshold

- [--limit] (default 0): max users to process (0 = no limit)

- [--execute]: actually delete matched users

- [--include-staff]: include staff users (excluded by default)

- Always excludes superusers

- Dry-run prints candidate list and summary

### **Validation**

- Ran targeted test module:

- manage.py test website.tests.test_delete_unverified_users_command

- Result: Ran 4 tests ... OK


**### Safety Notes**

- Non-destructive by default (dry-run).

- Explicit opt-in required for deletion ([--execute]).

- Conservative defaults avoid deleting staff/superusers unless explicitly allowed.


### **Checklist**


-  Added command implementation

-  Added tests for dry-run and execute flows

-  Verified limit behavior

-  Verified staff inclusion toggle

-  Confirmed targeted tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a management command for administrators to identify and delete unverified user accounts joined before a specified cutoff, with configurable time periods, batch limits, and safety checks excluding superusers.

* **Tests**
  * Added test suite validating the new user deletion command behavior in dry-run and execution modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->