### PR TITLE
Fix HTMX actions login redirect

### DIFF
--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -307,22 +307,25 @@
         <script>
             document.body.addEventListener('htmx:beforeSwap', function(evt) {
                 // Check if response is a redirect to login page (302/301)
-                if (evt.detail.xhr.status === 302 || evt.detail.xhr.status === 301) {
-                    const redirectLocation = evt.detail.xhr.getResponseHeader('Location');
-                    
-                    // If redirecting to login, do full-page navigation instead of swap
-                    if (redirectLocation && redirectLocation.includes('/accounts/login/')) {
-                        evt.detail.shouldSwap = false;
-                        window.location.href = redirectLocation;
-                    }
+                const xhr = evt.detail && evt.detail.xhr;
+                if (!xhr) return;
+
+                // Primary signal: detect redirect via final URL
+                const responseURL = xhr.responseURL || '';
+                if (responseURL.includes('/accounts/login/')) {
+                    evt.detail.shouldSwap = false;
+                    window.location.assign(responseURL);
+                    return;
                 }
-                
-                // Fallback: Check if response HTML contains login form
-                if (evt.detail.xhr.status === 200) {
-                    const responseText = evt.detail.xhr.responseText;
-                    if (responseText.includes('id="login"') || responseText.includes('name="login"')) {
+
+                // Fallback: inspect HTML more robustly
+                if (xhr.status === 200 && (xhr.getResponseHeader('Content-Type') || '').includes('text/html')) {
+                    const doc = new DOMParser().parseFromString(xhr.responseText, 'text/html');
+                    const looksLikeLogin = doc.querySelector('#login, [name="login"], form[action*="/accounts/login/"]');
+                    if (looksLikeLogin) {
                         evt.detail.shouldSwap = false;
-                        window.location.href = '/accounts/login/?next=' + encodeURIComponent(window.location.pathname);
+                        const next = `${window.location.pathname}${window.location.search}`;
+                        window.location.assign(`/accounts/login/?next=${encodeURIComponent(next)}`);
                     }
                 }
             });

--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -303,6 +303,30 @@
         <script src="https://unpkg.com/htmx.org@1.9.10/dist/ext/json-enc.js"
                 integrity="sha384-nRnAvEUI7N/XvvowiMiq7oEI04gOXMCqD3Bidvedw+YNbj7zTQACPlRI3Jt3vYM4"
                 crossorigin="anonymous"></script>
+        <!-- Handle login redirects for HTMX requests -->
+        <script>
+            document.body.addEventListener('htmx:beforeSwap', function(evt) {
+                // Check if response is a redirect to login page (302/301)
+                if (evt.detail.xhr.status === 302 || evt.detail.xhr.status === 301) {
+                    const redirectLocation = evt.detail.xhr.getResponseHeader('Location');
+                    
+                    // If redirecting to login, do full-page navigation instead of swap
+                    if (redirectLocation && redirectLocation.includes('/accounts/login/')) {
+                        evt.detail.shouldSwap = false;
+                        window.location.href = redirectLocation;
+                    }
+                }
+                
+                // Fallback: Check if response HTML contains login form
+                if (evt.detail.xhr.status === 200) {
+                    const responseText = evt.detail.xhr.responseText;
+                    if (responseText.includes('id="login"') || responseText.includes('name="login"')) {
+                        evt.detail.shouldSwap = false;
+                        window.location.href = '/accounts/login/?next=' + encodeURIComponent(window.location.pathname);
+                    }
+                }
+            });
+        </script>
         <script src="{% static 'vendor/bootstrap/js/bootstrap.min.js' %}"></script>
         <script src="{% static 'js/ui.js' %}"></script>
         {% block after_js %}

--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -314,7 +314,10 @@
                 const responseURL = xhr.responseURL || '';
                 if (responseURL.includes('/accounts/login/')) {
                     evt.detail.shouldSwap = false;
-                    window.location.assign(responseURL);
+                    const loginUrl = new URL(responseURL, window.location.origin);
+                    const next = `${window.location.pathname}${window.location.search}`;
+                    loginUrl.searchParams.set('next', next);
+                    window.location.assign(loginUrl.toString());
                     return;
                 }
 


### PR DESCRIPTION
Fixes #5742 

Fixes an issue where HTMX actions (Like, Dislike, Flag, Save) performed by unauthenticated users would render the login form inside a partial page instead of redirecting to the full login page.

Adds an htmx:beforeSwap handler to detect login redirects and perform full-page navigation instead of partial swaps.

Tested locally by making an issue, Video Recording added below:-

https://github.com/user-attachments/assets/a6431508-4166-4fb9-bc4b-7db265caf505







<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved login handling during page interactions. The app now automatically redirects you to login when required and returns you to your original destination after authentication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->