### PR TITLE
test: document edge-case limitation in repetitive content spam detection

### DIFF
--- a/website/tests/test_spam_edge_cases.py
+++ b/website/tests/test_spam_edge_cases.py
@@ -1,0 +1,24 @@
+from django.test import TestCase
+from website.spam_checker import calculate_spam_score
+
+class SpamCheckerEdgeCaseTest(TestCase):
+
+    def test_repetitive_emojis_not_detected(self):
+        # 100 emojis with no spaces
+        description = "😂" * 100
+        markdown_description = ""
+
+        # Run it through the scanner
+        result = calculate_spam_score(
+            description=description,
+            markdown_description=markdown_description,
+            user=None,
+            reporter_ip="127.0.0.1",
+        )
+
+        # Documenting the weakness: Currently, the system DOES NOT flag this as spam.
+        # We assert False so the test passes, but it highlights the logic gap.
+        self.assertFalse(
+            result["is_spam"],
+            "LIMITATION: Repetitive emojis without spaces bypass the spam filter."
+        )


### PR DESCRIPTION
### What does this PR do?
Adds a unit test documenting an edge case in `website/spam_checker.py` where repetitive content without spaces bypasses the spam filter.

### Background
While reviewing the `is_repetitive_content` helper, I noticed it tokenizes input using `.split()`. This creates a blind spot: if a user or bot submits a long string of repeated characters or emojis (e.g., `"😂" * 100`), the engine evaluates it as a single unique token. Because the `unique_ratio` remains artificially high (1/1), the content evades the spam flag. 

### Implementation Notes
* This is a **test-only** PR to prove the edge case and establish a baseline.
* The test currently asserts `False` for the spam check. This ensures the CI pipeline stays green while explicitly documenting the known limitation.

### Discussion / Next Steps
I held off on modifying the core logic because I wanted to align with the team's preferred approach first. To catch this, would you prefer:
1. Moving to regex-based tokenization?
2. Adding a character-level entropy check?

Happy to write the actual patch once we agree on the best architectural direction!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for emoji pattern handling in spam detection validation to document current system behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->