### PR TITLE
bug fix: TypeError 'list' object is not callable in settings.py

### DIFF
--- a/blt/settings.py
+++ b/blt/settings.py
@@ -143,7 +143,7 @@ if DEBUG and not TESTING:
     # Configure INTERNAL_IPS for Docker environment
     INTERNAL_IPS = {"127.0.0.1", "::1", "10.0.2.2"}
     try:
-        _, _, ips = socket.gethostbyname_ex(socket.gethostname())
+        unused_hostname, unused_aliaslist, ips = socket.gethostbyname_ex(socket.gethostname())
     except (socket.gaierror, OSError):
         # Fall back to default INTERNAL_IPS if hostname resolution fails
         ips = []

--- a/blt/settings.py
+++ b/blt/settings.py
@@ -143,7 +143,7 @@ if DEBUG and not TESTING:
     # Configure INTERNAL_IPS for Docker environment
     INTERNAL_IPS = {"127.0.0.1", "::1", "10.0.2.2"}
     try:
-        __, __, ips = socket.gethostbyname_ex(socket.gethostname())
+        _hostname, _aliases, ips = socket.gethostbyname_ex(socket.gethostname())
     except (socket.gaierror, OSError):
         # Fall back to default INTERNAL_IPS if hostname resolution fails
         ips = []

--- a/blt/settings.py
+++ b/blt/settings.py
@@ -143,7 +143,7 @@ if DEBUG and not TESTING:
     # Configure INTERNAL_IPS for Docker environment
     INTERNAL_IPS = {"127.0.0.1", "::1", "10.0.2.2"}
     try:
-        unused_hostname, unused_aliaslist, ips = socket.gethostbyname_ex(socket.gethostname())
+        __, __, ips = socket.gethostbyname_ex(socket.gethostname())
     except (socket.gaierror, OSError):
         # Fall back to default INTERNAL_IPS if hostname resolution fails
         ips = []


### PR DESCRIPTION
### Issue
Running Django management commands (like makemigrations or runserver) resulted in a TypeError: 'list' object is not callable at line 263: ("en", _("English")).
-  The translation alias _ was being overwritten  by the return values of socket.gethostbyname_ex() in the networking configuration block.

<img width="371" height="498" alt="Screenshot 2026-03-03 at 9 21 18 PM" src="https://github.com/user-attachments/assets/0f5914a9-1946-44be-ac79-48dc36f16be6" />

### Fixes
Changed the unpacking of socket.gethostbyname_ex to use __  as a throwaway variable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Minor internal variable renaming and formatting for clarity. No changes to behavior, error handling, public APIs, or user-facing functionality; zero impact on features or performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->