### PR TITLE
Enforce new‑contributor PR policy correctly (exclude current PR; org‑wide prior PRs < 3)

### DIFF
--- a/.github/workflows/close-single-file-deletion-prs.yml
+++ b/.github/workflows/close-single-file-deletion-prs.yml
@@ -4,11 +4,10 @@ name: Close PRs from Non-First-Time Contributors
 # SECURITY: We do NOT check out or execute PR code. We only use the GitHub API.
 #
 # Accepted PR policy:
-#   Only pull requests from first-time contributors (FIRST_TIMER or
-#   FIRST_TIME_CONTRIBUTOR) that delete between 1 and 20 files (no other changes)
-#   are accepted. Everything else is automatically closed:
-#     - First-time contributor with any change other than file-only deletions (1–20 files).
-#     - Any contributor who has previously contributed to this repository.
+#   1. Contributor must have 3 or fewer prior PRs across the OWASP-BLT organization
+#      (current PR excluded from count).
+#   2. PR must consist entirely of file deletions (no additions or modifications).
+#   3. PR must delete at most 3 files.
 on:
   pull_request_target:
     types:
@@ -48,7 +47,7 @@ jobs:
       && github.actor != 'github-actions[bot]'
       && github.actor != 'allcontributors[bot]'
     steps:
-      - name: Enforce first-time contributor PR policy
+      - name: Enforce new-contributor PR policy
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -59,133 +58,85 @@ jobs:
               return;
             }
 
-            const owner = context.repo.owner;         // "OWASP-BLT"
-            const repo  = context.repo.repo;
+            const owner       = context.repo.owner;   // "OWASP-BLT"
+            const repo        = context.repo.repo;
             const pull_number = pr.number;
-            const author = pr.user.login;
+            const author      = pr.user.login;
 
-            // Count PRIOR PRs across the OWASP-BLT org, EXCLUDING the current PR.
-            // We anchor the search to created:<pr.created_at so the just-opened PR is not counted.
+            // ── Gate 1: Org-wide prior PR count ──────────────────────────────
+            // Count PRs by this author in the org BEFORE the current PR was created.
             const createdAtIso = new Date(pr.created_at).toISOString();
             const q = `org:${owner} is:pr author:${author} created:<${createdAtIso}`;
-
-            const res = await github.request('GET /search/issues', { q, per_page: 1 });
-            const priorCount = res.data.total_count;
+            const searchRes = await github.request('GET /search/issues', { q, per_page: 1 });
+            const priorCount = searchRes.data.total_count;
 
             core.info(`Author ${author} has ${priorCount} prior PR(s) in ${owner} (excluding current PR).`);
 
