### PR TITLE
Fix typos: recieve -> receive, enviroment -> environment

### DIFF
--- a/website/static/js/jquery.caret.js
+++ b/website/static/js/jquery.caret.js
@@ -6,7 +6,7 @@
         });
     } else if (typeof exports === 'object') {
         // Node. Does not work with strict CommonJS, but
-        // only CommonJS-like enviroments that support module.exports,
+        // only CommonJS-like environments that support module.exports,
         // like Node.
         module.exports = factory(require("jquery"));
     } else {

--- a/website/templates/organization/bughunt/view_bughunt.html
+++ b/website/templates/organization/bughunt/view_bughunt.html
@@ -471,7 +471,7 @@
                                     <path d="M10 .5a9.5 9.5 0 1 0 9.5 9.5A9.51 9.51 0 0 0 10 .5Zm3.707 8.207-4 4a1 1 0 0 1-1.414 0l-2-2a1 1 0 0 1 1.414-1.414L9 10.586l3.293-3.293a1 1 0 0 1 1.414 1.414Z" />
                                 </svg>
                                 {% if reward.valid_submissions_eligible %}
-                                    <span class="text-base font-normal leading-tight text-gray-500 dark:text-gray-500">Each Accepted Bug will recieve ${{ reward.value }}</span>
+                                    <span class="text-base font-normal leading-tight text-gray-500 dark:text-gray-500">Each Accepted Bug will receive ${{ reward.value }}</span>
                                 {% else %}
                                     <span class="text-base font-normal leading-tight text-gray-500 dark:text-gray-500">Top {{ reward.no_of_eligible_projects }} Users</span>
                                 {% endif %}


### PR DESCRIPTION
Fixed two typos found across the codebase:
- `recieve` → `receive` in `view_bughunt.html`
- `enviroment` → `environment` in `jquery.caret.js`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Fixed spelling errors in reward descriptions and code documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->