### PR TITLE
fix: resolve ValueError in award_streak_badges preventing badges from being awarded

### DIFF
--- a/website/models.py
+++ b/website/models.py
@@ -1173,8 +1173,18 @@ class UserProfile(models.Model):
 
         for milestone, badge_title in streak_badges.items():
             if self.current_streak >= milestone:
-                badge, _ = Badge.objects.get(
+                # Use get_or_create() to safely fetch or create the badge.
+                # Badge.objects.get() returns a single object, not a (instance, created)
+                # tuple — tuple-unpacking it raises ValueError at runtime, silently
+                # swallowed by the outer try/except and breaking badge awards for all users.
+                badge, _ = Badge.objects.get_or_create(
                     title=badge_title,
+                    defaults={
+                        "description": (
+                            f"Awarded for maintaining a {badge_title.lower()} check-in streak."
+                        ),
+                        "type": "automatic",
+                    },
                 )
 
                 # Avoid duplicate badge awards

--- a/website/tests/test_streak_badges.py
+++ b/website/tests/test_streak_badges.py
@@ -1,0 +1,94 @@
+"""
+Regression tests for award_streak_badges() on UserProfile.
+
+This test file covers the silent ValueError bug caused by using
+Badge.objects.get() (returns a single object) instead of
+Badge.objects.get_or_create() (returns a (object, created) tuple),
+which made tuple-unpacking fail silently, preventing streak badges
+from ever being awarded to any user.
+"""
+
+from django.contrib.auth.models import User
+from django.test import TestCase
+
+from website.models import Badge, UserBadge, UserProfile
+
+
+class AwardStreakBadgesTest(TestCase):
+    """Tests that streak badges are correctly awarded at milestones."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = User.objects.create_user(
+            username="streakuser",
+            email="streak@example.com",
+            password="testpass123",
+        )
+
+    def test_award_badge_at_7_day_milestone_no_valueerror(self):
+        """
+        Reaching a 7-day streak must award a badge without raising ValueError.
+
+        Regression test: Badge.objects.get() was incorrectly tuple-unpacked as
+        `badge, _ = Badge.objects.get(...)`, which raises ValueError because
+        get() returns a single object, not a (instance, created) tuple.
+        The exception was silently swallowed, so badges were never awarded.
+        """
+        profile = self.user.userprofile
+        profile.current_streak = 7
+
+        try:
+            profile.award_streak_badges()
+        except ValueError as exc:
+            self.fail(
+                f"award_streak_badges() raised ValueError: {exc}. "
+                "Ensure Badge.objects.get_or_create() is used, not get()."
+            )
+
+        badge = Badge.objects.filter(title="Weekly Streak").first()
+        self.assertIsNotNone(badge, "Weekly Streak badge should be created after milestone")
+        self.assertTrue(
+            UserBadge.objects.filter(user=self.user, badge=badge).exists(),
+            "UserBadge record should exist for the user after reaching milestone",
+        )
+
+    def test_no_duplicate_badge_on_repeated_calls(self):
+        """Calling award_streak_badges twice must not create duplicate UserBadge records."""
+        profile = self.user.userprofile
+        profile.current_streak = 7
+
+        profile.award_streak_badges()
+        profile.award_streak_badges()
+
+        count = UserBadge.objects.filter(
+            user=self.user, badge__title="Weekly Streak"
+        ).count()
+        self.assertEqual(count, 1, "Badge must only be awarded once per milestone")
+
+    def test_no_badge_below_milestone(self):
+        """Users below the 7-day threshold must receive no badge."""
+        profile = self.user.userprofile
+        profile.current_streak = 6  # One below the 7-day milestone
+
+        profile.award_streak_badges()
+
+        self.assertFalse(
+            UserBadge.objects.filter(user=self.user).exists(),
+            "No badge should be awarded when streak is below any milestone",
+        )
+
+    def test_multiple_milestones_award_multiple_badges(self):
+        """A streak of 30 should award the 7-day, 15-day, and 30-day badges."""
+        profile = self.user.userprofile
+        profile.current_streak = 30
+
+        profile.award_streak_badges()
+
+        awarded_titles = set(
+            UserBadge.objects.filter(user=self.user).values_list(
+                "badge__title", flat=True
+            )
+        )
+        self.assertIn("Weekly Streak", awarded_titles, "7-day badge should be awarded")
+        self.assertIn("Half-Month Streak", awarded_titles, "15-day badge should be awarded")
+        self.assertIn("Monthly Streak", awarded_titles, "30-day badge should be awarded")


### PR DESCRIPTION
## Summary
Fixes a runtime bug in `award_streak_badges()` that prevented badges from being awarded.

## Problem
`Badge.objects.get()` returns a single object, but the code tuple-unpacked it as `(badge, _)`, causing a `ValueError`.  
This error was silently caught, so badges were never awarded.

## Fix
Replaced with `get_or_create()` which correctly returns `(instance, created)` and handles missing badge rows.

## Tests
Added regression tests to verify:
- badge awarding works
- no duplicates
- correct milestone behavior

## Impact
All users were affected — no streak badges were being awarded.

Fixes #6087

## Note
`Badge.title` does not currently have a unique constraint, which may allow duplicate rows under concurrency.  
This PR focuses on fixing the runtime bug; I can open a follow-up PR to add a uniqueness constraint if needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Streak milestone badges are now automatically created when users reach specific streak thresholds (7-day, 30-day, etc.) with auto-generated descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->