-            // Policy: allow only if priorCount < 3; otherwise, comment and close.
-            if (priorCount < 3) {
-              core.info(`PR #${pull_number} allowed (priorCount < 3). No action taken.`);
-            core.info(`PR #${pull_number} changes ${files.length} file(s).`);
-            files.forEach(f => core.info(`  ${f.status}: ${f.filename}`));
-
-            // Accept PRs that only delete files, with a count between 1 and 20
-            const MAX_DELETIONS = 20;
-            const allFilesDeleted = files.length >= 1 && files.every(f => f.status === 'removed');
-            const withinDeletionLimit = files.length <= MAX_DELETIONS;
-            const onlyFileDeletions = allFilesDeleted && withinDeletionLimit;
-
-            let closeReason = null;
-            let message = null;
-
-            if (!isFirstTimeContributor) {
-              // Any PR from a returning contributor is automatically closed.
-              closeReason = `returning contributor (${authorAssociation}) — only first-time contributors may submit PRs`;
-
-              // Look up the author's previous merged PRs in this repository
-              let previousPRsSection = '';
-              try {
-                const previousPRs = await github.rest.search.issuesAndPullRequests({
-                  q: `repo:${owner}/${repo} is:pr is:merged author:${author}`,
-                  per_page: 5,
-                  sort: 'updated',
-                  order: 'desc',
-                });
-                const mergedPRs = previousPRs.data.items;
-                if (mergedPRs.length > 0) {
-                  const prLinks = mergedPRs
-                    .map(p => `  - [#${p.number}: ${p.title}](${p.html_url})`)
-                    .join('\n');
-                  previousPRsSection = [
-                    '',
-                    '📋 **Your previous merged contributions to this repository:**',
-                    prLinks,
-                  ].join('\n');
-                }
-              } catch (searchErr) {
-                core.warning(`Could not fetch previous PRs for ${author}.`);
-                core.debug(`Search error details: ${searchErr.message}`);
-              }
-
-              message = [
-                `👋 Hi @${author},`,
-                '',
-                '🚫 **This pull request has been automatically closed** because only **first-time contributors** (`FIRST_TIMER` or `FIRST_TIME_CONTRIBUTOR`) may submit pull requests to this repository at this time.',
-                '',
-                'Your GitHub account has previously contributed to this repository, so this PR does not qualify for automatic acceptance.',
-                previousPRsSection,
-                '',
-                '⚠️ **Please note:** Closed pull requests of this type are recorded and will count toward **negative scoring** on your contributor profile.',
-                '',
-                'If you believe this was closed in error, please open an issue to discuss it with the maintainers.',
-                '',
-                'Thank you for your understanding! 🙏',
+            if (priorCount > 3) {
+              const body = [
+                `👋 Hi @${author}, thanks for the PR!`,
+                ``,
+                `🚫 This repository currently only accepts pull requests from **new contributors**`,
+                `(**3 or fewer prior PRs across the ${owner} organization**).`,
+                ``,
+                `Our records show you have **${priorCount} prior PR(s)**, which exceeds the limit, so this PR is being closed.`,
+                ``,
+                `If you believe this was closed in error, please open an issue to discuss with the maintainers.`,
+                ``,
+                `Thank you for understanding.`,
               ].join('\n');
-            } else if (isFirstTimeContributor && !onlyFileDeletions) {
-              // First-time contributor whose PR is NOT a valid file-deletion PR
-              closeReason = `first-time contributor submitting a non-deletion or oversized PR`;
-              const tooManyFiles = allFilesDeleted && !withinDeletionLimit;
-              let condition2Text;
-              if (tooManyFiles) {
-                condition2Text = `Your PR deletes ${files.length} files, which exceeds the maximum of ${MAX_DELETIONS}.`;
-              } else {
-                condition2Text = 'Your PR contains changes other than file deletions (e.g., modifications or additions).';
-              }
-              message = [
-                `👋 Hi @${author}, thank you for your interest in contributing!`,
-                '',
-                `🚫 **This pull request has been automatically closed** because pull requests from first-time contributors are only accepted when they **delete between 1 and ${MAX_DELETIONS} files** with no other changes.`,
-                '',
-                'The conditions that must both be true for a first-time contributor\'s PR to be accepted are:',
-                '',
-                '1. **You have not previously contributed** to this repository',
-                `2. **The PR deletes between 1 and ${MAX_DELETIONS} files** with no other changes`,
-                '',
-                `Your PR does not meet condition 2. ${condition2Text}`,
-                '',
-                '⚠️ **Please note:** Closed pull requests of this type are recorded and will count toward **negative scoring** on your contributor profile.',
-                '',
-                'If you believe this was closed in error, please open an issue to discuss it with the maintainers before resubmitting.',
-                '',
-                '**We warmly welcome genuine contributions!** Here are some great ways to get started:',
-                '- Browse issues labeled [`good first issue`](../../labels/good%20first%20issue)',
-                '- Fix a bug or implement a requested feature',
-                '- Improve tests or documentation in a meaningful way',
-                '',
-                'Thank you for your understanding! 🙏',
-              ].join('\n');
-            }
 
-            if (!closeReason) {
-              core.info(`PR #${pull_number} does not match any auto-close condition. No action taken.`);
+              await github.rest.issues.createComment({ owner, repo, issue_number: pull_number, body });
+              await github.rest.pulls.update({ owner, repo, pull_number, state: 'closed' });
+              core.info(`PR #${pull_number} closed (priorCount ${priorCount} > 3).`);
               return;
             }
 
-            const body = [
-              `👋 Hi @${author}, thanks for the PR!`,
-              ``,
-              `🚫 This repository currently only accepts pull requests from **new contributors** `,
-              `(**fewer than 3 prior PRs across the ${owner} organization**).`,
-              ``,
-              `Our records show you have reached this limit, so this PR is being closed.`,
-              ``,
-              `If you believe this was closed in error, please open an issue to discuss with the maintainers.`,
-              ``,
-              `Thank you for understanding.`,
-            ].join('\n');
+            // ── Gate 2: File-deletion policy ─────────────────────────────────
+            // PR must consist entirely of file deletions, and at most 3 files.
+            const MAX_DELETIONS = 3;
+            const filesRes = await github.rest.pulls.listFiles({
+              owner,
+              repo,
+              pull_number,
+              per_page: 100,
+            });
+            const files = filesRes.data;
 
-            await github.rest.issues.createComment({ owner, repo, issue_number: pull_number, body });
-            await github.rest.pulls.update({ owner, repo, pull_number, state: 'closed' });
+            core.info(`PR #${pull_number} changes ${files.length} file(s).`);
+            files.forEach(f => core.info(`  ${f.status}: ${f.filename}`));
 
-            core.info(`PR #${pull_number} closed (priorCount >= 3).`);
+            const allDeleted   = files.length >= 1 && files.every(f => f.status === 'removed');
+            const withinLimit  = files.length <= MAX_DELETIONS;
+
+            if (!allDeleted || !withinLimit) {
+              let reason;
+              if (!allDeleted) {
+                const nonDeleted = files.filter(f => f.status !== 'removed').map(f => `\`${f.filename}\``).join(', ');
+                reason = `This PR contains changes other than file deletions (${nonDeleted}), which is not permitted.`;
+              } else {
+                reason = `This PR deletes **${files.length} files**, which exceeds the maximum of **${MAX_DELETIONS}** file deletions allowed.`;
+              }
+
+              const body = [
+                `👋 Hi @${author}, thanks for the PR!`,
+                ``,
+                `🚫 This PR has been closed because it does not meet the contribution policy.`,
+                ``,
+                reason,
+                ``,
+                `**Policy for new contributors:** PRs must consist entirely of file deletions, with at most ${MAX_DELETIONS} files deleted.`,
+                ``,
+                `If you believe this was closed in error, please open an issue to discuss with the maintainers.`,
+                ``,
+                `Thank you for understanding.`,
+              ].join('\n');
+
+              await github.rest.issues.createComment({ owner, repo, issue_number: pull_number, body });
+              await github.rest.pulls.update({ owner, repo, pull_number, state: 'closed' });
+              core.info(`PR #${pull_number} closed (file policy: allDeleted=${allDeleted}, count=${files.length}).`);
+              return;
+            }
+
+            // ── All gates passed ─────────────────────────────────────────────
+            core.info(`PR #${pull_number} allowed (priorCount=${priorCount} <= 3, ${files.length} file(s) all deleted).`);

--- a/.github/workflows/close-single-file-deletion-prs.yml
+++ b/.github/workflows/close-single-file-deletion-prs.yml
@@ -88,7 +88,9 @@ jobs:
               ``,
               `Our records show you have reached this limit, so this PR is being closed.`,
               ``,
-              `If you believe this was closed in error, please open an issue to discuss.`,
+              `If you believe this was closed in error, please open an issue to discuss with the maintainers.`,
+              ``,
+              `Thank you for understanding.`,
             ].join('\n');
 
             await github.rest.issues.createComment({ owner, repo, issue_number: pull_number, body });

--- a/.github/workflows/close-single-file-deletion-prs.yml
+++ b/.github/workflows/close-single-file-deletion-prs.yml
@@ -59,101 +59,39 @@ jobs:
               return;
             }
 
-            const owner = context.repo.owner;
-            const repo = context.repo.repo;
+            const owner = context.repo.owner;         // "OWASP-BLT"
+            const repo  = context.repo.repo;
             const pull_number = pr.number;
-            const authorAssociation = pr.author_association;
             const author = pr.user.login;
 
-            core.info(`PR #${pull_number} by ${author} (association: ${authorAssociation})`);
+            // Count PRIOR PRs across the OWASP-BLT org, EXCLUDING the current PR.
+            // We anchor the search to created:<pr.created_at so the just-opened PR is not counted.
+            const createdAtIso = new Date(pr.created_at).toISOString();
+            const q = `org:${owner} is:pr author:${author} created:<${createdAtIso}`;
 
-            // FIRST_TIMER: author has never made any commit on GitHub before (brand new GitHub user)
-            // FIRST_TIME_CONTRIBUTOR: author has committed elsewhere but never to this repository
-            const isFirstTimeContributor =
-              authorAssociation === 'FIRST_TIMER' ||
-              authorAssociation === 'FIRST_TIME_CONTRIBUTOR';
+            const res = await github.request('GET /search/issues', { q, per_page: 1 });
+            const priorCount = res.data.total_count;
 
-            // Get all files changed in the PR (with pagination)
-            const files = await github.paginate(github.rest.pulls.listFiles, {
-              owner,
-              repo,
-              pull_number,
-              per_page: 100,
-            });
+            core.info(`Author ${author} has ${priorCount} prior PR(s) in ${owner} (excluding current PR).`);
 
-            core.info(`PR #${pull_number} changes ${files.length} file(s).`);
-            files.forEach(f => core.info(`  ${f.status}: ${f.filename}`));
-
-            const onlyOneFileDeleted = files.length === 1 && files[0].status === 'removed';
-
-            let closeReason = null;
-            let message = null;
-
-            if (!isFirstTimeContributor) {
-              // Any PR from a returning contributor is automatically closed.
-              closeReason = `returning contributor (${authorAssociation}) — only first-time contributors may submit PRs`;
-              message = [
-                `👋 Hi @${author},`,
-                '',
-                '🚫 **This pull request has been automatically closed** because only **first-time contributors** (`FIRST_TIMER` or `FIRST_TIME_CONTRIBUTOR`) may submit pull requests to this repository at this time.',
-                '',
-                'Your GitHub account has previously contributed to this repository, so this PR does not qualify for automatic acceptance.',
-                '',
-                '⚠️ **Please note:** Closed pull requests of this type are recorded and will count toward **negative scoring** on your contributor profile.',
-                '',
-                'If you believe this was closed in error, please open an issue to discuss it with the maintainers.',
-                '',
-                'Thank you for your understanding! 🙏',
-              ].join('\n');
-            } else if (isFirstTimeContributor && !onlyOneFileDeleted) {
-              // First-time contributor whose PR is NOT a single-file deletion
-              closeReason = `first-time contributor submitting a non-single-file-deletion PR`;
-              message = [
-                `👋 Hi @${author}, thank you for your interest in contributing!`,
-                '',
-                '🚫 **This pull request has been automatically closed** because pull requests from first-time contributors are only accepted when they **delete exactly one file**.',
-                '',
-                'The conditions that must both be true for a first-time contributor\'s PR to be accepted are:',
-                '',
-                '1. **You have not previously contributed** to this repository',
-                '2. **The PR deletes exactly one file** with no other changes',
-                '',
-                'Your PR does not meet condition 2.',
-                '',
-                '⚠️ **Please note:** Closed pull requests of this type are recorded and will count toward **negative scoring** on your contributor profile.',
-                '',
-                'If you believe this was closed in error, please open an issue to discuss it with the maintainers before resubmitting.',
-                '',
-                '**We warmly welcome genuine contributions!** Here are some great ways to get started:',
-                '- Browse issues labeled [`good first issue`](../../labels/good%20first%20issue)',
-                '- Fix a bug or implement a requested feature',
-                '- Improve tests or documentation in a meaningful way',
-                '',
-                'Thank you for your understanding! 🙏',
-              ].join('\n');
-            }
-
-            if (!closeReason) {
-              core.info(`PR #${pull_number} does not match any auto-close condition. No action taken.`);
+            // Policy: allow only if priorCount < 3; otherwise, comment and close.
+            if (priorCount < 3) {
+              core.info(`PR #${pull_number} allowed (priorCount < 3). No action taken.`);
               return;
             }
 
-            core.info(`Closing PR #${pull_number}: ${closeReason}.`);
+            const body = [
+              `👋 Hi @${author}, thanks for the PR!`,
+              ``,
+              `🚫 This repository currently only accepts pull requests from **new contributors** `,
+              `(**fewer than 3 prior PRs across the ${owner} organization**).`,
+              ``,
+              `Our records show you have reached this limit, so this PR is being closed.`,
+              ``,
+              `If you believe this was closed in error, please open an issue to discuss.`,
+            ].join('\n');
 
-            // Post an explanatory comment on the PR
-            await github.rest.issues.createComment({
-              owner,
-              repo,
-              issue_number: pull_number,
-              body: message,
-            });
+            await github.rest.issues.createComment({ owner, repo, issue_number: pull_number, body });
+            await github.rest.pulls.update({ owner, repo, pull_number, state: 'closed' });
 
-            // Close the PR
-            await github.rest.pulls.update({
-              owner,
-              repo,
-              pull_number,
-              state: 'closed',
-            });
-
-            core.info(`PR #${pull_number} has been closed with an explanatory comment.`);
+            core.info(`PR #${pull_number} closed (priorCount >= 3).`);


### PR DESCRIPTION
Summary:-
What happened before was that it was counting the PR just opened also, so due to that each new contributor also had one open PR which got closed then. 
So This PR fixes this gate that was incorrectly closing valid new‑contributor PRs. We now allow PRs in BLT when the author has fewer than 3 prior PRs across the OWASP‑BLT organization (excluding the PR being opened). Authors at or above the threshold receive a clear comment and the PR is closed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * PR-closure logic now enforces a new-contributor policy using an author’s org-wide prior-PR count and a simplified deletion limit (max 3 deletions); decisions use a single standardized closure path.

* **Bug Fix**
  * Fixed workflow behavior that could mis-handle prior-PR counting, preventing unexpected closure or failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->