### PR TITLE
fix: enforce domain boundary in OWASP hostname check CWE-183

### DIFF
--- a/website/api/views.py
+++ b/website/api/views.py
@@ -1230,7 +1230,7 @@ class OwaspComplianceChecker(APIView):
                 if not href:
                     continue
                 netloc = urlparse(href).netloc.lower()
-                if netloc.endswith("owasp.org"):
+                if netloc.endswith("owasp.org"): or netloc.endswith('.owasp.org"):
                     owasp_links.append(a)
 
             has_project_link = len(owasp_links) > 0

--- a/website/api/views.py
+++ b/website/api/views.py
@@ -1230,7 +1230,7 @@ class OwaspComplianceChecker(APIView):
                 if not href:
                     continue
                 netloc = urlparse(href).netloc.lower()
-                if netloc.endswith("owasp.org"): or netloc.endswith('.owasp.org"):
+                if netloc == "owasp.org" or netloc.endswith(".owasp.org"):
                     owasp_links.append(a)
 
             has_project_link = len(owasp_links) > 0


### PR DESCRIPTION
## Summary

Fixes a subdomain boundary bypass in `check_website_compliance()` where `netloc.endswith("owasp.org")` incorrectly accepts arbitrary domains such as `evilowasp.org`, `nowasp.org`, or any string that happens to end with the substring `owasp.org`.

## Root Cause

`str.endswith()` is a substring check with no awareness of domain structure. Without a dot boundary, it matches on character sequence alone:

```
evilowasp.org  → endswith("owasp.org") → True  ✗
nowasp.org     → endswith("owasp.org") → True  ✗
wiki.owasp.org → endswith("owasp.org") → True  ✓
owasp.org      → endswith("owasp.org") → True  ✓
```

This means the compliance check — intended to verify that a project page links back to the official OWASP domain — can be satisfied by a link to an attacker-controlled domain whose name ends in `owasp.org`.

## Fix

```python
# Before
if netloc.endswith("owasp.org"):

# After
if netloc == "owasp.org" or netloc.endswith(".owasp.org"):
```

The dot prefix enforces a proper label boundary. Only `owasp.org` itself and legitimate subdomains (`wiki.owasp.org`, `cheatsheetseries.owasp.org`, etc.) are accepted.

## Impact

The `OwaspComplianceChecker` API is used to evaluate whether a project's website legitimately references OWASP. Without this fix, a non-OWASP site could pass the `has_project_link` compliance check by including a link to a lookalike domain, producing a false-positive `compliant` result.

## References
- CWE-183: Permissive List of Allowed Inputs
- Related: the comment directly above this block already reads "strict hostname check" — this fix makes the implementation match its own documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OWASP link detection in website compliance scanning to recognize both the primary owasp.org domain and its subdomains (e.g., anything ending with .owasp.org). This yields more accurate detection of project links, improving the computed project-link presence and resulting compliance outcomes without changing returned fields or response structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->