### PR TITLE
Add workflow to generate first-time contributors report

### DIFF
--- a/.github/workflows/first-time-contributors.yml
+++ b/.github/workflows/first-time-contributors.yml
@@ -1,0 +1,196 @@
+name: Build first-time contributor JSON (org-wide)
+
+on:
+  workflow_dispatch:
+    inputs:
+      org:
+        description: GitHub org to scan
+        default: OWASP-BLT
+        required: true
+      since:
+        description: Cutoff date (ISO, merged after this); default is April 2, 2026
+        default: "2026-04-02"
+        required: true
+  schedule:
+    - cron: "15 7 * * *"  # daily at 07:15 UTC
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  build-json:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build first-time contributors JSON
+        id: build
+        uses: actions/github-script@v7
+        env:
+          ORG: ${{ inputs.org || 'OWASP-BLT' }}
+          SINCE: ${{ inputs.since || '2026-04-02' }}
+          OUT_PATH: data/first_time_contributors.json
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+
+            const org   = process.env.ORG   || 'OWASP-BLT';
+            const since = process.env.SINCE || '2026-04-02';
+            const outPath = process.env.OUT_PATH || 'data/first_time_contributors.json';
+
+            const bots = new Set([
+              'github-actions[bot]',
+              'dependabot[bot]',
+              'owasp-blt[bot]',
+              'coderabbitai[bot]'
+            ]);
+
+            function isBot(login) {
+              if (!login) return true;
+              const lower = login.toLowerCase();
+              return lower.endsWith('[bot]') || bots.has(lower);
+            }
+
+            // 1) Find merged PRs since cutoff across the org
+            const q = `org:${org} is:pr is:merged merged:>=${since}`;
+            core.info(`[search] ${q}`);
+
+            const mergedItems = await github.paginate(
+              github.rest.search.issuesAndPullRequests,
+              { q, per_page: 100 },
+              (res) => res.data.items
+            );
+
+            // 2) Per-author, pick earliest merged PR after cutoff
+            const perAuthor = new Map();
+            for (const it of mergedItems) {
+              const login = it.user && it.user.login ? it.user.login : null;
+              if (!login || isBot(login)) continue;            // skip bots/apps
+              if (!it.pull_request) continue;                  // only PRs
+              // We still need merged_at; fetch PR fully for accuracy
+              const repoFull = it.repository_url.split('/').slice(-2).join('/');
+              const [owner, repo] = repoFull.split('/');
+              const prNum = it.number;
+              const pr = await github.rest.pulls.get({ owner, repo, pull_number: prNum });
+              const mAt = pr.data.merged_at;
+              if (!mAt) continue;
+              if (new Date(mAt) < new Date(since)) continue;   // just-in-case guard
+
+              const prev = perAuthor.get(login);
+              if (!prev || new Date(mAt) < new Date(prev.firstMergedAt)) {
+                perAuthor.set(login, {
+                  login,
+                  firstMergedAt: mAt,
+                  pr: {
+                    owner, repo, number: prNum,
+                    title: it.title,
+                    url: it.html_url,
+                    merged_at: mAt
+                  }
+                });
+              }
+            }
+
+            // 3) Keep only those with NO prior merged PRs before SINCE (org-wide)
+            async function priorMergedCountBefore(login) {
+              const qPrior = `org:${org} is:pr is:merged author:${login} merged:<${since}`;
+              const r = await github.request('GET /search/issues', { q: qPrior, per_page: 1 });
+              return r.data.total_count || 0;
+            }
+
+            const firstTimers = [];
+            for (const [login, data] of perAuthor.entries()) {
+              const cnt = await priorMergedCountBefore(login);
+              if (cnt === 0) firstTimers.push(data);
+            }
+
+            // 4) Hydrate user profile + sponsors existence (HEAD to sponsors page)
+            async function getUser(login) {
+              const r = await github.rest.users.getByUsername({ username: login });
+              return r.data || {};
+            }
+
+            async function sponsorsExists(login) {
+              const url = `https://github.com/sponsors/${login}`;
+              try {
+                // Try HEAD; treat 200/301/302/307/308 as exists
+                const res = await fetch(url, { method: 'HEAD', redirect: 'manual' });
+                return {
+                  exists: (res.status && res.status < 400),
+                  url
+                };
+              } catch {
+                return { exists: false, url };
+              }
+            }
+
+            const contributors = [];
+            for (const ent of firstTimers) {
+              const u = await getUser(ent.login);
+              const sp = await sponsorsExists(ent.login);
+
+              contributors.push({
+                login: ent.login,
+                name: u.name || null,
+                profile_url: u.html_url || `https://github.com/${ent.login}`,
+                first_merged_pr: {
+                  repo: `${ent.pr.owner}/${ent.pr.repo}`,
+                  number: ent.pr.number,
+                  title: ent.pr.title,
+                  url: ent.pr.url,
+                  merged_at: ent.pr.merged_at
+                },
+                sponsors: {
+                  exists: sp.exists,
+                  url: sp.url
+                },
+                paid: null,
+                notes: ""
+              });
+            }
+
+            // Sort by merged_at ascending (earliest first)
+            contributors.sort((a,b) => new Date(a.first_merged_pr.merged_at) - new Date(b.first_merged_pr.merged_at));
+
+            // 5) Load any existing JSON and merge on login (keep your paid/notes if present)
+            let existing = { generated_at: null, since, contributors: [] };
+            if (fs.existsSync(outPath)) {
+              try {
+                existing = JSON.parse(fs.readFileSync(outPath, 'utf8'));
+              } catch {}
+            }
+            const byLogin = new Map((existing.contributors || []).map(c => [c.login.toLowerCase(), c]));
+            for (const c of contributors) {
+              const key = c.login.toLowerCase();
+              if (byLogin.has(key)) {
+                const old = byLogin.get(key);
+                // preserve manual fields
+                c.paid  = old.paid  ?? c.paid;
+                c.notes = old.notes ?? c.notes;
+              }
+              byLogin.set(key, c);
+            }
+
+            const merged = Array.from(byLogin.values());
+            // Write directory and file
+            fs.mkdirSync(path.dirname(outPath), { recursive: true });
+            const payload = {
+              generated_at: new Date().toISOString(),
+              since,
+              contributors: merged
+            };
+            fs.writeFileSync(outPath, JSON.stringify(payload, null, 2));
+            core.info(`Wrote ${outPath} with ${merged.length} contributors`);
+
+            // Expose a small summary
+            core.setOutput('count', String(merged.length));
+
+      - name: Commit JSON
+        uses: EndBug/add-and-commit@v9
+        with:
+          add: "first_time_contributors.json"
+          message: "chore: update first-time contributors JSON [skip ci]"
+          default_author: github_actions

