### PR TITLE
Add bots to botPatterns

### DIFF
--- a/.github/workflows/leaderboard-bot.yml
+++ b/.github/workflows/leaderboard-bot.yml
@@ -41,7 +41,17 @@ jobs:
             const isBot = (user) => {
               if (!user || !user.login) return false;
               const loginLower = user.login.toLowerCase();
-              const botPatterns = ['copilot', '[bot]', 'dependabot', 'github-actions', 'renovate', 'actions-user'];
+              const botPatterns = [
+                'copilot',
+                '[bot]',
+                'dependabot',
+                'github-actions',
+                'renovate',
+                'actions-user',
+                'coderabbitai',
+                'coderabbit',
+                'sentry-autofix'
+              ];
               return (user.type && user.type === 'Bot') ||
                      botPatterns.some(pattern => loginLower.includes(pattern));
             };


### PR DESCRIPTION
Added coderabbitai and sentry to the botPatterns as they were being counted in the first two PR review counts and in the github leaderboard.

Tested locally by making a PR on fork which is reviewed by coderabbitai and made a new PR in which coderabbitai is not shown in the leaderboard.
Screenshots:-

<img width="1919" height="870" alt="image" src="https://github.com/user-attachments/assets/e8b107d3-2094-46c5-81c3-1c92a55bc6df" />
<img width="1919" height="865" alt="image" src="https://github.com/user-attachments/assets/2676cbdf-5261-45d4-8af0-d333d019aa9d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded bot detection patterns to recognize additional automated service accounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->