### PR TITLE
fix: make OpenCV optional to prevent startup crash when cv2 is missing

### DIFF
--- a/website/utils.py
+++ b/website/utils.py
@@ -12,7 +12,11 @@ from datetime import datetime
 from ipaddress import ip_address
 from urllib.parse import quote, urlparse, urlsplit, urlunparse
 
-import cv2
+try:
+    import cv2
+except ImportError:
+    cv2 = None
+
 import markdown
 import numpy as np
 import requests
@@ -1249,6 +1253,10 @@ def _get_face_cascade():
     if _face_cascade_cache is not None:
         return _face_cascade_cache
 
+    if cv2 is None:
+        logging.error("OpenCV not available – cannot load Haar Cascade classifier.")
+        return None
+
     try:
         cascade_path = cv2.data.haarcascades + "haarcascade_frontalface_default.xml"
         classifier = cv2.CascadeClassifier(cascade_path)
@@ -1279,6 +1287,10 @@ def overlay_faces(image, color=(0, 0, 0)):
     """
     try:
         logging.debug("Starting face detection process")
+
+        if cv2 is None:
+            logging.warning("OpenCV not available - skipping face overlay")
+            return image
 
         # Convert image to grayscale
         gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
@@ -1343,6 +1355,9 @@ def process_bug_screenshot(image_file, overlay_color=(0, 0, 0)):
     logging.info(f"Processing screenshot: {getattr(image_file, 'name', 'unknown')}")
 
     try:
+        if cv2 is None:
+            raise ImportError("OpenCV (cv2) is not installed")
+
         logging.debug("OpenCV imported successfully for screenshot processing")
 
         # Reset file pointer to beginning

--- a/website/utils.py
+++ b/website/utils.py
@@ -16,6 +16,7 @@ try:
     import cv2
 except ImportError:
     cv2 = None
+    logging.warning("OpenCV (cv2) not installed; face-processing features will be disabled.")
 
 import markdown
 import numpy as np


### PR DESCRIPTION
## Summary

This change makes OpenCV (cv2) an optional dependency.

## Changes
- Wrap `cv2` import in `try/except`
- Prevent Django startup failure when OpenCV is not installed
- Add defensive checks in face-processing utilities
- Ensure non-image features work without requiring OpenCV

## Why

Previously, importing `cv2` at module level caused the application to fail during startup if OpenCV was not installed.  
This change ensures the application boots normally and only disables face-processing features when OpenCV is unavailable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * App now detects when native image-processing support is unavailable and falls back to alternative processing so it no longer crashes.
  * Improved protective checks and consistent logging around face-processing flows to surface clear warnings and ensure input images are returned unchanged when advanced processing is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->