--- a/.github/workflows/first-time-contributors.yml
+++ b/.github/workflows/first-time-contributors.yml
@@ -1,4 +1,4 @@
-name: Build first-time contributor JSON (org-wide)
+name: Build first-time contributor in README(org-wide)
 
 on:
   workflow_dispatch:
@@ -14,24 +14,25 @@ on:
   schedule:
     - cron: "15 7 * * *"  # daily at 07:15 UTC
 
+concurrency:
+   group: ${{ github.workflow }}-${{ github.event_name }}
+   cancel-in-progress: false
+
 permissions:
   contents: write
-  issues: read
-  pull-requests: read
 
 jobs:
-  build-json:
+  build-readme:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
-      - name: Build first-time contributors JSON
+      - name: Update first-time contributors in README
         id: build
         uses: actions/github-script@v7
         env:
           ORG: ${{ inputs.org || 'OWASP-BLT' }}
           SINCE: ${{ inputs.since || '2026-04-02' }}
-          OUT_PATH: first_time_contributors.json
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -51,6 +52,12 @@ jobs:
               const lower = login.toLowerCase();
               return lower.endsWith('[bot]') || bots.has(lower);
             }
+            
+            const clean = (s) =>
+              String(s || '')
+                .replace(/\|/g, '\\|')
+                .replace(/\n/g, ' ')
+                .trim();
 
             // 1) Fetch merged PRs (Search API)
             const q = `org:${org} is:pr is:merged merged:>=${since}`;
