### PR TITLE
fix(docs): replace placeholder OpenAPI schema metadata with real project info

### DIFF
--- a/blt/urls.py
+++ b/blt/urls.py
@@ -375,12 +375,20 @@ admin.autodiscover()
 # Use the drf_yasg schema view
 schema_view = get_schema_view(
     openapi.Info(
-        title="API",
+        title="OWASP Bug Logging Tool (BLT) API",
         default_version="v1",
-        description="Test description",
-        terms_of_service="https://www.google.com/policies/terms/",
-        contact=openapi.Contact(email="contact@snippets.local"),
-        license=openapi.License(name="BSD License"),
+        description=(
+            "REST API for the OWASP Bug Logging Tool (BLT). "
+            "Provides endpoints for issue tracking, domain management, "
+            "organizations, bug hunts, leaderboards, and security research."
+        ),
+        terms_of_service="https://owasp.org/www-policy/",
+        contact=openapi.Contact(
+            name="OWASP BLT",
+            url="https://github.com/OWASP-BLT/BLT",
+            email="blt-project-leader@owasp.org",
+        ),
+        license=openapi.License(name="AGPL-3.0 License"),
     ),
     public=True,
     permission_classes=(permissions.AllowAny,),


### PR DESCRIPTION
## Summary

The drf-yasg schema_view used placeholder values:
- Title: "API" 
- Description: "Test description"
- Contact: "contact@snippets.local"

Updated to reflect the actual OWASP BLT project with a meaningful API description, correct OWASP contact information, project GitHub URL, and the correct AGPL-3.0 license.

## Changes
- `blt/urls.py`: Updated `schema_view` openapi.Info with real project metadata

## Test plan
- Visit `/swagger/` and verify the updated title, description, contact, and license
- Visit `/redoc/` and verify the same

