### PR TITLE
fix(security): add permission_classes to DomainViewSet

### DIFF
--- a/website/api/views.py
+++ b/website/api/views.py
@@ -158,6 +158,7 @@ class DomainViewSet(viewsets.ModelViewSet):
 
     serializer_class = DomainSerializer
     queryset = Domain.objects.all()
+    permission_classes = [IsAuthenticatedOrReadOnly]
     filter_backends = (filters.SearchFilter,)
     search_fields = ("url", "name")
     http_method_names = ["get", "post", "head"]

--- a/website/tests/test_domain_api.py
+++ b/website/tests/test_domain_api.py
@@ -1,0 +1,39 @@
+from allauth.account.models import EmailAddress
+from django.contrib.auth import get_user_model
+from rest_framework import status
+from rest_framework.authtoken.models import Token
+from rest_framework.test import APITestCase
+
+from website.models import Domain
+
+User = get_user_model()
+
+
+class DomainViewSetPermissionTests(APITestCase):
+    """Verify DomainViewSet enforces IsAuthenticatedOrReadOnly."""
+
+    url = "/api/v1/domain/"
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username="testuser", email="test@test.com", password="TestPass123!"
+        )
+        EmailAddress.objects.create(user=self.user, email="test@test.com", verified=True, primary=True)
+        self.token = Token.objects.get(user=self.user)
+        Domain.objects.create(url="https://example.com", name="example.com")
+
+    def test_unauthenticated_get_succeeds(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_unauthenticated_post_rejected(self):
+        response = self.client.post(self.url, data={"url": "https://new.com", "name": "new.com"})
+        self.assertIn(response.status_code, [status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN])
+
+    def test_authenticated_post_succeeds(self):
+        response = self.client.post(
+            self.url,
+            data={"url": "https://new.com", "name": "new.com"},
+            HTTP_AUTHORIZATION=f"Token {self.token.key}",
+        )
+        self.assertIn(response.status_code, [status.HTTP_200_OK, status.HTTP_201_CREATED])


### PR DESCRIPTION
## Summary

`DomainViewSet` had no explicit `permission_classes`, defaulting to `AllowAny`. This allowed unauthenticated users to create domains via `POST /api/v1/domain/`, which could lead to data pollution and abuse.

Added `IsAuthenticatedOrReadOnly` so GET/HEAD remain public but POST requires authentication.

## Changes
- `website/api/views.py`: Added `permission_classes = [IsAuthenticatedOrReadOnly]` to `DomainViewSet`

## Test plan
- Verify unauthenticated GET requests to `/api/v1/domain/` still return 200
- Verify unauthenticated POST requests to `/api/v1/domain/` return 401
- Verify authenticated POST requests to `/api/v1/domain/` succeed

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unauthenticated users can now view domain information without login; authentication is still required to create, update, or delete domains.
* **Tests**
  * Added API tests validating that unauthenticated GETs succeed, unauthenticated POSTs are rejected, and authenticated POSTs succeed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->