### PR TITLE
fix: remove duplicate 'follows' field in UserProfileSerializer

### DIFF
--- a/website/serializers.py
+++ b/website/serializers.py
@@ -64,7 +64,6 @@ class UserProfileSerializer(serializers.ModelSerializer):
             "user_avatar",
             "description",
             "winnings",
-            "follows",
             "issue_upvoted",
             "issue_saved",
             "issue_flaged",


### PR DESCRIPTION
## Summary

The `follows` field appeared twice in `UserProfileSerializer.Meta.fields`, which can cause unexpected serialization behavior and makes the code harder to maintain.

## Changes
- `website/serializers.py`: Removed the duplicate `"follows"` entry from the `fields` tuple

## Test plan
- Verify `/api/v1/profile/` endpoint still returns correct user profile data with `follows` field
- Verify the field only appears once in the serialized response

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * User profile data no longer includes the follows field in API responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->