### PR TITLE
a11y: add aria-labels to footer social icon links

### DIFF
--- a/website/templates/home.html
+++ b/website/templates/home.html
@@ -1410,8 +1410,8 @@
             <div class="max-w-7xl mx-auto text-center">
                 <p class="mb-4">Follow us on:</p>
                 <div class="flex justify-center space-x-6">
-                    <a href="https://x.com/OWASP_BLT" target="_blank"><i class="fab fa-x-twitter fa-2x"></i></a>
-                    <a href="https://github.com/OWASP-BLT" target="_blank"><i class="fab fa-github fa-2x"></i></a>
+                    <a href="https://x.com/OWASP_BLT" target="_blank" aria-label="Visit OWASP BLT on X (formerly Twitter)"><i class="fab fa-x-twitter fa-2x" aria-hidden="true"></i></a>
+                    <a href="https://github.com/OWASP-BLT" target="_blank" aria-label="Visit OWASP BLT on GitHub"><i class="fab fa-github fa-2x" aria-hidden="true"></i></a>
                 </div>
                 <!-- Email Support -->
                 <p class="mt-4 text-sm">


### PR DESCRIPTION
### Description
During a frontend audit, I noticed that several social media and external links (such as those in the footer and homepage) use FontAwesome icons without any accompanying screen-reader text. 

This causes Screen Readers to announce these elements generically as "Link," violating WCAG accessibility guidelines and reducing the platform's Lighthouse Accessibility score.

This PR injects descriptive `aria-label` attributes into the parent `<a>` tags and adds `aria-hidden="true"` to the decorative `<i>` tags to ensure full accessibility compliance for visually impaired users.

### Impact
- **Accessibility (a11y):** Ensures visually impaired users can properly navigate external links via Screen Readers.
- **Frontend Modernization:** Directly improves the Google Lighthouse Accessibility score for `home.html` and the global footer.

### Testing & UI
- **Visuals:** This is an under-the-hood DOM change. The visual UI remains exactly the same, so no UI screenshots are necessary.
- **Testing:** Verified the DOM Accessibility Tree in Chrome DevTools now correctly exposes the `aria-label` names (e.g., "Visit OWASP BLT on X") to screen reading software instead of empty nodes.

### Type of Change
- [x] Accessibility (a11y) Improvement
- [x] Frontend Refactor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced accessibility of social media links on the homepage for screen reader and assistive technology users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->