### PR TITLE
docs: fix poetry setup order to install before shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,10 +122,14 @@ docker info | findstr OSType
 
 #### Using Poetry
 ```bash
-# Install dependencies
+# Install Poetry
 pip install poetry
-poetry shell
+
+# 1. Install dependencies first (Creates the virtual environment)
 poetry install
+
+# 2. Activate the virtual environment
+poetry shell
 
 
 #### Beginner-Friendly Non-Docker Setup (Codespaces for Windows Beginners)


### PR DESCRIPTION
I corrected the Poetry installation order in the README. The previous version attempted to activate the shell before installing dependencies, which causes the command to fail if the environment hasn't been created yet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated project setup: clarified Poetry installation step, split dependency installation and environment activation into two sequenced steps (install first, then activate), removed the prior instruction to activate before installing, and made activation guidance explicit and separated from installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->