@@ -68,7 +75,7 @@ jobs:
               if (!login || isBot(login)) continue;
               if (!it.pull_request) continue;
 
-              const mAt = it.updated_at;
+              const mAt = it.closed_at;
               if (!mAt) continue;
 
               const repoFull = it.repository_url.split('/').slice(-2).join('/');
@@ -149,7 +156,7 @@ jobs:
             table += `|------------|----------|----------|\n`;
 
             for (const c of contributors) {
-              const name = c.name || c.login;
+              const name = clean(c.name || c.login);
               const sponsor = c.sponsors.exists
                 ? `[Yes](${c.sponsors.url})`
                 : `No`;
@@ -163,20 +170,22 @@ jobs:
               ? fs.readFileSync(readmePath, 'utf8')
               : '';
 
-            const marker = "## First-time Contributors";
             const START = "<!-- FIRST_TIME_CONTRIBUTORS_START -->";
             const END = "<!-- FIRST_TIME_CONTRIBUTORS_END -->";
+            const escapeRegex = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
             const section = `${START}\n${table}\n${END}`;
 
             let updated;
             if (readme.includes(START) && readme.includes(END)) {
-              const regex = new RegExp(`${START}[\\s\\S]*${END}`, 'm');
+              const escapedStart = escapeRegex(START);
+              const escapedEnd = escapeRegex(END);
+              const regex = new RegExp(`${escapedStart}[\\s\\S]*?${escapedEnd}`, 'm');
               updated = readme.replace(regex, section);
             } else {
               updated = readme + `\n\n${section}`;
             }
-            
+
             // 8) Write only if changed
             if (readme !== updated) {
               fs.writeFileSync(readmePath, updated);

--- a/.github/workflows/first-time-contributors.yml
+++ b/.github/workflows/first-time-contributors.yml
@@ -36,11 +36,8 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const fs = require('fs');
-            const path = require('path');
-
             const org   = process.env.ORG   || 'OWASP-BLT';
             const since = process.env.SINCE || '2026-04-02';
-            const outPath = process.env.OUT_PATH || 'first_time_contributors.json';
 
             const bots = new Set([
               'github-actions[bot]',
@@ -55,29 +52,27 @@ jobs:
               return lower.endsWith('[bot]') || bots.has(lower);
             }
 
-            // 1) Find merged PRs since cutoff across the org
+            // 1) Fetch merged PRs (Search API)
             const q = `org:${org} is:pr is:merged merged:>=${since}`;
-            core.info(`[search] ${q}`);
-
             const mergedItems = await github.paginate(
               github.rest.search.issuesAndPullRequests,
               { q, per_page: 100 },
               (res) => res.data.items
             );
 
-            // 2) Per-author, pick earliest merged PR after cutoff
+            // 2) Extract contributors (NO pulls.get)
             const perAuthor = new Map();
+
             for (const it of mergedItems) {
-              const login = it.user && it.user.login ? it.user.login : null;
-              if (!login || isBot(login)) continue;            // skip bots/apps
-              if (!it.pull_request) continue;                  // only PRs
-              // We still need merged_at; fetch PR fully for accuracy
+              const login = it.user?.login;
+              if (!login || isBot(login)) continue;
+              if (!it.pull_request) continue;
+
+              const mAt = it.updated_at;
+              if (!mAt) continue;
+
               const repoFull = it.repository_url.split('/').slice(-2).join('/');
               const [owner, repo] = repoFull.split('/');
-              const prNum = it.number;
-              const mAt = it.pull_request?.merged_at;
-              if (!mAt) continue;
-              if (new Date(mAt) < new Date(since)) continue;   // just-in-case guard
 
               const prev = perAuthor.get(login);
               if (!prev || new Date(mAt) < new Date(prev.firstMergedAt)) {
@@ -85,7 +80,9 @@ jobs:
                   login,
                   firstMergedAt: mAt,
                   pr: {
-                    owner, repo, number: prNum,
+                    owner,
+                    repo,
+                    number: it.number,
                     title: it.title,
                     url: it.html_url,
                     merged_at: mAt
@@ -94,7 +91,7 @@ jobs:
               }
             }
 
-            // 3) Keep only those with NO prior merged PRs before SINCE (org-wide)
+            // 3) Filter true first-timers
             async function priorMergedCountBefore(login) {
               const qPrior = `org:${org} is:pr is:merged author:${login} merged:<${since}`;
               const r = await github.request('GET /search/issues', { q: qPrior, per_page: 1 });
@@ -107,7 +104,7 @@ jobs:
               if (cnt === 0) firstTimers.push(data);
             }
 
-            // 4) Hydrate user profile + sponsors existence (HEAD to sponsors page)
+            // 4) Get user + sponsors (FIXED redirect handling)
             async function getUser(login) {
               const r = await github.rest.users.getByUsername({ username: login });
               return r.data || {};
@@ -116,10 +113,9 @@ jobs:
             async function sponsorsExists(login) {
               const url = `https://github.com/sponsors/${login}`;
               try {
-                // Try HEAD; treat 200/301/302/307/308 as exists
                 const res = await fetch(url, { method: 'HEAD', redirect: 'manual' });
                 return {
-                  exists: (res.status && res.status < 400),
+                  exists: (res.status && res.status < 400) || res.type === 'opaqueredirect',
                   url
                 };
               } catch {
@@ -127,6 +123,7 @@ jobs:
               }
             }
 
+            // 5) Build contributors list
             const contributors = [];
             for (const ent of firstTimers) {
               const u = await getUser(ent.login);
@@ -136,85 +133,64 @@ jobs:
                 login: ent.login,
                 name: u.name || null,
                 profile_url: u.html_url || `https://github.com/${ent.login}`,
-                first_merged_pr: {
-                  repo: `${ent.pr.owner}/${ent.pr.repo}`,
-                  number: ent.pr.number,
-                  title: ent.pr.title,
-                  url: ent.pr.url,
-                  merged_at: ent.pr.merged_at
-                },
-                sponsors: {
-                  exists: sp.exists,
-                  url: sp.url
-                },
-                paid: null,
-                notes: ""
+                pr: ent.pr,
+                sponsors: sp
               });
             }
 
-            // Sort by merged_at ascending (earliest first)
-            contributors.sort((a,b) => new Date(a.first_merged_pr.merged_at) - new Date(b.first_merged_pr.merged_at));
+            // Sort
+            contributors.sort((a, b) =>
+              new Date(a.pr.merged_at) - new Date(b.pr.merged_at)
+            );
 
-            // 5) Load any existing JSON and merge on login (keep your paid/notes if present)
-            let existing = { generated_at: null, since, contributors: [] };
-            if (fs.existsSync(outPath)) {
-              try {
-                existing = JSON.parse(fs.readFileSync(outPath, 'utf8'));
-              } catch {}
-            }
-            const byLogin = new Map((existing.contributors || []).map(c => [c.login.toLowerCase(), c]));
+            // 6) Generate README section
+            let table = `## First-time Contributors (since ${since})\n\n`;
+            table += `| Contributor | First PR | Sponsors |\n`;
+            table += `|------------|----------|----------|\n`;
+
             for (const c of contributors) {
-              const key = c.login.toLowerCase();
-              if (byLogin.has(key)) {
-                const old = byLogin.get(key);
-                // preserve manual fields
-                c.paid  = old.paid  ?? c.paid;
-                c.notes = old.notes ?? c.notes;
-              }
-              byLogin.set(key, c);
+              const name = c.name || c.login;
+              const sponsor = c.sponsors.exists
+                ? `[Yes](${c.sponsors.url})`
+                : `No`;
+
+              table += `| [${name}](${c.profile_url}) | [#${c.pr.number}](${c.pr.url}) | ${sponsor} |\n`;
             }
 
-            const merged = Array.from(byLogin.values());
-            merged.sort((a, b) => {
-               const mergedAtDiff =
-                 new Date(a.first_merged_pr.merged_at) - new Date(b.first_merged_pr.merged_at);
-               if (mergedAtDiff !== 0) {
-                 return mergedAtDiff;
-               }
-               return a.login.localeCompare(b.login);
-             });
-            const nextComparablePayload = {
-              since,
-              contributors: merged
-            };
-            const existingComparablePayload = {
-               since: existing.since ?? since,
-               contributors: existing.contributors || []
-             };
-             const hasChanged =
-               JSON.stringify(existingComparablePayload) !== JSON.stringify(nextComparablePayload);
-             if (hasChanged) {
-               // Write directory and file only when contributor data changes
-               fs.mkdirSync(path.dirname(outPath), { recursive: true });
-               const payload = {
-                 generated_at: new Date().toISOString(),
-                 since,
-                 contributors: merged
-               };
-               fs.writeFileSync(outPath, JSON.stringify(payload, null, 2));
-               core.info(`Wrote ${outPath} with ${merged.length} contributors`);
-             } else {
-               core.info(`No contributor changes detected; skipped writing ${outPath}`);
-             }
+            // 7) Inject into README
+            const readmePath = 'README.md';
+            let readme = fs.existsSync(readmePath)
+              ? fs.readFileSync(readmePath, 'utf8')
+              : '';
 
-            // Expose a small summary
-            core.setOutput('count', String(merged.length));
-            core.setOutput('changed', hasChanged ? 'true' : 'false');
+            const marker = "## First-time Contributors";
+            const START = "<!-- FIRST_TIME_CONTRIBUTORS_START -->";
+            const END = "<!-- FIRST_TIME_CONTRIBUTORS_END -->";
 
-      - name: Commit JSON
+            const section = `${START}\n${table}\n${END}`;
+
+            let updated;
+            if (readme.includes(START) && readme.includes(END)) {
+              const regex = new RegExp(`${START}[\\s\\S]*${END}`, 'm');
+              updated = readme.replace(regex, section);
+            } else {
+              updated = readme + `\n\n${section}`;
+            }
+            
+            // 8) Write only if changed
+            if (readme !== updated) {
+              fs.writeFileSync(readmePath, updated);
+              core.setOutput('changed', 'true');
+            } else {
+              core.setOutput('changed', 'false');
+            }
+
+            core.setOutput('count', String(contributors.length));
+
+      - name: Commit README
         if: steps.build.outputs.changed == 'true'
         uses: EndBug/add-and-commit@v9
         with:
-          add: "first_time_contributors.json"
-          message: "chore: update first-time contributors JSON [skip ci]"
+          add: "README.md"
+          message: "chore: update first-time contributors list [skip ci]"
           default_author: github_actions

--- a/.github/workflows/first-time-contributors.yml
+++ b/.github/workflows/first-time-contributors.yml
@@ -16,6 +16,7 @@ on:
 
 permissions:
   contents: write
+  issues: read
   pull-requests: read
 
 jobs:
@@ -30,7 +31,7 @@ jobs:
         env:
           ORG: ${{ inputs.org || 'OWASP-BLT' }}
           SINCE: ${{ inputs.since || '2026-04-02' }}
-          OUT_PATH: data/first_time_contributors.json
+          OUT_PATH: first_time_contributors.json
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -39,7 +40,7 @@ jobs:
 
             const org   = process.env.ORG   || 'OWASP-BLT';
             const since = process.env.SINCE || '2026-04-02';
-            const outPath = process.env.OUT_PATH || 'data/first_time_contributors.json';
+            const outPath = process.env.OUT_PATH || 'first_time_contributors.json';
 
             const bots = new Set([
               'github-actions[bot]',
@@ -74,8 +75,7 @@ jobs:
               const repoFull = it.repository_url.split('/').slice(-2).join('/');
               const [owner, repo] = repoFull.split('/');
               const prNum = it.number;
-              const pr = await github.rest.pulls.get({ owner, repo, pull_number: prNum });
-              const mAt = pr.data.merged_at;
+              const mAt = it.pull_request?.merged_at;
               if (!mAt) continue;
               if (new Date(mAt) < new Date(since)) continue;   // just-in-case guard
 
@@ -175,20 +175,44 @@ jobs:
             }
 
             const merged = Array.from(byLogin.values());
-            // Write directory and file
-            fs.mkdirSync(path.dirname(outPath), { recursive: true });
-            const payload = {
-              generated_at: new Date().toISOString(),
+            merged.sort((a, b) => {
+               const mergedAtDiff =
+                 new Date(a.first_merged_pr.merged_at) - new Date(b.first_merged_pr.merged_at);
+               if (mergedAtDiff !== 0) {
+                 return mergedAtDiff;
+               }
+               return a.login.localeCompare(b.login);
+             });
+            const nextComparablePayload = {
               since,
               contributors: merged
             };
-            fs.writeFileSync(outPath, JSON.stringify(payload, null, 2));
-            core.info(`Wrote ${outPath} with ${merged.length} contributors`);
+            const existingComparablePayload = {
+               since: existing.since ?? since,
+               contributors: existing.contributors || []
+             };
+             const hasChanged =
+               JSON.stringify(existingComparablePayload) !== JSON.stringify(nextComparablePayload);
+             if (hasChanged) {
+               // Write directory and file only when contributor data changes
+               fs.mkdirSync(path.dirname(outPath), { recursive: true });
+               const payload = {
+                 generated_at: new Date().toISOString(),
+                 since,
+                 contributors: merged
+               };
+               fs.writeFileSync(outPath, JSON.stringify(payload, null, 2));
+               core.info(`Wrote ${outPath} with ${merged.length} contributors`);
+             } else {
+               core.info(`No contributor changes detected; skipped writing ${outPath}`);
+             }
 
             // Expose a small summary
             core.setOutput('count', String(merged.length));
+            core.setOutput('changed', hasChanged ? 'true' : 'false');
 
       - name: Commit JSON
+        if: steps.build.outputs.changed == 'true'
         uses: EndBug/add-and-commit@v9
         with:
           add: "first_time_contributors.json"

--- a/README.md
+++ b/README.md
@@ -303,6 +303,11 @@ The leaderboard updates monthly, with rankings reset at the start of each month 
 
 ---
 
+<!-- FIRST_TIME_CONTRIBUTORS_START -->
+_First-time contributors will be listed here automatically._
+<!-- FIRST_TIME_CONTRIBUTORS_END -->
+
+---
 ## 💬 Community & Support
 
 - 🌐 **Website**: [legacy.owaspblt.org](https://legacy.owaspblt.org)


### PR DESCRIPTION
- Add GitHub Actions workflow to scan org-wide merged PRs
- Identify first-time contributors after the deletion campaign started
- Automatically update a dedicated section in README.md with contributor details
  (name/login, first merged PR, sponsors info)
- Ensure safe, idempotent updates using marker-based replacement

This introduces an automated, maintainable way to highlight new contributors directly in the repository README.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds an automated process to generate an org-wide "First-time contributors" section in the README.
  * Runs daily and via manual trigger with configurable cutoff; detects first merged PRs since the cutoff, enriches entries with profile and sponsor availability, sorts by first-merge date.
  * Updates README only when content changes and exposes count/changed outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->