### PR TITLE
Added OSSH catalog api endpoint

### DIFF
--- a/blt/urls.py
+++ b/blt/urls.py
@@ -284,6 +284,7 @@ from website.views.ossh import (
     ossh_home,
     ossh_results,
 )
+from website.views.ossh_catalog import ossh_catalog
 from website.views.project import (
     ProjectBadgeView,
     ProjectCompactListView,
@@ -1114,6 +1115,7 @@ urlpatterns = [
     ),
     path("pending-transactions/", pending_transactions_view, name="pending_transactions"),
     path("open-source-sorting-hat/", ossh_home, name="ossh_home"),
+    path("api/ossh/catalog", ossh_catalog, name="ossh_catalog"),
     path("open-source-sorting-hat/results", ossh_results, name="ossh_results"),
     path("get-github-data/", get_github_data, name="get_github_data"),
     path("get-recommended-repos/", get_recommended_repos, name="get_recommended_repos"),

--- a/blt/urls.py
+++ b/blt/urls.py
@@ -1115,7 +1115,7 @@ urlpatterns = [
     ),
     path("pending-transactions/", pending_transactions_view, name="pending_transactions"),
     path("open-source-sorting-hat/", ossh_home, name="ossh_home"),
-    path("api/ossh/catalog", ossh_catalog, name="ossh_catalog"),
+    path("api/ossh/catalog/", ossh_catalog, name="ossh_catalog"),
     path("open-source-sorting-hat/results", ossh_results, name="ossh_results"),
     path("get-github-data/", get_github_data, name="get_github_data"),
     path("get-recommended-repos/", get_recommended_repos, name="get_recommended_repos"),

--- a/website/views/ossh_catalog.py
+++ b/website/views/ossh_catalog.py
@@ -1,5 +1,3 @@
-import json
-
 from django.http import JsonResponse
 from django.views.decorators.http import require_GET
 
@@ -7,109 +5,126 @@ from website.models import OsshArticle, OsshCommunity, OsshDiscussionChannel, Re
 
 
 def _tags(obj):
-    """
-    Best-effort tags:
-    - if obj.tags is a list/JSONField/text
-    - or tags is ManyToMany
-    """
-    if hasattr(obj, "tags"):
-        v = getattr(obj, "tags")
-        # JSONField(list)
-        if isinstance(v, (list, tuple)):
-            return [str(x).strip() for x in v if str(x).strip()]
-        # comma-separated text / JSON string
-        if isinstance(v, str) and v.strip():
-            s = v.strip()
-            if s.startswith("[") and s.endswith("]"):
-                try:
-                    arr = json.loads(s)
-                    if isinstance(arr, list):
-                        return [str(x).strip() for x in arr if str(x).strip()]
-                except Exception:
-                    pass
-            return [x.strip() for x in s.split(",") if x.strip()]
-        # ManyToMany
-        try:
-            if hasattr(v, "all"):
-                return [str(t).strip() for t in v.all() if str(t).strip()]
-        except Exception:
-            pass
-    return []
+    # With prefetch_related("tags") this won't cause N+1 queries
+    return [t.name for t in obj.tags.all()]
 
 
 @require_GET
 def ossh_catalog(request):
     """
-    Read-only catalog for BLT-OSSH GitHub Pages.
-
-    Returns ONLY OSSH-related public data:
-      - Repo
-      - OsshCommunity
-      - OsshDiscussionChannel
-      - OsshArticle
+    Returns the OSSH catalog (repos + communities + discussion_channels + articles) as JSON.
+    Uses real model fields + prefetch_related("tags") to avoid N+1 queries.
     """
-    repos = []
-    for r in Repo.objects.all():
-        repos.append(
-            {
-                "name": getattr(r, "name", "") or getattr(r, "repo_name", "") or "",
-                "full_name": getattr(r, "full_name", "") or getattr(r, "github_full_name", "") or "",
-                "description": getattr(r, "description", "") or "",
-                "url": getattr(r, "url", "") or getattr(r, "repo_url", "") or getattr(r, "source_code", "") or "",
-                "language": getattr(r, "language", "") or getattr(r, "primary_language", "") or "",
-                "stars": int(getattr(r, "stars", 0) or getattr(r, "stargazers_count", 0) or 0),
-                "forks": int(getattr(r, "forks", 0) or getattr(r, "forks_count", 0) or 0),
-                "tags": _tags(r),
-            }
-        )
 
-    communities = []
-    for c in OsshCommunity.objects.all():
-        communities.append(
-            {
-                "name": getattr(c, "name", "") or "",
-                "description": getattr(c, "description", "") or "",
-                "url": getattr(c, "url", "") or getattr(c, "link", "") or "",
-                "members": getattr(c, "members", "") or getattr(c, "member_count", "") or "",
-                "tags": _tags(c),
-            }
-        )
+    # -----------------
+    # Repos
+    # -----------------
+    repos_qs = Repo.objects.only(
+        "id", "name", "repo_url", "primary_language", "stars", "forks", "description"
+    ).prefetch_related("tags")
 
-    discussion_channels = []
-    for ch in OsshDiscussionChannel.objects.all():
-        discussion_channels.append(
-            {
-                "name": getattr(ch, "name", "") or "",
-                "platform": getattr(ch, "platform", "") or getattr(ch, "source", "") or "",
-                "invite_url": getattr(ch, "invite_url", "") or getattr(ch, "url", "") or "",
-                "member_count": int(getattr(ch, "member_count", 0) or getattr(ch, "members", 0) or 0),
-                "tags": _tags(ch),
-            }
-        )
+    repos = [
+        {
+            "name": r.name,
+            "url": r.repo_url,
+            "description": getattr(r, "description", "") or "",
+            "primary_language": r.primary_language or "",
+            "stars": r.stars or 0,
+            "forks": r.forks or 0,
+            "tags": _tags(r),
+        }
+        for r in repos_qs
+    ]
 
-    articles = []
-    for a in OsshArticle.objects.all():
-        articles.append(
-            {
-                "title": getattr(a, "title", "") or getattr(a, "name", "") or "",
-                "category": getattr(a, "category", "") or "",
-                "url": getattr(a, "url", "") or getattr(a, "link", "") or "",
-                "tags": _tags(a),
-            }
-        )
+    # -----------------
+    # Communities
+    # -----------------
+    communities_qs = OsshCommunity.objects.only(
+        "id",
+        "name",
+        "description",
+        "website",
+        "source",
+        "category",
+        "contributors_count",
+    ).prefetch_related("tags")
+
+    communities = [
+        {
+            "name": c.name,
+            "description": c.description or "",
+            "website": c.website or "",
+            "source": c.source or "",
+            "category": c.category or "",
+            "contributors_count": c.contributors_count or 0,
+            "tags": _tags(c),
+        }
+        for c in communities_qs
+    ]
+
+    # -----------------
+    # Discussion Channels
+    # -----------------
+    channels_qs = OsshDiscussionChannel.objects.only(
+        "id",
+        "name",
+        "description",
+        "source",
+        "member_count",
+        "invite_url",
+        "logo_url",
+    ).prefetch_related("tags")
+
+    discussion_channels = [
+        {
+            "name": ch.name,
+            "description": ch.description or "",
+            "source": ch.source or "",
+            "member_count": ch.member_count or 0,
+            "invite_url": ch.invite_url or "",
+            "logo_url": ch.logo_url or "",
+            "tags": _tags(ch),
+        }
+        for ch in channels_qs
+    ]
+
+    # -----------------
+    # Articles
+    # -----------------
+    articles_qs = OsshArticle.objects.only(
+        "id",
+        "title",
+        "author",
+        "author_profile_image",
+        "description",
+        "publication_date",
+        "source",
+        "url",
+        "cover_image",
+        "reading_time_minutes",
+    ).prefetch_related("tags")
+
+    articles = [
+        {
+            "title": a.title,
+            "author": a.author,
+            "author_profile_image": a.author_profile_image or "",
+            "description": a.description or "",
+            "publication_date": a.publication_date.isoformat() if a.publication_date else "",
+            "source": a.source or "",
+            "url": a.url or "",
+            "cover_image": a.cover_image or "",
+            "reading_time_minutes": a.reading_time_minutes or 0,
+            "tags": _tags(a),
+        }
+        for a in articles_qs
+    ]
 
     payload = {
-        "site": {
-            "source": "OWASP-BLT/BLT",
-            "generated_from": "database",
-        },
         "repos": repos,
         "communities": communities,
         "discussion_channels": discussion_channels,
         "articles": articles,
     }
 
-    resp = JsonResponse(payload, json_dumps_params={"indent": 2})
-    resp["Access-Control-Allow-Origin"] = "*"
-    resp["Cache-Control"] = "public, max-age=300"
-    return resp
+    return JsonResponse(payload, json_dumps_params={"indent": 2})

--- a/website/views/ossh_catalog.py
+++ b/website/views/ossh_catalog.py
@@ -1,0 +1,115 @@
+import json
+
+from django.http import JsonResponse
+from django.views.decorators.http import require_GET
+
+from website.models import OsshArticle, OsshCommunity, OsshDiscussionChannel, Repo
+
+
+def _tags(obj):
+    """
+    Best-effort tags:
+    - if obj.tags is a list/JSONField/text
+    - or tags is ManyToMany
+    """
+    if hasattr(obj, "tags"):
+        v = getattr(obj, "tags")
+        # JSONField(list)
+        if isinstance(v, (list, tuple)):
+            return [str(x).strip() for x in v if str(x).strip()]
+        # comma-separated text / JSON string
+        if isinstance(v, str) and v.strip():
+            s = v.strip()
+            if s.startswith("[") and s.endswith("]"):
+                try:
+                    arr = json.loads(s)
+                    if isinstance(arr, list):
+                        return [str(x).strip() for x in arr if str(x).strip()]
+                except Exception:
+                    pass
+            return [x.strip() for x in s.split(",") if x.strip()]
+        # ManyToMany
+        try:
+            if hasattr(v, "all"):
+                return [str(t).strip() for t in v.all() if str(t).strip()]
+        except Exception:
+            pass
+    return []
+
+
+@require_GET
+def ossh_catalog(request):
+    """
+    Read-only catalog for BLT-OSSH GitHub Pages.
+
+    Returns ONLY OSSH-related public data:
+      - Repo
+      - OsshCommunity
+      - OsshDiscussionChannel
+      - OsshArticle
+    """
+    repos = []
+    for r in Repo.objects.all():
+        repos.append(
+            {
+                "name": getattr(r, "name", "") or getattr(r, "repo_name", "") or "",
+                "full_name": getattr(r, "full_name", "") or getattr(r, "github_full_name", "") or "",
+                "description": getattr(r, "description", "") or "",
+                "url": getattr(r, "url", "") or getattr(r, "repo_url", "") or getattr(r, "source_code", "") or "",
+                "language": getattr(r, "language", "") or getattr(r, "primary_language", "") or "",
+                "stars": int(getattr(r, "stars", 0) or getattr(r, "stargazers_count", 0) or 0),
+                "forks": int(getattr(r, "forks", 0) or getattr(r, "forks_count", 0) or 0),
+                "tags": _tags(r),
+            }
+        )
+
+    communities = []
+    for c in OsshCommunity.objects.all():
+        communities.append(
+            {
+                "name": getattr(c, "name", "") or "",
+                "description": getattr(c, "description", "") or "",
+                "url": getattr(c, "url", "") or getattr(c, "link", "") or "",
+                "members": getattr(c, "members", "") or getattr(c, "member_count", "") or "",
+                "tags": _tags(c),
+            }
+        )
+
+    discussion_channels = []
+    for ch in OsshDiscussionChannel.objects.all():
+        discussion_channels.append(
+            {
+                "name": getattr(ch, "name", "") or "",
+                "platform": getattr(ch, "platform", "") or getattr(ch, "source", "") or "",
+                "invite_url": getattr(ch, "invite_url", "") or getattr(ch, "url", "") or "",
+                "member_count": int(getattr(ch, "member_count", 0) or getattr(ch, "members", 0) or 0),
+                "tags": _tags(ch),
+            }
+        )
+
+    articles = []
+    for a in OsshArticle.objects.all():
+        articles.append(
+            {
+                "title": getattr(a, "title", "") or getattr(a, "name", "") or "",
+                "category": getattr(a, "category", "") or "",
+                "url": getattr(a, "url", "") or getattr(a, "link", "") or "",
+                "tags": _tags(a),
+            }
+        )
+
+    payload = {
+        "site": {
+            "source": "OWASP-BLT/BLT",
+            "generated_from": "database",
+        },
+        "repos": repos,
+        "communities": communities,
+        "discussion_channels": discussion_channels,
+        "articles": articles,
+    }
+
+    resp = JsonResponse(payload, json_dumps_params={"indent": 2})
+    resp["Access-Control-Allow-Origin"] = "*"
+    resp["Cache-Control"] = "public, max-age=300"
+    return resp


### PR DESCRIPTION
Adds a new read-only endpoint (/api/ossh/catalog) that exports BLT’s OSSH dataset (repos, communities, discussion channels, articles) as a single JSON payload. This lets BLT-OSSH (GitHub Pages) fetch or curl the canonical data directly from the main BLT site without scraping.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a read-only API endpoint /api/ossh/catalog (GET) that returns a public catalog of repositories, communities, discussion channels, and articles.
  * Response provides curated metadata fields and tag lists for each item, delivered as a JSON payload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->