### PR TITLE
Add authenticated Project least-members API endpoint for BLT-Lettuce migration

### DIFF
--- a/blt/urls.py
+++ b/blt/urls.py
@@ -1041,7 +1041,10 @@ urlpatterns = [
     ),
     path(
         "api/v1/projects/least-members-channel/",
-        ProjectViewSet.as_view({"get": "least_members_channel"}),
+        ProjectViewSet.as_view(
+            {"get": "least_members_channel"},
+            permission_classes=[permissions.IsAuthenticated],
+        ),
         name="projects_least_members_channel_api",
     ),
     path(

--- a/blt/urls.py
+++ b/blt/urls.py
@@ -1040,6 +1040,11 @@ urlpatterns = [
         name="projects_api",
     ),
     path(
+        "api/v1/projects/least-members-channel/",
+        ProjectViewSet.as_view({"get": "least_members_channel"}),
+        name="projects_least_members_channel_api",
+    ),
+    path(
         "auth/delete",
         AuthApiViewset.as_view({"delete": "delete"}),
         name="auth-delete-api",

--- a/website/api/views.py
+++ b/website/api/views.py
@@ -940,6 +940,23 @@ class ProjectViewSet(viewsets.ModelViewSet):
         project_data = self._serialize_projects(projects)
         return Response({"count": len(project_data), "projects": project_data})
 
+    @action(
+        detail=False,
+        methods=["get"],
+        url_path="least-members-channel",
+        permission_classes=[IsAuthenticated],
+    )
+    def least_members_channel(self, request, *args, **kwargs):
+        """Return the project channel with the least members (excluding project-blt)."""
+        project = (
+            Project.objects.filter(slack_channel__isnull=False, slack_user_count__gt=0)
+            .exclude(slack_channel="")
+            .exclude(slack_channel="project-blt")
+            .order_by("slack_user_count")
+            .first()
+        )
+        return Response({"slack_channel": project.slack_channel if project else None})
+
     @action(detail=False, methods=["get"])
     def search(self, request, *args, **kwargs):
         """Search projects by name, description, or tags."""

--- a/website/tests/test_api.py
+++ b/website/tests/test_api.py
@@ -432,3 +432,80 @@ class ProjectFreshnessFilteringTestCase(APITestCase):
         for project in data["results"]:
             self.assertIn("freshness", project)
             self.assertIsNotNone(project["freshness"])
+
+
+class ProjectLeastMembersChannelApiTestCase(APITestCase):
+    def setUp(self):
+        self.org = Organization.objects.create(name="API Test Org", url="https://api-test.org")
+        self.user = get_user_model().objects.create_user(username="leastmembers-user", email="lm@example.com")
+        self.client.force_authenticate(user=self.user)
+
+    def test_requires_authentication(self):
+        self.client.force_authenticate(user=None)
+        response = self.client.get("/api/v1/projects/least-members-channel/")
+        self.assertIn(response.status_code, [401, 403])
+
+    def test_returns_least_members_channel(self):
+        Project.objects.create(
+            organization=self.org,
+            name="BLT",
+            slug="blt",
+            description="BLT project",
+            slack_channel="project-blt",
+            slack_user_count=1,
+        )
+        Project.objects.create(
+            organization=self.org,
+            name="Project A",
+            slug="project-a",
+            description="A",
+            slack_channel="project-a",
+            slack_user_count=30,
+        )
+        Project.objects.create(
+            organization=self.org,
+            name="Project B",
+            slug="project-b",
+            description="B",
+            slack_channel="project-b",
+            slack_user_count=10,
+        )
+
+        response = self.client.get("/api/v1/projects/least-members-channel/")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["slack_channel"], "project-b")
+
+    def test_returns_none_when_no_eligible_project(self):
+        Project.objects.create(
+            organization=self.org,
+            name="BLT",
+            slug="blt-only",
+            description="BLT only",
+            slack_channel="project-blt",
+            slack_user_count=4,
+        )
+        response = self.client.get("/api/v1/projects/least-members-channel/")
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNone(response.json()["slack_channel"])
+
+    def test_excludes_blank_slack_channel(self):
+        Project.objects.create(
+            organization=self.org,
+            name="Blank Channel",
+            slug="blank-channel",
+            description="Blank",
+            slack_channel="",
+            slack_user_count=1,
+        )
+        Project.objects.create(
+            organization=self.org,
+            name="Valid Channel",
+            slug="valid-channel",
+            description="Valid",
+            slack_channel="project-valid",
+            slack_user_count=2,
+        )
+
+        response = self.client.get("/api/v1/projects/least-members-channel/")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["slack_channel"], "project-valid")


### PR DESCRIPTION
This PR introduces a small BLT-core API contract needed for the ongoing Slack migration to BLT-Lettuce.

It adds an authenticated endpoint for retrieving the project with the least members, along with regression tests to ensure stable behavior for external consumers.

## Context

During development, Slack runtime logic will be migrated out of BLT in #5887 and moved into BLT-Lettuce.  
As a result, the scope of this PR was reduced to keep only BLT-core changes that remain relevant after the migration.

The goal is to ensure BLT exposes a stable API surface for Lettuce (and future external services) rather than modifying removed monolith Slack handlers.

## Changes

- Added authenticated endpoint:
  `GET /api/v1/projects/least-members-channel/`
- Wired endpoint into API router
- Added regression tests including:
  - authentication requirement validation
  - endpoint behavior verification

## Why This Helps

BLT-Lettuce now consumes BLT via REST APIs.  
This endpoint formalizes part of that contract and ensures:

- authenticated access
- predictable response behavior
- regression protection during migration

## Notes

- Slack handler migration code was intentionally removed from this PR after #5887 was discovered.
- A backup branch was preserved before rewrite for reference:
  `backup/feature-slack-project-api-migration-pre-rewrite`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new API endpoint that retrieves the Slack channel with the least number of members from eligible projects. Authentication is required to access this endpoint.

* **Tests**
  * Added comprehensive test coverage for the new endpoint, including authentication validation and edge case handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->